### PR TITLE
Phase 2: replace raw setTimeout in GameScene.waveComplete with a scene-clock timer

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -47,7 +47,7 @@ Do this first so every later PR is protected.
 Consult the pinned Phaser 3.90 docs (scene lifecycle, events, time) before each change.
 Each bullet is one small PR unless trivially related.
 
-- [ ] `GameScene.ts:231` — replace raw `setTimeout` with a pause-aware, scene-owned timer cleaned up on shutdown
+- [x] `GameScene.ts:231` — replace raw `setTimeout` with a pause-aware, scene-owned timer cleaned up on shutdown
 - [ ] `HUD.js` — remove keyboard listeners on shutdown; guard `JSON.parse(localStorage.getItem(...))`
 - [ ] Introduce a typed, error-handled save/storage service wrapping all `localStorage` access (`HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) — with unit tests
 - [ ] `Resource.ts` — add cleanup; unsubscribe RxJS subscriptions on shutdown

--- a/src/scenes/GameScene.test.ts
+++ b/src/scenes/GameScene.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import GameScene from "./GameScene";
+
+// Regression tests for the Phase 2 fix (issue #307): waveComplete used a raw
+// setTimeout, which kept running while the scene clock was paused and could
+// fire increaseLevel after the scene had shut down (e.g. ESC to town or game
+// over during the 4s loot-collection window).
+//
+// The methods under test only touch `time` and `next_level_timer`, so we run
+// them against a minimal fake scene built on the real prototype — mocking at
+// the entity seam rather than booting Phaser.
+
+interface FakeTimer {
+    remove: ReturnType<typeof vi.fn>;
+}
+
+interface SceneUnderTest {
+    time: { delayedCall: ReturnType<typeof vi.fn> };
+    next_level_timer?: FakeTimer;
+    increaseLevel(): void;
+    waveComplete(): void;
+    removeNextLevelTimer(): void;
+}
+
+function makeScene(): { scene: SceneUnderTest; pending: FakeTimer } {
+    const pending: FakeTimer = { remove: vi.fn() };
+    const scene = Object.create(GameScene.prototype) as SceneUnderTest;
+    scene.time = { delayedCall: vi.fn(() => pending) };
+    return { scene, pending };
+}
+
+describe("GameScene.waveComplete", () => {
+    it("schedules the next wave on the scene clock, scoped to the scene", () => {
+        const { scene } = makeScene();
+
+        scene.waveComplete();
+
+        expect(scene.time.delayedCall).toHaveBeenCalledTimes(1);
+        expect(scene.time.delayedCall).toHaveBeenCalledWith(4000, scene.increaseLevel, [], scene);
+    });
+
+    it("does not use a raw setTimeout", () => {
+        const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+        const { scene } = makeScene();
+
+        scene.waveComplete();
+
+        expect(setTimeoutSpy).not.toHaveBeenCalled();
+        setTimeoutSpy.mockRestore();
+    });
+
+    it("stores the timer so shutdown cleanup can cancel it", () => {
+        const { scene, pending } = makeScene();
+
+        scene.waveComplete();
+        expect(scene.next_level_timer).toBe(pending);
+
+        scene.removeNextLevelTimer();
+        expect(pending.remove).toHaveBeenCalledWith(false);
+        expect(scene.next_level_timer).toBeUndefined();
+    });
+
+    it("replaces a previously scheduled timer instead of stacking", () => {
+        const { scene } = makeScene();
+        const stale: FakeTimer = { remove: vi.fn() };
+        scene.next_level_timer = stale;
+
+        scene.waveComplete();
+
+        expect(stale.remove).toHaveBeenCalledWith(false);
+        expect(scene.time.delayedCall).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/scenes/GameScene.test.ts
+++ b/src/scenes/GameScene.test.ts
@@ -20,12 +20,26 @@ interface SceneUnderTest {
     increaseLevel(): void;
     waveComplete(): void;
     removeNextLevelTimer(): void;
+    gameOver(): void;
+    shutdown(): void;
+    physics: { pause: ReturnType<typeof vi.fn> };
+    enemies: { runChildUpdate: boolean };
+    UI: { cleanup: ReturnType<typeof vi.fn> };
+    player: { cleanup: ReturnType<typeof vi.fn> };
+    input: { off: ReturnType<typeof vi.fn> };
+    events: { off: ReturnType<typeof vi.fn> };
 }
 
 function makeScene(): { scene: SceneUnderTest; pending: FakeTimer } {
     const pending: FakeTimer = { remove: vi.fn() };
     const scene = Object.create(GameScene.prototype) as SceneUnderTest;
     scene.time = { delayedCall: vi.fn(() => pending) };
+    scene.physics = { pause: vi.fn() };
+    scene.enemies = { runChildUpdate: true };
+    scene.UI = { cleanup: vi.fn() };
+    scene.player = { cleanup: vi.fn() };
+    scene.input = { off: vi.fn() };
+    scene.events = { off: vi.fn() };
     return { scene, pending };
 }
 
@@ -69,5 +83,32 @@ describe("GameScene.waveComplete", () => {
 
         expect(stale.remove).toHaveBeenCalledWith(false);
         expect(scene.time.delayedCall).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("GameScene.gameOver", () => {
+    it("cancels a pending next-wave timer so no wave spawns mid game-over", () => {
+        const { scene, pending } = makeScene();
+        scene.waveComplete();
+
+        scene.gameOver();
+
+        expect(pending.remove).toHaveBeenCalledWith(false);
+        expect(scene.next_level_timer).toBeUndefined();
+        expect(scene.physics.pause).toHaveBeenCalled();
+    });
+});
+
+describe("GameScene.shutdown", () => {
+    it("cancels the pending next-wave timer and runs entity cleanup", () => {
+        const { scene, pending } = makeScene();
+        scene.waveComplete();
+
+        scene.shutdown();
+
+        expect(pending.remove).toHaveBeenCalledWith(false);
+        expect(scene.next_level_timer).toBeUndefined();
+        expect(scene.UI.cleanup).toHaveBeenCalled();
+        expect(scene.player.cleanup).toHaveBeenCalled();
     });
 });

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -1,4 +1,4 @@
-import { Scene, Input, GameObjects, Display } from "phaser";
+import { Scene, Input, GameObjects, Display, Scenes } from "phaser";
 import AssignClass from "@entities/Player/AssignClass";
 import AssignType from "@entities/Enemy/AssignType";
 import Boss from "@entities/Enemy/Boss";
@@ -112,6 +112,10 @@ export default class GameScene extends Scene {
 
         this.events.once("player:dead", this.gameOver, this);
 
+        // Phaser does not call shutdown() automatically — wire it to the
+        // scene lifecycle event so cleanup runs on every scene transition.
+        this.events.once(Scenes.Events.SHUTDOWN, this.shutdown, this);
+
         // When loading from an array, make sure to specify the tileWidth and tileHeight
         // const map = this.make.tilemap({ key: "map"});
         // const tileset = map.addTilesetImage("tileset_organic", "tiles", 16, 16, 1, 2);
@@ -203,6 +207,9 @@ export default class GameScene extends Scene {
 
     gameOver(): void {
         this.game_over = true;
+        // Dying inside the post-wave window must cancel the pending next-wave
+        // timer, or it would spawn a wave during the game-over transition.
+        this.removeNextLevelTimer();
         this.physics.pause();
         this.enemies.runChildUpdate = false;
         this.time.delayedCall(
@@ -342,7 +349,6 @@ export default class GameScene extends Scene {
     }
 
     shutdown(): void {
-        console.log("SHUTDOWN GAME: ", this.UI);
         // Clean up HUD subscriptions
         if (this.UI && this.UI.cleanup) {
             this.UI.cleanup();

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -253,16 +253,11 @@ export default class GameScene extends Scene {
     }
 
     waveComplete(): void {
-        // this.removeNextLevelTimer();
-        // Pause time after a short delay so that loot has a change to animate and activate
-        // this.time.delayedCall(1000, () => {
-        // 	this.time.paused = true;
-        // }, [], this);
         // Give the player time to collect loot and cast spells.
-        // We use a regular setTimeout here as the game timers are paused.
-        setTimeout(() => {
-            this.increaseLevel();
-        }, 4000);
+        // Scene clock timer (not setTimeout): pause-aware, and removed by the
+        // clock on scene shutdown so it can't fire after leaving the scene.
+        this.removeNextLevelTimer();
+        this.next_level_timer = this.time.delayedCall(4000, this.increaseLevel, [], this);
     }
 
     spawnEnemies(list: EnemyType[], wave_multiplier?: number): void {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,20 +11,31 @@ export default defineConfig({
         css: false,
     },
     resolve: {
-        alias: {
+        alias: [
             // Phaser's package "main" is its raw src build, which requires the
             // dev-only phaser3spectorjs package. Use the bundled dist (what the
             // app build uses) so tests can import Phaser-dependent modules.
-            phaser: path.resolve(__dirname, "./node_modules/phaser/dist/phaser.esm.js"),
-            "@store": path.resolve(__dirname, "./src/store"),
-            "@ui": path.resolve(__dirname, "./src/ui"),
-            "@helpers": path.resolve(__dirname, "./src/helpers"),
-            "@scenes": path.resolve(__dirname, "./src/scenes"),
-            "@entities": path.resolve(__dirname, "./src/entities"),
-            "@config": path.resolve(__dirname, "./src/config"),
-            "@queries": path.resolve(__dirname, "./src/ui/operations/queries"),
-            "@mutations": path.resolve(__dirname, "./src/ui/operations/mutations"),
-            "@": path.resolve(__dirname, "./src"),
-        },
+            // Exact-match regex: a string alias would also prefix-rewrite
+            // "phaser/<subpath>" imports onto the dist file path.
+            {
+                find: /^phaser$/,
+                replacement: path.resolve(__dirname, "./node_modules/phaser/dist/phaser.esm.js"),
+            },
+            { find: "@store", replacement: path.resolve(__dirname, "./src/store") },
+            { find: "@ui", replacement: path.resolve(__dirname, "./src/ui") },
+            { find: "@helpers", replacement: path.resolve(__dirname, "./src/helpers") },
+            { find: "@scenes", replacement: path.resolve(__dirname, "./src/scenes") },
+            { find: "@entities", replacement: path.resolve(__dirname, "./src/entities") },
+            { find: "@config", replacement: path.resolve(__dirname, "./src/config") },
+            {
+                find: "@queries",
+                replacement: path.resolve(__dirname, "./src/ui/operations/queries"),
+            },
+            {
+                find: "@mutations",
+                replacement: path.resolve(__dirname, "./src/ui/operations/mutations"),
+            },
+            { find: "@", replacement: path.resolve(__dirname, "./src") },
+        ],
     },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
     },
     resolve: {
         alias: {
+            // Phaser's package "main" is its raw src build, which requires the
+            // dev-only phaser3spectorjs package. Use the bundled dist (what the
+            // app build uses) so tests can import Phaser-dependent modules.
+            phaser: path.resolve(__dirname, "./node_modules/phaser/dist/phaser.esm.js"),
             "@store": path.resolve(__dirname, "./src/store"),
             "@ui": path.resolve(__dirname, "./src/ui"),
             "@helpers": path.resolve(__dirname, "./src/helpers"),

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,17 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom has no canvas implementation, and Phaser probes a 2D context at import
+// time (src/device/CanvasFeatures.js). Stub the minimal surface that probe
+// touches so modules importing Phaser can be unit tested without the native
+// `canvas` package.
+const context2DStub = {
+    fillStyle: "",
+    globalCompositeOperation: "",
+    fillRect: () => {},
+    drawImage: () => {},
+    getImageData: () => ({ data: [0, 0, 0, 0] }),
+    putImageData: () => {},
+};
+
+HTMLCanvasElement.prototype.getContext = (() =>
+    context2DStub) as unknown as typeof HTMLCanvasElement.prototype.getContext;


### PR DESCRIPTION
Part of Phase 2 (#307) — first stability fix from `docs/ROADMAP.md`.

## What

`GameScene.waveComplete()` scheduled the next wave with a raw `setTimeout(…, 4000)`. Raw timeouts are not pause-aware and keep running after the scene shuts down: leaving the scene (ESC to town) or a game over during the 4-second loot window would still fire `increaseLevel()` on a dead scene — incrementing the wave in Redux and spawning enemies into destroyed groups.

It now uses `this.time.delayedCall(4000, this.increaseLevel, [], this)`, stored in the existing `next_level_timer` field so `removeNextLevelTimer()`/`shutdown()` can cancel it. Any previously pending timer is removed first so timers can't stack.

Verified against the Phaser **3.90** source (per CLAUDE.md): the scene `Time.Clock` listens for `SceneEvents.SHUTDOWN` and destroys all pending timer events, so the timer cannot outlive the scene.

## Review round 1 fixes (commit 25c5513, maintainer-approved)

The first review round raised three findings; the maintainer asked for all three to be addressed in this PR:

1. **`gameOver()` now cancels the pending next-wave timer** — dying inside the 4s post-wave window can no longer dispatch `nextWave()` and spawn enemies during the game-over transition.
2. **`shutdown()` is now wired to `Scenes.Events.SHUTDOWN` in `create()`** — Phaser does not auto-call a method named `shutdown`, so its HUD/player cleanup was dead code. `HUD.cleanup()`/`Player.cleanup()` were verified safe to run at shutdown (idempotent unsubscribe loops; the keyboard plugin is not destroyed until game destroy). The debug `console.log` was removed now that the method fires on every scene transition. ⚠️ Behavior change: previously-dead cleanup now runs; this also front-runs part of the roadmap's `HUD.js` bullet.
3. **vitest `phaser` alias is an exact-match regex** (`/^phaser$/`) so `phaser/<subpath>` imports can't be prefix-rewritten onto the dist file path.

## Behavior notes / risk

- **No timing change to the wave flow.** The old comment ("We use a regular setTimeout here as the game timers are paused") is stale: `this.time.paused` is only ever set by `levelComplete()`, which is dead code (never called). The scene clock is running when `waveComplete` fires, so the 4s delay behaves identically — except it now correctly pauses with the clock and dies with the scene.
- Removed the stale commented-out block inside `waveComplete` only; `levelComplete`/`setNextLevelTimer` dead code left untouched.

## Flagged (not fixed here, per "preserve and flag")

- **Pre-existing wave auto-advance quirk** (found independently by both review rounds, preserved by this PR): the scene clock updates before `scene.update()` each frame and spawn `delayedCall`s land a frame late, so each non-boss wave after the first re-emits `enemies:dead` into the fresh once-listener at wave start. The 4s timer therefore effectively auto-advances from wave start, not wave clear; a wave taking longer than 4s increments mid-combat. Pre-existing on `main` (worse there: raw setTimeouts stacked). Gameplay-visible — maintainer decision needed on whether/when to fix.
- `levelComplete()` is unused dead code.

## Test infrastructure (mechanics, decided per CLAUDE.md)

Making `GameScene` importable under Vitest/jsdom needed two small changes:
- `vitest.setup.ts`: stub the minimal 2D-canvas surface Phaser probes at import time (`src/device/CanvasFeatures.js`) — avoids the native `canvas` package.
- `vitest.config.ts`: alias `phaser` (exact match) to its bundled ESM dist; the package `main` points at the raw src build, which hard-requires the dev-only `phaser3spectorjs` package.

These also unblock the Phase 4 Phaser-adjacent unit tests.

## Test evidence

`src/scenes/GameScene.test.ts` — 6 regression tests, mocking at the entity seam (no Phaser boot):
- schedules the next wave on the scene clock (4000ms, scoped to the scene)
- no raw `setTimeout` used (regression guard)
- timer is stored and cancellable via `removeNextLevelTimer()`
- a pending timer is replaced, not stacked
- `gameOver()` cancels the pending timer
- `shutdown()` cancels the timer and runs HUD/player cleanup

Local gates, all green: `typecheck` ✅ · `lint` ✅ · `format:check` ✅ · `test` 22/22 ✅ · `build` ✅

Roadmap checkbox ticked in `docs/ROADMAP.md`.

https://claude.ai/code/session_018LPqRcNWWyRfuyKb8aedDs