### PR TITLE
Fix spurious wave auto-advance: only treat a wave as cleared when no spawns are pending

### DIFF
--- a/src/scenes/GameScene.test.ts
+++ b/src/scenes/GameScene.test.ts
@@ -17,29 +17,40 @@ interface FakeTimer {
 interface SceneUnderTest {
     time: { delayedCall: ReturnType<typeof vi.fn> };
     next_level_timer?: FakeTimer;
+    pending_spawns: number;
     increaseLevel(): void;
     waveComplete(): void;
     removeNextLevelTimer(): void;
     gameOver(): void;
     shutdown(): void;
+    update(time: number, delta: number): void;
+    spawnEnemies(list: string[]): void;
+    spawnEnemy: ReturnType<typeof vi.fn>;
     physics: { pause: ReturnType<typeof vi.fn> };
-    enemies: { runChildUpdate: boolean };
+    enemies: { runChildUpdate: boolean; getChildren: ReturnType<typeof vi.fn> };
     UI: { cleanup: ReturnType<typeof vi.fn> };
-    player: { cleanup: ReturnType<typeof vi.fn> };
-    input: { off: ReturnType<typeof vi.fn> };
-    events: { off: ReturnType<typeof vi.fn> };
+    player: { cleanup: ReturnType<typeof vi.fn>; alive: boolean };
+    input: { off: ReturnType<typeof vi.fn>; activePointer: object };
+    cursors: { esc: { isDown: boolean } };
+    events: {
+        off: ReturnType<typeof vi.fn>;
+        once: ReturnType<typeof vi.fn>;
+        emit: ReturnType<typeof vi.fn>;
+    };
 }
 
 function makeScene(): { scene: SceneUnderTest; pending: FakeTimer } {
     const pending: FakeTimer = { remove: vi.fn() };
     const scene = Object.create(GameScene.prototype) as SceneUnderTest;
     scene.time = { delayedCall: vi.fn(() => pending) };
+    scene.pending_spawns = 0;
     scene.physics = { pause: vi.fn() };
-    scene.enemies = { runChildUpdate: true };
+    scene.enemies = { runChildUpdate: true, getChildren: vi.fn(() => []) };
     scene.UI = { cleanup: vi.fn() };
-    scene.player = { cleanup: vi.fn() };
-    scene.input = { off: vi.fn() };
-    scene.events = { off: vi.fn() };
+    scene.player = { cleanup: vi.fn(), alive: false };
+    scene.input = { off: vi.fn(), activePointer: {} };
+    scene.cursors = { esc: { isDown: false } };
+    scene.events = { off: vi.fn(), once: vi.fn(), emit: vi.fn() };
     return { scene, pending };
 }
 
@@ -96,6 +107,42 @@ describe("GameScene.gameOver", () => {
         expect(pending.remove).toHaveBeenCalledWith(false);
         expect(scene.next_level_timer).toBeUndefined();
         expect(scene.physics.pause).toHaveBeenCalled();
+    });
+});
+
+describe("GameScene wave-clear detection", () => {
+    it("does not emit enemies:dead while scheduled spawns have not landed", () => {
+        const { scene } = makeScene();
+        scene.pending_spawns = 2;
+
+        scene.update(0, 16);
+
+        expect(scene.events.emit).not.toHaveBeenCalledWith("enemies:dead");
+    });
+
+    it("emits enemies:dead once the group is empty and no spawns are pending", () => {
+        const { scene } = makeScene();
+
+        scene.update(0, 16);
+
+        expect(scene.events.emit).toHaveBeenCalledWith("enemies:dead");
+    });
+
+    it("counts scheduled spawns as pending until each one lands", () => {
+        const { scene, pending } = makeScene();
+        const spawnCallbacks: Array<() => void> = [];
+        scene.time.delayedCall = vi.fn((_delay: number, callback: () => void) => {
+            spawnCallbacks.push(callback);
+            return pending;
+        });
+        scene.spawnEnemy = vi.fn();
+
+        scene.spawnEnemies(["baby-ghoul", "baby-ghoul"]);
+        expect(scene.pending_spawns).toBe(2);
+
+        spawnCallbacks.forEach((callback) => callback());
+        expect(scene.pending_spawns).toBe(0);
+        expect(scene.spawnEnemy).toHaveBeenCalledTimes(2);
     });
 });
 

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -31,6 +31,7 @@ export default class GameScene extends Scene {
     public enemies!: Phaser.GameObjects.Group;
     public active_enemies!: Phaser.GameObjects.Group;
     private game_over: boolean = false;
+    private pending_spawns: number = 0;
     public depth_group: Record<string, number> = {
         BASE: 10,
         UI: 10000,
@@ -51,6 +52,10 @@ export default class GameScene extends Scene {
     }
 
     create(): void {
+        // Scene instances are reused across scene.start(), so field
+        // initializers do not re-run — reset per-run state here.
+        this.pending_spawns = 0;
+
         const scene_padding = 40;
         this.global_game_width = Number(this.sys.game.config.width);
         this.global_game_height = Number(this.sys.game.config.height);
@@ -155,7 +160,10 @@ export default class GameScene extends Scene {
     update(time: number, delta: number): void {
         let mouse = this.input.activePointer;
 
-        if (this.enemies.getChildren().length === 0 && !this.game_over)
+        // Spawn delayedCalls land a frame after they are scheduled (the clock
+        // updates before scene.update), so an empty group only means the wave
+        // is cleared once no spawns are still pending.
+        if (this.enemies.getChildren().length === 0 && this.pending_spawns === 0 && !this.game_over)
             this.events.emit("enemies:dead");
 
         if (this.player.alive) this.player.update(mouse, this.cursors, time, delta);
@@ -271,9 +279,11 @@ export default class GameScene extends Scene {
         // Remove exsiting instances of this event so that it does trigger multiple times
         this.events.off("enemies:dead");
 
+        this.pending_spawns += list.length;
         list.forEach((enemy, i) => {
             this.time.delayedCall(this.global_spawn_time * i, () => {
                 this.spawnEnemy(enemy, wave_multiplier);
+                this.pending_spawns--;
             });
         });
 


### PR DESCRIPTION
Part of Phase 2 (#307). Fixes the wave auto-advance bug flagged by both review rounds on #314, with maintainer go-ahead to fix.

## The bug

The scene clock runs its timer callbacks **before** `scene.update()` each frame, and a `delayedCall` scheduled inside another timer callback can't fire until the next frame. So when `increaseLevel` (running inside the 4s post-wave timer) scheduled the new wave's spawn `delayedCall`s and re-armed `once("enemies:dead")`, that same frame's `update()` saw an empty enemies group and fired `waveComplete` immediately — arming a spurious 4-second auto-advance at the **start** of every non-boss wave after the first.

Effect: any wave taking longer than 4 seconds incremented mid-combat and spawned the next wave on top of the live one. Pre-existing on `main` long before #314 (worse there: the raw `setTimeout`s stacked).

## The fix

A `pending_spawns` counter tracks spawns that are scheduled but haven't landed; `update()` only treats the wave as cleared when the group is empty **and** nothing is pending.

- Counter is reset in `create()` — scene instances are reused across `scene.start()`, so field initializers don't re-run (a shutdown mid-spawn would otherwise strand a stale count).
- `spawnBoss` adds its boss synchronously inside the same call, so it needs no counter.

## Behavior change (intended, maintainer-approved)

Waves now advance 4 seconds after actually being **cleared** — as the original "give the player time to collect loot" comment intended — instead of effectively 4 seconds after wave **start**. Players who relied on waiting out a hard wave will now have to clear it.

## Flagged, not fixed (preserve and flag)

While adding the `create()` reset I noticed `game_over` has the same reused-instance problem: it is set `true` in `gameOver()` and only initialized by a field initializer, so it is never reset on a subsequent `scene.start("GameScene")`. If the game over flow restarts the scene on the same Game instance, `update()` would never emit `enemies:dead` again (waves would never advance). Possibly masked by how the React side rebuilds the game — needs a maintainer look before touching.

## Test evidence

Three new regression tests in `src/scenes/GameScene.test.ts` (25 total, all passing):
- `update()` does not emit `enemies:dead` while scheduled spawns haven't landed
- `update()` emits `enemies:dead` once the group is empty and nothing is pending
- `spawnEnemies` counts scheduled spawns as pending until each one lands

Local gates, all green: `typecheck` ✅ · `lint` ✅ · `format:check` ✅ · `test` 25/25 ✅ · `build` ✅

https://claude.ai/code/session_018LPqRcNWWyRfuyKb8aedDs

---
_Generated by [Claude Code](https://claude.ai/code/session_018LPqRcNWWyRfuyKb8aedDs)_