### PR TITLE
Phase 2: typed save/storage service for all localStorage access

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,7 +49,7 @@ Each bullet is one small PR unless trivially related.
 
 - [x] `GameScene.ts:231` — replace raw `setTimeout` with a pause-aware, scene-owned timer cleaned up on shutdown
 - [x] `HUD.js` — remove keyboard listeners on shutdown; guard `JSON.parse(localStorage.getItem(...))`
-- [ ] Introduce a typed, error-handled save/storage service wrapping all `localStorage` access (`HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) — with unit tests
+- [x] Introduce a typed, error-handled save/storage service wrapping all `localStorage` access (`HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) — with unit tests
 - [ ] `Resource.ts` — add cleanup; unsubscribe RxJS subscriptions on shutdown
 - [ ] `Gem.js`, `Trap.js`, `Spell.ts` — unregister event listeners on destroy/shutdown
 - [ ] `PhaserGame.tsx` — remove the `setTimeout(createGame, 100)` boot race; turn off arcade `debug: true` (behavior-visible: flag in PR)

--- a/src/entities/UI/HUD.js
+++ b/src/entities/UI/HUD.js
@@ -2,6 +2,7 @@ import { GameObjects, Display, Actions } from "phaser";
 import { toggleHUD, toggleUi, addLoot, loadGame } from "@store/gameReducer";
 import store from "@store";
 import mapStateToData from "@helpers/mapStateToData";
