### PR TITLE
Phase 2: HUD save/load guards and precise keyboard listener cleanup

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -48,7 +48,7 @@ Consult the pinned Phaser 3.90 docs (scene lifecycle, events, time) before each 
 Each bullet is one small PR unless trivially related.
 
 - [x] `GameScene.ts:231` — replace raw `setTimeout` with a pause-aware, scene-owned timer cleaned up on shutdown
-- [ ] `HUD.js` — remove keyboard listeners on shutdown; guard `JSON.parse(localStorage.getItem(...))`
+- [x] `HUD.js` — remove keyboard listeners on shutdown; guard `JSON.parse(localStorage.getItem(...))`
 - [ ] Introduce a typed, error-handled save/storage service wrapping all `localStorage` access (`HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) — with unit tests
 - [ ] `Resource.ts` — add cleanup; unsubscribe RxJS subscriptions on shutdown
 - [ ] `Gem.js`, `Trap.js`, `Spell.ts` — unregister event listeners on destroy/shutdown

--- a/src/entities/UI/HUD.js
+++ b/src/entities/UI/HUD.js
@@ -45,40 +45,22 @@ class UI extends GameObjects.Container {
             })
         );
 
-        scene.input.keyboard.on("keyup-P", () => store.dispatch(toggleUi("character")), this);
-        // TEMP KEYBINDS
-        scene.input.keyboard.on(
-            "keyup-R",
-            () => store.dispatch(addLoot(Math.floor(Math.random() * 100))),
-            this
-        );
+        this.save_slot = store.getState().game.saveSlot;
 
-        // Saving
-        const slot = store.getState().game.saveSlot;
-        scene.input.keyboard.on(
-            "keyup-S",
-            () => {
-                localStorage.setItem(slot, JSON.stringify(store.getState()));
-            },
-            this
-        );
-        scene.input.keyboard.on(
-            "keyup-D",
-            () => {
-                ["slot_a", "slot_b", "slot_c"].forEach((slot) => {
-                    localStorage.removeItem(slot);
-                });
-            },
-            this
-        );
-        scene.input.keyboard.on(
-            "keyup-L",
-            () => {
-                const save_data = JSON.parse(localStorage.getItem(slot));
-                save_data ? store.dispatch(loadGame(save_data)) : console.log("NO DATA TO LOAD");
-            },
-            this
-        );
+        // Keep handler references so cleanup() can remove exactly these
+        // listeners rather than every listener bound to the event.
+        this.key_handlers = {
+            "keyup-P": () => store.dispatch(toggleUi("character")),
+            // TEMP KEYBINDS
+            "keyup-R": () => store.dispatch(addLoot(Math.floor(Math.random() * 100))),
+            // Saving
+            "keyup-S": () => this.saveGame(),
+            "keyup-D": () => this.deleteSaves(),
+            "keyup-L": () => this.loadSavedGame(),
+        };
+        Object.entries(this.key_handlers).forEach(([event, handler]) => {
+            scene.input.keyboard.on(event, handler, this);
+        });
 
         this.scene.add.existing(this).setDepth(this.scene.depth_group.UI).setScrollFactor(0);
     }
@@ -136,17 +118,42 @@ class UI extends GameObjects.Container {
             .on("pointerdown", () => store.dispatch(toggleUi("system")), this);
     }
 
+    saveGame() {
+        // localStorage.setItem can throw (quota, privacy mode); a key handler
+        // must not crash the game over a failed save.
+        try {
+            localStorage.setItem(this.save_slot, JSON.stringify(store.getState()));
+        } catch (error) {
+            console.warn("Failed to save game to slot", this.save_slot, error);
+        }
+    }
+
+    deleteSaves() {
+        ["slot_a", "slot_b", "slot_c"].forEach((slot) => {
+            localStorage.removeItem(slot);
+        });
+    }
+
+    loadSavedGame() {
+        // Corrupt save data must not throw out of a key handler.
+        let save_data = null;
+        try {
+            save_data = JSON.parse(localStorage.getItem(this.save_slot));
+        } catch (error) {
+            console.warn("Ignoring corrupt save data in slot", this.save_slot, error);
+        }
+        save_data ? store.dispatch(loadGame(save_data)) : console.log("NO DATA TO LOAD");
+    }
+
     cleanup() {
         // Unsubscribe from all store subscriptions
         this.subscriptions.forEach((unsubscribe) => unsubscribe());
         this.subscriptions = [];
 
-        // Clean up keyboard event listeners
-        this.scene.input.keyboard.off("keyup-P");
-        this.scene.input.keyboard.off("keyup-R");
-        this.scene.input.keyboard.off("keyup-S");
-        this.scene.input.keyboard.off("keyup-D");
-        this.scene.input.keyboard.off("keyup-L");
+        // Remove exactly the keyboard listeners registered in the constructor
+        Object.entries(this.key_handlers).forEach(([event, handler]) => {
+            this.scene.input.keyboard.off(event, handler, this);
+        });
     }
 }
 

--- a/src/entities/UI/HUD.test.ts
+++ b/src/entities/UI/HUD.test.ts
@@ -44,6 +44,13 @@ describe("UI.loadSavedGame", () => {
     });
 
     it("dispatches loadGame with the parsed save data", () => {
+        // loadSavedGame is a shape-agnostic passthrough: it dispatches whatever
+        // it parses, which is what this pins. The fixture is a flat GameState
+        // slice purely to satisfy loadGame's Partial<GameState> type — the real
+        // keyup-S save writes the *root* { game: {...} } shape, which loadGame
+        // does not type-accept. That save-shape mismatch is the pre-existing bug
+        // flagged in the PR, deferred to the typed storage service; this test
+        // deliberately does not assert that (buggy) round-trip.
         const save_data = { coins: 42, wave: 3 };
         localStorage.setItem("slot_a", JSON.stringify(save_data));
 

--- a/src/entities/UI/HUD.test.ts
+++ b/src/entities/UI/HUD.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import UI from "./HUD";
+import store from "@store";
+import { loadGame } from "@store/gameReducer";
+
+// Regression tests for the Phase 2 HUD fixes (issue #307): the keyup-L
+// handler crashed on corrupt save data (unguarded JSON.parse), and cleanup()
+// removed keyboard listeners by event name only. The save/load/cleanup logic
+// now lives in named methods, tested here against a minimal fake built on the
+// real prototype — no Phaser boot.
+
+interface HudUnderTest {
+    save_slot: string;
+    subscriptions: Array<ReturnType<typeof vi.fn>>;
+    key_handlers: Record<string, () => void>;
+    scene: { input: { keyboard: { off: ReturnType<typeof vi.fn> } } };
+    saveGame(): void;
+    deleteSaves(): void;
+    loadSavedGame(): void;
+    cleanup(): void;
+}
+
+function makeHud(): HudUnderTest {
+    const hud = Object.create(UI.prototype) as HudUnderTest;
+    hud.save_slot = "slot_a";
+    hud.subscriptions = [];
+    hud.key_handlers = {};
+    hud.scene = { input: { keyboard: { off: vi.fn() } } };
+    return hud;
+}
+
+describe("UI.loadSavedGame", () => {
+    let dispatch: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        dispatch = vi.spyOn(store, "dispatch").mockImplementation((action) => action);
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it("dispatches loadGame with the parsed save data", () => {
+        const save_data = { coins: 42, wave: 3 };
+        localStorage.setItem("slot_a", JSON.stringify(save_data));
+
+        makeHud().loadSavedGame();
+
+        expect(dispatch).toHaveBeenCalledWith(loadGame(save_data));
+    });
+
+    it("does not throw or dispatch when the slot holds corrupt JSON", () => {
+        localStorage.setItem("slot_a", "{ not valid json");
+        const hud = makeHud();
+
+        expect(() => hud.loadSavedGame()).not.toThrow();
+        expect(dispatch).not.toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("does not dispatch when the slot is empty", () => {
+        makeHud().loadSavedGame();
+
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+});
+
+describe("UI.saveGame", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        localStorage.clear();
+    });
+
+    it("writes the store state to the save slot", () => {
+        makeHud().saveGame();
+
+        expect(localStorage.getItem("slot_a")).toBe(JSON.stringify(store.getState()));
+    });
+
+    it("does not throw when localStorage rejects the write", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw new DOMException("quota exceeded", "QuotaExceededError");
+        });
+        const hud = makeHud();
+
+        expect(() => hud.saveGame()).not.toThrow();
+        expect(console.warn).toHaveBeenCalled();
+    });
+});
+
+describe("UI.cleanup", () => {
+    it("unsubscribes store subscriptions and removes the registered key listeners", () => {
+        const hud = makeHud();
+        const unsubscribeA = vi.fn();
+        const unsubscribeB = vi.fn();
+        hud.subscriptions = [unsubscribeA, unsubscribeB];
+        const handlerP = vi.fn();
+        const handlerL = vi.fn();
+        hud.key_handlers = { "keyup-P": handlerP, "keyup-L": handlerL };
+
+        hud.cleanup();
+
+        expect(unsubscribeA).toHaveBeenCalled();
+        expect(unsubscribeB).toHaveBeenCalled();
+        expect(hud.subscriptions).toEqual([]);
+        expect(hud.scene.input.keyboard.off).toHaveBeenCalledWith("keyup-P", handlerP, hud);
+        expect(hud.scene.input.keyboard.off).toHaveBeenCalledWith("keyup-L", handlerL, hud);
+        expect(hud.scene.input.keyboard.off).toHaveBeenCalledTimes(2);
+    });
+});


### PR DESCRIPTION
Part of Phase 2 (#307) — second roadmap bullet: `HUD.js` keyboard listeners + `JSON.parse(localStorage.getItem(...))` guard.

## What

**Guarded save/load.** The keyup-L handler called `JSON.parse(localStorage.getItem(slot))` unguarded — corrupt save data threw an uncaught exception out of a keyboard handler. The inline save/load/delete closures now live in named methods:
- `loadSavedGame()` catches parse errors, warns, and skips the dispatch. Empty-slot behavior unchanged (`JSON.parse(null)` → `null` → "NO DATA TO LOAD", no dispatch).
- `saveGame()` catches `setItem` failures (quota, privacy mode) so a failed save can't crash the game. Slightly beyond the bullet's letter, but same crash class in the same handler family.
- `deleteSaves()` unchanged behavior.

**Precise listener cleanup.** `cleanup()` removed listeners by event name only (`keyboard.off("keyup-P")`), which strips *every* listener bound to that key, not just the HUD's. Handler references are now kept in `key_handlers` and removed individually with their context. This cleanup actually runs on scene shutdown since #314 wired `GameScene.shutdown()`.

## Behavior notes / risk

- Save slot is still captured at construction time (`store.getState().game.saveSlot`) — now stored as `this.save_slot` rather than a closure variable; same semantics.
- No change to what is saved/loaded — only crash-proofing. Extracting closures to methods is mechanics.

## Flagged, not fixed (preserve and flag)

**Save-shape mismatch:** keyup-S saves the *root* store state (`{ game: {...} }`) but `loadGame` expects (and the reducer installs) a `Partial<GameState>` *slice* — so a keyup-L load nests the state one level deep (`state.game.game`). Pre-existing, behavior-visible, and exactly what the next roadmap bullet (typed save/storage service wrapping `HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) should resolve — needs a decision there on the canonical save format and migration of existing saves.

## Test evidence

New `src/entities/UI/HUD.test.ts` — 6 tests on the real prototype with a fake scene (no Phaser boot):
- load: valid data dispatches `loadGame`; corrupt JSON neither throws nor dispatches (warns); empty slot doesn't dispatch
- save: writes store state to the slot; a throwing `setItem` doesn't crash
- cleanup: unsubscribes store subscriptions and removes exactly the registered key listeners (event + handler + context)

Local gates, all green: `typecheck` ✅ · `lint` ✅ · `format:check` ✅ · `test` 31/31 ✅ · `build` ✅

Roadmap checkbox ticked in `docs/ROADMAP.md`.

https://claude.ai/code/session_018LPqRcNWWyRfuyKb8aedDs

---
_Generated by [Claude Code](https://claude.ai/code/session_018LPqRcNWWyRfuyKb8aedDs)_