### PR TITLE
Workflow: agents watch every PR they open until merged/closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,12 @@ before starting work; link PRs to the relevant phase issue.
   every comment, push fixes, then invoke `/qa-review` again. Only request maintainer
   review after QA posts APPROVE. Do not pass the QA agent conversation history or
   broader codebase context — this keeps it honest and scope-focused.
+- **Watch every PR you open (agent-authored PRs only):** the moment you open a PR,
+  subscribe to its activity (`subscribe_pr_activity`) and keep monitoring it for review
+  comments and CI status until it is merged or closed. Address actionable review/CI
+  events as they arrive (fix when confident and small; ask the maintainer when
+  ambiguous or architecturally significant). This is an action only the agent can take,
+  so it cannot be a settings hook.
 - Dependency majors are individual PRs, never bundled with feature work.
 
 ## Code conventions


### PR DESCRIPTION
Addresses #307 (Phase 2 — stability fixes; documents an agent-PR workflow convention).

## Summary

Adds a working-agreement rule to `CLAUDE.md`: when an agent opens a PR, it must immediately subscribe to that PR's activity (`subscribe_pr_activity`) and keep monitoring review comments + CI until the PR is merged or closed, acting on actionable events (fix when confident/small; ask the maintainer when ambiguous or architecturally significant).

Placed next to the existing QA-gate rule, since both are agent-authored-PR conventions.

## Why a doc rule (not a settings hook)

Subscribing to PR activity calls an MCP tool only the agent can invoke during its turn; a `settings.json` hook runs shell commands and cannot make that call. So the durable mechanism for "always do this" is a documented convention every agent follows, not harness automation. The rule text notes this explicitly.

## Risk notes

- Docs-only change; no code, no behavior impact.

## Test evidence

- All five gates pass locally: `typecheck`, `lint`, `format:check`, `test` (41), `build`.

https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q

---
_Generated by [Claude Code](https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q)_