+import { readSave, writeSave, removeSave, SAVE_SLOTS } from "@services/saveStorage";
 
 const styles = {
     font: "12px monospace",
@@ -119,30 +120,22 @@ class UI extends GameObjects.Container {
     }
 
     saveGame() {
-        // localStorage.setItem can throw (quota, privacy mode); a key handler
-        // must not crash the game over a failed save.
-        try {
-            localStorage.setItem(this.save_slot, JSON.stringify(store.getState()));
-        } catch (error) {
-            console.warn("Failed to save game to slot", this.save_slot, error);
-        }
+        // The save/storage service swallows quota/privacy-mode write failures so
+        // a key handler never crashes the game over a failed save.
+        writeSave(this.save_slot, store.getState());
     }
 
     deleteSaves() {
-        ["slot_a", "slot_b", "slot_c"].forEach((slot) => {
-            localStorage.removeItem(slot);
-        });
+        SAVE_SLOTS.forEach((slot) => removeSave(slot));
     }
 
     loadSavedGame() {
-        // Corrupt save data must not throw out of a key handler.
-        let save_data = null;
-        try {
-            save_data = JSON.parse(localStorage.getItem(this.save_slot));
-        } catch (error) {
-            console.warn("Ignoring corrupt save data in slot", this.save_slot, error);
-        }
-        save_data ? store.dispatch(loadGame(save_data)) : console.log("NO DATA TO LOAD");
+        // Saves persist the root state ({ game: {...} }); loadGame expects the
+        // inner game slice, so unwrap .game (matching the Save menu's Load).
+        const save_data = readSave(this.save_slot);
+        save_data && save_data.game
+            ? store.dispatch(loadGame(save_data.game))
+            : console.log("NO DATA TO LOAD");
     }
 
     cleanup() {

--- a/src/entities/UI/HUD.test.ts
+++ b/src/entities/UI/HUD.test.ts
@@ -43,20 +43,16 @@ describe("UI.loadSavedGame", () => {
         localStorage.clear();
     });
 
-    it("dispatches loadGame with the parsed save data", () => {
-        // loadSavedGame is a shape-agnostic passthrough: it dispatches whatever
-        // it parses, which is what this pins. The fixture is a flat GameState
-        // slice purely to satisfy loadGame's Partial<GameState> type — the real
-        // keyup-S save writes the *root* { game: {...} } shape, which loadGame
-        // does not type-accept. That save-shape mismatch is the pre-existing bug
-        // flagged in the PR, deferred to the typed storage service; this test
-        // deliberately does not assert that (buggy) round-trip.
-        const save_data = { coins: 42, wave: 3 };
-        localStorage.setItem("slot_a", JSON.stringify(save_data));
+    it("unwraps the root save shape and dispatches loadGame with the game slice", () => {
+        // Saves persist the *root* state ({ game: {...} }); loadGame expects the
+        // inner slice. loadSavedGame now unwraps .game (matching the Save menu's
+        // Load), fixing the round-trip that previously double-nested game.
+        const game = { coins: 42, wave: 3 };
+        localStorage.setItem("slot_a", JSON.stringify({ game }));
 
         makeHud().loadSavedGame();
 
-        expect(dispatch).toHaveBeenCalledWith(loadGame(save_data));
+        expect(dispatch).toHaveBeenCalledWith(loadGame(game));
     });
 
     it("does not throw or dispatch when the slot holds corrupt JSON", () => {

--- a/src/scenes/LoadScene.ts
+++ b/src/scenes/LoadScene.ts
@@ -267,7 +267,6 @@ export default class LoadScene extends Scene {
         createAnimations(this);
         store.dispatch(toggleUi("save"));
         this.scene.start("SelectScene");
-        //console.log(localStorage.getItem('itemname','contents'));
     }
 
     shutdown(): void {

--- a/src/services/saveStorage.test.ts
+++ b/src/services/saveStorage.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readSave, writeSave, removeSave, readAllSaves, SAVE_SLOTS } from "./saveStorage";
+
+// Unit tests for the typed save/storage service (Phase 2, #307). Every save
+// path goes through here, so these pin the JSON round-trip, the error handling
+// (corrupt reads, failing writes), and the multi-slot read.
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+});
+
+describe("readSave", () => {
+    it("parses and returns the stored save", () => {
+        const save = { game: { coins: 7, wave: 2 } };
+        localStorage.setItem("slot_a", JSON.stringify(save));
+
+        expect(readSave("slot_a")).toEqual(save);
+    });
+
+    it("returns null for an empty slot", () => {
+        expect(readSave("slot_a")).toBeNull();
+    });
+
+    it("returns null and warns on corrupt JSON without throwing", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        localStorage.setItem("slot_a", "{ not valid json");
+
+        expect(readSave("slot_a")).toBeNull();
+        expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("returns null and warns when reading throws", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+            throw new DOMException("denied", "SecurityError");
+        });
+
+        expect(readSave("slot_a")).toBeNull();
+        expect(console.warn).toHaveBeenCalled();
+    });
+});
+
+describe("writeSave", () => {
+    it("serializes the save and reports success", () => {
+        const save = { game: { coins: 99 } } as never;
+
+        expect(writeSave("slot_b", save)).toBe(true);
+        expect(localStorage.getItem("slot_b")).toBe(JSON.stringify(save));
+    });
+
+    it("returns false and warns when the write throws, without throwing", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw new DOMException("quota exceeded", "QuotaExceededError");
+        });
+
+        expect(writeSave("slot_b", {} as never)).toBe(false);
+        expect(console.warn).toHaveBeenCalled();
+    });
+});
+
+describe("removeSave", () => {
+    it("removes the slot", () => {
+        localStorage.setItem("slot_c", JSON.stringify({ game: {} }));
+
+        removeSave("slot_c");
+
+        expect(localStorage.getItem("slot_c")).toBeNull();
+    });
+
+    it("warns and does not throw when removal throws", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+            throw new DOMException("denied", "SecurityError");
+        });
+
+        expect(() => removeSave("slot_c")).not.toThrow();
+        expect(console.warn).toHaveBeenCalled();
+    });
+});
+
+describe("readAllSaves", () => {
+    it("reads every default slot in order, mapping empty/corrupt to null", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const save = { game: { wave: 5 } };
+        localStorage.setItem("slot_a", JSON.stringify(save));
+        localStorage.setItem("slot_c", "{ corrupt");
+
+        expect(readAllSaves()).toEqual([save, null, null]);
+    });
+
+    it("defaults to the three canonical save slots", () => {
+        expect(SAVE_SLOTS).toEqual(["slot_a", "slot_b", "slot_c"]);
+    });
+});

