### PR TITLE
Phase 2: lifecycle cleanup for Spell, Gem, Trap

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,7 @@ Each bullet is one small PR unless trivially related.
 - [x] `HUD.js` — remove keyboard listeners on shutdown; guard `JSON.parse(localStorage.getItem(...))`
 - [x] Introduce a typed, error-handled save/storage service wrapping all `localStorage` access (`HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) — with unit tests
 - [x] `Resource.ts` — add cleanup; unsubscribe RxJS subscriptions on shutdown
-- [ ] `Gem.js`, `Trap.js`, `Spell.ts` — unregister event listeners on destroy/shutdown
+- [x] `Gem.js`, `Trap.js`, `Spell.ts` — unregister event listeners on destroy/shutdown
 - [ ] `PhaserGame.tsx` — remove the `setTimeout(createGame, 100)` boot race; turn off arcade `debug: true` (behavior-visible: flag in PR)
 - [ ] Document the resulting lifecycle conventions in `CLAUDE.md` (every entity cleans up on `SHUTDOWN`)
 

--- a/src/entities/Loot/Gem.js
+++ b/src/entities/Loot/Gem.js
@@ -15,15 +15,32 @@ class Gem extends GameObjects.Sprite {
         this.body.setVelocity(getRandomVelocity(35, 70), getRandomVelocity(35, 70)).setDrag(100);
         this.body.immovable = true;
 
-        this.scene.time.delayedCall(500, this.activate, [], this);
+        this.activateTimer = this.scene.time.delayedCall(500, this.activate, [], this);
         this.once("loot:collect", this.collect, this);
 
         const color = new Display.Color().random(100);
         this.setScale(0.5).setTint(color.color);
+
+        // Lifecycle: the activate timer and the player collider outlive a plain
+        // destroy (the gem's own "loot:collect" listener is removed by Phaser).
+        // Stale colliders are harmless no-ops but accumulate during a run, so
+        // release both when the gem is destroyed (collected, or on shutdown).
+        this.once(GameObjects.Events.DESTROY, this.cleanup, this);
     }
 
     activate() {
-        this.scene.physics.add.collider(this.scene.player, this, this.touch, null, this);
+        this.collider = this.scene.physics.add.collider(
+            this.scene.player,
+            this,
+            this.touch,
+            null,
+            this
+        );
+    }
+
+    cleanup() {
+        if (this.activateTimer) this.activateTimer.remove();
+        if (this.collider) this.scene.physics.world.removeCollider(this.collider);
     }
 
     touch() {

--- a/src/entities/Loot/Gem.test.ts
+++ b/src/entities/Loot/Gem.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from "vitest";
+import Gem from "./Gem";
+
+// Regression test for the Phase 2 Gem lifecycle fix (issue #307). The gem's own
+// "loot:collect" listener is removed by Phaser's destroy(), but the activate
+// timer and the player collider are not — stale colliders accumulate during a
+// run. cleanup() releases both. Constructor-free fake on the real prototype.
+
+interface GemUnderTest {
+    activateTimer?: { remove: ReturnType<typeof vi.fn> };
+    collider?: object;
+    scene: { physics: { world: { removeCollider: ReturnType<typeof vi.fn> } } };
+    cleanup(): void;
+}
+
+function makeGem(): GemUnderTest {
+    const gem = Object.create(Gem.prototype) as GemUnderTest;
+    gem.scene = { physics: { world: { removeCollider: vi.fn() } } };
+    return gem;
+}
+
+describe("Gem.cleanup", () => {
+    it("removes the activate timer and the collider", () => {
+        const gem = makeGem();
+        gem.activateTimer = { remove: vi.fn() };
+        gem.collider = { id: "collider" };
+
+        gem.cleanup();
+
+        expect(gem.activateTimer.remove).toHaveBeenCalledTimes(1);
+        expect(gem.scene.physics.world.removeCollider).toHaveBeenCalledWith(gem.collider);
+    });
+
+    it("does not throw when the collider was never created", () => {
+        const gem = makeGem();
+        gem.activateTimer = { remove: vi.fn() };
+
+        expect(() => gem.cleanup()).not.toThrow();
+        expect(gem.scene.physics.world.removeCollider).not.toHaveBeenCalled();
+    });
+});

--- a/src/entities/Spells/Spell.test.ts
+++ b/src/entities/Spells/Spell.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { Scenes } from "phaser";
+import Spell from "./Spell";
+
+// Regression tests for the Phase 2 Spell lifecycle fix (issue #307). Spell
+// registers listeners on external emitters that Phaser does not remove on its
+// own destroy: scene.events ("spell:disableall"/"spell:enableall"), the player
+// resource ("change"), and its button + the keyboard. Because the spell
+// GameObject is not destroyed on scene SHUTDOWN, these would accumulate across
+// runs. cleanup() removes them. Tested against the real prototype with a
+// constructor-free fake — no Phaser boot — matching the other lifecycle tests.
+
+interface SpellUnderTest {
+    scene: { events: { off: ReturnType<typeof vi.fn> } };
+    player: { resource: { off: ReturnType<typeof vi.fn> } };
+    button: {
+        off: ReturnType<typeof vi.fn>;
+        scene: { input: { keyboard: { off: ReturnType<typeof vi.fn> } } };
+    };
+    hotkey: string;
+    cleanup(): void;
+}
+
+function makeSpell(): SpellUnderTest {
+    const spell = Object.create(Spell.prototype) as SpellUnderTest;
+    spell.scene = { events: { off: vi.fn() } };
+    spell.player = { resource: { off: vi.fn() } };
+    spell.button = {
+        off: vi.fn(),
+        scene: { input: { keyboard: { off: vi.fn() } } },
+    };
+    spell.hotkey = "ONE";
+    return spell;
+}
+
+describe("Spell.cleanup", () => {
+    it("removes the scene.events listeners it registered, including the SHUTDOWN handler", () => {
+        const spell = makeSpell();
+
+        spell.cleanup();
+
+        expect(spell.scene.events.off).toHaveBeenCalledWith(
+            "spell:disableall",
+            Spell.prototype.killSpell,
+            spell
+        );
+        expect(spell.scene.events.off).toHaveBeenCalledWith(
+            "spell:enableall",
+            Spell.prototype.monitorSpell,
+            spell
+        );
+        expect(spell.scene.events.off).toHaveBeenCalledWith(
+            Scenes.Events.SHUTDOWN,
+            Spell.prototype.cleanup,
+            spell
+        );
+    });
+
+    it("removes the resource change listener", () => {
+        const spell = makeSpell();
+
+        spell.cleanup();
+
+        expect(spell.player.resource.off).toHaveBeenCalledWith(
+            "change",
+            Spell.prototype.onResourceChangeHandler,
+            spell
+        );
+    });
+
+    it("turns off the button pointer and keyboard listeners", () => {
+        const spell = makeSpell();
+
+        spell.cleanup();
+
+        expect(spell.button.off).toHaveBeenCalledWith("pointerover", Spell.prototype.over, spell);
+        expect(spell.button.off).toHaveBeenCalledWith("pointerout", Spell.prototype.out, spell);
+        expect(spell.button.off).toHaveBeenCalledWith(
+            "pointerdown",
+            Spell.prototype.setPrimed,
+            spell
+        );
+        expect(spell.button.scene.input.keyboard.off).toHaveBeenCalledWith(
+            "keydown-ONE",
+            Spell.prototype.setPrimed,
+            spell
+        );
+    });
+});

--- a/src/entities/Spells/Spell.ts
+++ b/src/entities/Spells/Spell.ts
@@ -1,4 +1,4 @@
-import { GameObjects, Display, Scene } from "phaser";
+import { GameObjects, Display, Scene, Scenes } from "phaser";
 import store from "@store";
 import type { SpellOptions, TargetType } from "@/types/game";
 import type Player from "@entities/Player/Player";
@@ -46,6 +46,27 @@ class Spell extends GameObjects.Sprite {
         this.scene.events.on("spell:disableall", this.killSpell, this);
         this.scene.events.on("spell:enableall", this.monitorSpell, this);
         this.scene.add.existing(this).setDepth(1000).setVisible(false);
+
+        // Lifecycle: the spell registers listeners on external emitters
+        // (scene.events, the player resource, its button + the keyboard) that
+        // Phaser does not remove for us. The spell GameObject is not destroyed on
+        // scene SHUTDOWN (a shut-down scene may reactivate), so its scene.events
+        // listeners would otherwise accumulate across runs — clean up on both
+        // SHUTDOWN and an individual destroy.
+        this.scene.events.once(Scenes.Events.SHUTDOWN, this.cleanup, this);
+        this.once(GameObjects.Events.DESTROY, this.cleanup, this);
+    }
+
+    cleanup(): void {
+        // Remove listeners registered on external emitters (the spell's own
+        // listeners are removed by Phaser's destroy()). Idempotent: off() is a
+        // no-op when the listener is already gone, so the overlapping SHUTDOWN
+        // and DESTROY paths can both run safely.
+        this.scene.events.off("spell:disableall", this.killSpell, this);
+        this.scene.events.off("spell:enableall", this.monitorSpell, this);
+        this.scene.events.off(Scenes.Events.SHUTDOWN, this.cleanup, this);
+        this.player.resource.off("change", this.onResourceChangeHandler, this);
+        this.setButtonEvents("off");
     }
 
     checkResource(): boolean {

--- a/src/entities/Weapons/Trap.js
+++ b/src/entities/Weapons/Trap.js
@@ -13,7 +13,7 @@ class Trap extends GameObjects.Sprite {
 
         this.on("trap:spawned", this.spawnedHandler, this);
 
-        this.scene.time.delayedCall(
+        this.lifespanTimer = this.scene.time.delayedCall(
             lifespan * 1000,
             () => {
                 this.destroy();
@@ -21,6 +21,12 @@ class Trap extends GameObjects.Sprite {
             [],
             this
         );
+
+        // Lifecycle: the lifespan timer and the two colliders outlive a plain
+        // destroy (the trap's own "trap:spawned" listener is removed by Phaser).
+        // Release them when the trap is destroyed (on collide, expiry, or
+        // shutdown) so stale colliders don't accumulate during a run.
+        this.once(GameObjects.Events.DESTROY, this.cleanup, this);
     }
 
     collide(target) {
@@ -31,8 +37,26 @@ class Trap extends GameObjects.Sprite {
     }
 
     spawnedHandler() {
-        this.scene.physics.add.collider(this.scene.active_enemies, this, this.collide, null, this);
-        this.scene.physics.add.collider(this.scene.player, this, this.destroy, null, this);
+        this.enemyCollider = this.scene.physics.add.collider(
+            this.scene.active_enemies,
+            this,
+            this.collide,
+            null,
+            this
+        );
+        this.playerCollider = this.scene.physics.add.collider(
+            this.scene.player,
+            this,
+            this.destroy,
+            null,
+            this
+        );
+    }
+
+    cleanup() {
+        if (this.lifespanTimer) this.lifespanTimer.remove();
+        if (this.enemyCollider) this.scene.physics.world.removeCollider(this.enemyCollider);
+        if (this.playerCollider) this.scene.physics.world.removeCollider(this.playerCollider);
     }
 }
 

--- a/src/entities/Weapons/Trap.test.ts
+++ b/src/entities/Weapons/Trap.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+import Trap from "./Trap";
+
+// Regression test for the Phase 2 Trap lifecycle fix (issue #307). The trap's
+// own "trap:spawned" listener is removed by Phaser's destroy(), but the lifespan
+// timer and the two colliders are not. cleanup() releases them so stale
+// colliders don't accumulate during a run. Constructor-free fake on the real
+// prototype.
+
+interface TrapUnderTest {
+    lifespanTimer?: { remove: ReturnType<typeof vi.fn> };
+    enemyCollider?: object;
+    playerCollider?: object;
+    scene: { physics: { world: { removeCollider: ReturnType<typeof vi.fn> } } };
+    cleanup(): void;
+}
+
+function makeTrap(): TrapUnderTest {
+    const trap = Object.create(Trap.prototype) as TrapUnderTest;
+    trap.scene = { physics: { world: { removeCollider: vi.fn() } } };
+    return trap;
+}
+
+describe("Trap.cleanup", () => {
+    it("removes the lifespan timer and both colliders", () => {
+        const trap = makeTrap();
+        trap.lifespanTimer = { remove: vi.fn() };
+        trap.enemyCollider = { id: "enemy" };
+        trap.playerCollider = { id: "player" };
+
+        trap.cleanup();
+
+        expect(trap.lifespanTimer.remove).toHaveBeenCalledTimes(1);
+        expect(trap.scene.physics.world.removeCollider).toHaveBeenCalledWith(trap.enemyCollider);
+        expect(trap.scene.physics.world.removeCollider).toHaveBeenCalledWith(trap.playerCollider);
+    });
+
+    it("does not throw when colliders were never created (trap destroyed before spawn)", () => {
+        const trap = makeTrap();
+        trap.lifespanTimer = { remove: vi.fn() };
+
+        expect(() => trap.cleanup()).not.toThrow();
+        expect(trap.scene.physics.world.removeCollider).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Addresses #307 (Phase 2 — stability fixes).

## Summary

Adds lifecycle cleanup to `Spell.ts`, `Gem.js`, and `Trap.js` for the listeners/timers/colliders they register on emitters Phaser does not tear down for them.

Verified against the pinned Phaser 3.90 source: `GameObject.destroy()` emits `DESTROY` then calls `removeAllListeners()`, so an object's **own** listeners are already cleaned — the gem's `loot:collect` and trap's `trap:spawned` self-listeners were never the leak. What leaks are external-emitter listeners and physics/timer registrations:

- **`Spell.ts`** — removes the `scene.events` listeners it adds (`spell:disableall`, `spell:enableall`, plus its own `SHUTDOWN` handler), the player-resource `change` listener, and its button + keyboard listeners (`setButtonEvents("off")`). The spell GameObject is **not** destroyed on scene `SHUTDOWN` (per the docs, a shut-down scene may reactivate), so these accumulated on `scene.events` across every run — the meaningful bug. Cleanup is wired to both `Scenes.Events.SHUTDOWN` and `GameObjects.Events.DESTROY`.
- **`Gem.js` / `Trap.js`** — store and release the activate/lifespan timer and the physics colliders on `DESTROY`. Stale colliders are guarded no-ops in Arcade (`collideHandler` checks `object1.body`) but accumulate in the world's collider list during a run.

All `cleanup()` methods are idempotent.

## Risk notes

- No gameplay/behavior change: cleanup only runs at entity `DESTROY`/scene `SHUTDOWN`; during active play every listener/collider behaves exactly as before.
- Scoped to the three named files only. Deliberately did **not** touch `Player.cleanup()` (the open Resource PR #319 edits that same method) to avoid a conflicting edit / muddy scope.
- Pure mechanics decided per CLAUDE.md: cleanup wired via each entity's own `DESTROY` event (and `SHUTDOWN` for the non-destroyed Spell), consistent with the lifecycle-discipline convention.

## Test evidence

- New `Spell.test.ts`, `Gem.test.ts`, `Trap.test.ts`: each asserts its `cleanup()` removes the right listeners/timers/colliders, with constructor-free prototype fakes (matching the existing HUD/Resource lifecycle tests). Includes no-collider/idempotency cases.
- Full suite: 48 passing.
- All five gates pass locally: `typecheck`, `lint`, `format:check`, `test`, `build`.

https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q

---
_Generated by [Claude Code](https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q)_