### PR TITLE
Phase 2: document entity lifecycle conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,34 @@ before starting work; link PRs to the relevant phase issue.
   type the seam properly or ask. No `@ts-ignore`/`@ts-expect-error` without a comment
   explaining why and an issue reference.
 - **Lifecycle discipline (the historical source of bugs here):** every Phaser entity
-  that registers event listeners, timers, or store subscriptions must clean them up
-  on scene `SHUTDOWN`/destroy. Use `scene.time` (pause-aware) instead of raw
-  `setTimeout`/`setInterval`. RxJS/Redux subscriptions (`mapStateToData`) return an
-  unsubscribe function — store it and call it in cleanup.
+  that registers event listeners, timers, store subscriptions, or physics colliders
+  must release them when it goes away. Conventions established in Phase 2:
+    - **Give the entity a `cleanup()` method** that releases everything it registered, and
+      make it **idempotent** — the destroy and shutdown paths below can both fire for the
+      same entity.
+    - **Wire `cleanup()` to the right lifecycle event.** For entities destroyed during play
+      (loot, traps, projectiles), register it on the object's own destroy event:
+      `this.once(GameObjects.Events.DESTROY, this.cleanup, this)`. Phaser does **not**
+      destroy GameObjects on scene `SHUTDOWN` (a shut-down scene may reactivate), so
+      entities that outlive a wave/run must _also_ be cleaned on `SHUTDOWN` — either
+      self-subscribe (`scene.events.once(Scenes.Events.SHUTDOWN, this.cleanup, this)`) or
+      have the owner propagate it: `Player.cleanup()` calls `health/resource/shield.cleanup()`,
+      and a scene's `shutdown()` calls `player.cleanup()` / `UI.cleanup()`.
+    - **Only _external_ listeners need manual removal.** `destroy()` emits `DESTROY` then
+      calls `removeAllListeners()`, so an entity's own `this.on(...)` listeners are cleaned
+      automatically; listeners added to _other_ emitters (`scene.events`,
+      `scene.input.keyboard`, `player.resource`, a `button`) are not — `off()` them in
+      `cleanup()` with the same `(event, fn, context)` you registered.
+    - **Timers:** use `scene.time` (pause-aware) instead of raw `setTimeout`/`setInterval`;
+      store the `TimerEvent` and `.remove()` it in `cleanup()`.
+    - **Store subscriptions:** `mapStateToData` (RxJS) returns an unsubscribe function —
+      store it and call it in `cleanup()`.
+    - **Physics colliders:** store the `Collider` returned by `scene.physics.add.collider(...)`
+      and `scene.physics.world.removeCollider(...)` it in `cleanup()` (stale colliders are
+      guarded no-ops in Arcade but accumulate within a run).
+    - Mock entities at this seam in tests: build a constructor-free fake with
+      `Object.create(Entity.prototype)`, stub the emitters/timers, and assert `cleanup()`
+      releases them (see the HUD/Resource/Spell lifecycle tests).
 - All `localStorage` access goes through the typed save/storage service (Phase 2);
   never call `JSON.parse(localStorage.getItem(...))` directly.
 - Redux is the single source of truth for game state shared with the React UI; the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -53,7 +53,7 @@ Each bullet is one small PR unless trivially related.
 - [ ] `Resource.ts` — add cleanup; unsubscribe RxJS subscriptions on shutdown
 - [ ] `Gem.js`, `Trap.js`, `Spell.ts` — unregister event listeners on destroy/shutdown
 - [ ] `PhaserGame.tsx` — remove the `setTimeout(createGame, 100)` boot race; turn off arcade `debug: true` (behavior-visible: flag in PR)
-- [ ] Document the resulting lifecycle conventions in `CLAUDE.md` (every entity cleans up on `SHUTDOWN`)
+- [x] Document the resulting lifecycle conventions in `CLAUDE.md` (every entity cleans up on `SHUTDOWN`)
 
 ## Phase 3 — TypeScript completion
 


### PR DESCRIPTION
Addresses #307 (Phase 2 — stability fixes; the "document the resulting lifecycle conventions" item).

## Summary

Docs-only. Expands the **Lifecycle discipline** convention in `CLAUDE.md` from a single sentence into the concrete patterns the Phase 2 cleanup PRs established, so future entities follow them by default:

- Each entity gets an **idempotent `cleanup()`** that releases everything it registered.
- **Wiring:** `GameObjects.Events.DESTROY` for entities destroyed during play; `Scenes.Events.SHUTDOWN` (self-subscribe) or owner propagation (`Player.cleanup()` → resources; scene `shutdown()` → `player`/`UI`) for entities that survive a scene shutdown — since Phaser does **not** destroy GameObjects on `SHUTDOWN`.
- **Only external-emitter listeners need manual `off()`** — `destroy()` runs `removeAllListeners()`, so an object's own `this.on(...)` are auto-cleaned.
- Explicit guidance for **timers** (`scene.time` + `.remove()`), **RxJS subscriptions** (`mapStateToData` unsubscribe fn), and **physics colliders** (`removeCollider`).
- The **test seam**: constructor-free `Object.create(Entity.prototype)` fakes.

Also checks off the corresponding Phase 2 roadmap bullet.

## Risk notes

- Docs-only; no code or behavior impact.
- Describes conventions demonstrated by the in-flight cleanup PRs (#319 Resource, #321 Spell/Gem/Trap); the guidance is general and stands on its own regardless of merge order.

## Test evidence

- All five gates pass locally: `typecheck`, `lint`, `format:check`, `test` (41), `build`.

https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q

---
_Generated by [Claude Code](https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q)_