--- a/src/services/saveStorage.ts
+++ b/src/services/saveStorage.ts
@@ -1,0 +1,54 @@
+import type { RootState } from "@store";
+
+// Typed, error-handled wrapper around the browser localStorage save slots.
+// All save-game persistence goes through here so the JSON (de)serialization,
+// the error handling (quota/privacy-mode writes, corrupt reads, SSR where
+// `localStorage` is undefined), and the on-disk shape live in one place.
+//
+// The persisted shape is the Redux *root* state (`{ game: {...} }`), which is
+// what the save paths write. Callers that need the inner slice read it off
+// `.game` — see `loadGame`, which expects a `Partial<GameState>`.
+
+export type SaveData = RootState;
+
+export const SAVE_SLOTS = ["slot_a", "slot_b", "slot_c"] as const;
+export type SaveSlot = (typeof SAVE_SLOTS)[number];
+
+// Read and parse a save slot. Returns null for an empty slot, corrupt JSON, or
+// any environment where localStorage is unavailable — never throws.
+export function readSave(slot: string): SaveData | null {
+    try {
+        const raw = localStorage.getItem(slot);
+        return raw ? (JSON.parse(raw) as SaveData) : null;
+    } catch (error) {
+        console.warn("Ignoring corrupt save data in slot", slot, error);
+        return null;
+    }
+}
+
+// Serialize and write a save slot. Returns whether the write succeeded;
+// localStorage.setItem can throw on quota limits or in privacy mode, and a
+// failed save must not crash the caller.
+export function writeSave(slot: string, data: SaveData): boolean {
+    try {
+        localStorage.setItem(slot, JSON.stringify(data));
+        return true;
+    } catch (error) {
+        console.warn("Failed to save game to slot", slot, error);
+        return false;
+    }
+}
+
+// Remove a save slot. Never throws.
+export function removeSave(slot: string): void {
+    try {
+        localStorage.removeItem(slot);
+    } catch (error) {
+        console.warn("Failed to remove save in slot", slot, error);
+    }
+}
+
+// Read every slot in order, mapping empty/corrupt slots to null.
+export function readAllSaves(slots: readonly string[] = SAVE_SLOTS): (SaveData | null)[] {
+    return slots.map(readSave);
+}

--- a/src/ui/components/templates/Save.tsx
+++ b/src/ui/components/templates/Save.tsx
@@ -3,23 +3,17 @@ import { useDispatch } from "react-redux";
 import { loadGame, selectCharacter, setSaveSlot, switchUi } from "@store/gameReducer";
 import Button from "@components/Button";
 import Dialog from "@components/Dialog";
+import { readAllSaves, removeSave, SAVE_SLOTS } from "@services/saveStorage";
 import type { RootState } from "@store";
 
 interface SaveProps {
     load?: boolean;
 }
 
