### PR TITLE
Phase 2: remove PhaserGame boot-race setTimeout

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,7 +52,7 @@ Each bullet is one small PR unless trivially related.
 - [x] Introduce a typed, error-handled save/storage service wrapping all `localStorage` access (`HUD.js`, `Save.tsx`, `System.tsx`, `LoadScene.ts`) — with unit tests
 - [x] `Resource.ts` — add cleanup; unsubscribe RxJS subscriptions on shutdown
 - [x] `Gem.js`, `Trap.js`, `Spell.ts` — unregister event listeners on destroy/shutdown
-- [ ] `PhaserGame.tsx` — remove the `setTimeout(createGame, 100)` boot race; turn off arcade `debug: true` (behavior-visible: flag in PR)
+- [x] `PhaserGame.tsx` — remove the `setTimeout(createGame, 100)` boot race (arcade `debug` kept on per maintainer decision)
 - [ ] Document the resulting lifecycle conventions in `CLAUDE.md` (every entity cleans up on `SHUTDOWN`)
 
 ## Phase 3 — TypeScript completion

--- a/src/PhaserGame.tsx
+++ b/src/PhaserGame.tsx
@@ -25,39 +25,35 @@ const PhaserGame = () => {
             gameContainer.innerHTML = "";
         }
 
-        // Add a small delay to ensure DOM is ready
-        const createGame = () => {
-            const config = {
-                type: AUTO,
-                width: window.outerWidth,
-                height: window.outerHeight,
-                backgroundColor: "#6e9c48",
-                parent: "phaser-game",
-                physics: {
-                    default: "arcade",
-                    arcade: {
-                        debug: true,
-                        gravity: {
-                            x: 0,
-                            y: 0,
-                        },
+        const config = {
+            type: AUTO,
+            width: window.outerWidth,
+            height: window.outerHeight,
+            backgroundColor: "#6e9c48",
+            parent: "phaser-game",
+            physics: {
+                default: "arcade",
+                arcade: {
+                    debug: true,
+                    gravity: {
+                        x: 0,
+                        y: 0,
                     },
                 },
-                scene: [LoadScene, SelectScene, TownScene, GameScene, GameOverScene],
-                pixelArt: true,
-                antialias: false,
-                fullscreen: true,
-            };
-
-            gameRef.current = new Game(config);
+            },
+            scene: [LoadScene, SelectScene, TownScene, GameScene, GameOverScene],
+            pixelArt: true,
+            antialias: false,
+            fullscreen: true,
         };
 
-        // Use a timeout to ensure DOM is fully ready
-        const timeoutId = setTimeout(createGame, 100);
+        // The #phaser-game parent is rendered by this component and useEffect runs
+        // after the DOM is committed, so the container already exists — create the
+        // game synchronously rather than racing it behind a setTimeout.
+        gameRef.current = new Game(config);
 
         // Cleanup function for when component unmounts or hot reloads
         return () => {
-            clearTimeout(timeoutId);
             if (gameRef.current) {
                 console.log("Cleaning up Phaser game instance...");
                 gameRef.current.destroy(true, false);


### PR DESCRIPTION
Addresses #307 (Phase 2 — stability fixes).

## Summary

Removes the boot-race `setTimeout` in `PhaserGame.tsx`. The Phaser `Game` was created behind `setTimeout(createGame, 100)` with an "ensure DOM is ready" comment, but the `#phaser-game` parent `<div>` is rendered by this very component and the mount `useEffect` runs after the DOM is committed — the container already exists. The game is now created **synchronously** and the timeout (and its `clearTimeout` in cleanup) is dropped.

## Decisions

- **Arcade `debug: true` is intentionally kept on**, per your call. This PR only removes the boot race; the physics debug overlay is unchanged. The roadmap line is updated to reflect that (rather than implying the overlay was removed).

## Risk notes

- Behavior: initialization timing only — the game boots synchronously in the mount effect instead of 100 ms later. The pre-create cleanup (destroy existing instance, clear container) and the unmount/hot-reload cleanup are unchanged.
- No gameplay/visual change (debug overlay retained).

## Tests

- **No unit test added.** `PhaserGame.tsx` is a React/Phaser boot seam; importing it in Vitest requires a JSX transform + Testing Library wiring that doesn't exist yet — **component-test infrastructure is a Phase 4 deliverable** ("Component (Testing Library)"). Standing it up here would bundle Phase 4 infra into a Phase 2 fix, against the one-concern-per-PR rule. Flagging explicitly per the test convention.
- All five gates pass locally: `typecheck`, `lint`, `format:check`, `test` (52), `build`.

https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q

---
_Generated by [Claude Code](https://claude.ai/code/session_014vVU3CXRhHpRHbS6LKaq7q)_