-const getSaveGames = (slots: string[]): (RootState | null)[] => {
-    return slots.map((slot) => {
-        const saved = localStorage.getItem(slot);
-        return saved ? JSON.parse(saved) : null;
-    });
-};
-
 const Save: React.FC<SaveProps> = ({ load = false }) => {
     const dispatch = useDispatch();
-    const slots = ["slot_a", "slot_b", "slot_c"];
-    const [saveGames, setSaveGames] = useState<(RootState | null)[]>(getSaveGames(slots));
+    const slots = [...SAVE_SLOTS];
+    const [saveGames, setSaveGames] = useState<(RootState | null)[]>(() => readAllSaves(slots));
     const [showDialog, setShowDialog] = useState(false);
     const [currentSaveSlot, setCurrentSaveSlot] = useState<string | false>(false);
     const otherGames = load ? saveGames.filter((save) => save !== null) : saveGames;
@@ -32,8 +26,8 @@ const Save: React.FC<SaveProps> = ({ load = false }) => {
                     text="Confirm"
                     onClick={() => {
                         if (currentSaveSlot) {
-                            localStorage.removeItem(currentSaveSlot);
-                            setSaveGames(getSaveGames(slots));
+                            removeSave(currentSaveSlot);
+                            setSaveGames(readAllSaves(slots));
                             setShowDialog(false);
                         }
                     }}

--- a/src/ui/components/templates/System.tsx
+++ b/src/ui/components/templates/System.tsx
@@ -4,6 +4,7 @@ import { switchUi, toggleUi } from "@store/gameReducer";
 import Button from "@components/Button";
 import Dialog from "@components/Dialog";
 import { dialog_overlay } from "@ui/themes";
+import { writeSave } from "@services/saveStorage";
 import type { RootState } from "@store";
 
 interface SystemProps {
@@ -23,7 +24,7 @@ const System: React.FC<SystemProps> = ({ state }) => {
                     text="Yes"
                     onClick={() => {
                         if (saveSlot) {
-                            localStorage.setItem(saveSlot, JSON.stringify(state));
+                            writeSave(saveSlot, state);
                         }
                         dispatch(toggleUi("system"));
                         setShowDialog(false);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
             "@helpers/*": ["./src/helpers/*"],
             "@scenes/*": ["./src/scenes/*"],
             "@entities/*": ["./src/entities/*"],
+            "@services/*": ["./src/services/*"],
             "@config/*": ["./src/config/*"],
             "@types/*": ["./src/types/*"],
             "@/*": ["./src/*"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
             { find: "@helpers", replacement: path.resolve(__dirname, "./src/helpers") },
             { find: "@scenes", replacement: path.resolve(__dirname, "./src/scenes") },
             { find: "@entities", replacement: path.resolve(__dirname, "./src/entities") },
+            { find: "@services", replacement: path.resolve(__dirname, "./src/services") },
             { find: "@config", replacement: path.resolve(__dirname, "./src/config") },
             {
                 find: "@queries",


### PR DESCRIPTION
Addresses #307 (Phase 2 — stability fixes).

## Summary

Phase 2: introduce a typed, error-handled save/storage service and route every `localStorage` caller through it. JSON (de)serialization, the on-disk save shape, and error handling now live in one place instead of being duplicated across the HUD, the Save menu, and the System menu.

New `src/services/saveStorage.ts` exposes:
- `readSave(slot)` — parse a slot; returns `null` for empty/corrupt JSON or where `localStorage` is unavailable (SSR), never throws
- `writeSave(slot, data)` — serialize + write; returns success, swallows quota/privacy-mode failures
- `removeSave(slot)` — remove a slot, never throws
- `readAllSaves(slots?)` — read every slot in order, mapping empty/corrupt to `null`
- `SAVE_SLOTS` constant and `SaveData` / `SaveSlot` types

Callers routed through it: `HUD.js`, `Save.tsx`, `System.tsx`. Removed `LoadScene.ts`'s dead `localStorage` comment (its only reference). Added a `@services/*` path alias (tsconfig + vitest kept in sync).

## Behavior change (approved)

Fixes the `HUD` keyup-L quick-load round-trip. Saves persist the **root** state (`{ game: {...} }`), but `loadSavedGame` previously passed that whole object to `loadGame`, which expects the inner game slice — double-nesting game state. It now unwraps `.game`, matching the Save menu's Load button, which already did this. This was the pre-existing save-shape mismatch flagged in #316's HUD test; resolution was deferred to this service and confirmed with the maintainer before changing behavior.

## Risk notes

- Behavior-visible only on the broken path (keyup-L quick-load), which previously produced corrupt state; the two save paths and the Save-menu Load are unchanged.
- Save **format** on disk is unchanged (still root `{ game: {...} }`) — existing saves remain loadable.
- Pure mechanics decided per CLAUDE.md: service location (`src/services/`) and the new `@services/*` alias.

## Test evidence

- New `src/services/saveStorage.test.ts`: valid/empty/corrupt/throwing reads, success + failing writes, remove, multi-slot read.
- Updated `HUD.test.ts` to pin the corrected unwrap round-trip.
- Full suite: 41 passing.
- All five gates pass locally: `typecheck`, `lint`, `format:check`, `test`, `build`.

https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q