### PR TITLE
Phase 3: convert lib/cache to TypeScript with typed field policies

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,6 +1,6 @@
-import { InMemoryCache } from "@apollo/client";
+import { InMemoryCache, type FieldReadFunction, type TypePolicies } from "@apollo/client";
 
-const qualityColors = Object.freeze({
+const qualityColors: Record<string, string> = Object.freeze({
     common: "#bbbbbb",
     fine: "#00dd00",
     rare: "#0077ff",
@@ -8,7 +8,7 @@ const qualityColors = Object.freeze({
     legendary: "#ff9900",
 });
 
-const statShortNames = Object.freeze({
+const statShortNames: Record<string, string> = Object.freeze({
     attack_power: "AP",
     attack_speed: "AS",
     critical_chance: "C",
@@ -20,7 +20,7 @@ const statShortNames = Object.freeze({
     speed: "S",
 });
 
-const adjusted = (key, value) => {
+const adjusted = (key: string | undefined, value: number): number => {
     switch (key) {
         case "attack_power":
             return value / 2;
@@ -46,8 +46,8 @@ const adjusted = (key, value) => {
     }
 };
 
-const formatted = (key, value) => {
-    let format;
+const formatted = (key: string | undefined, value: number): string | number => {
+    let format: string | number;
     switch (key) {
         // These are rounded percentages (by the way... WTF is EPSILON???)
         case "attack_speed":
@@ -62,35 +62,41 @@ const formatted = (key, value) => {
     return format;
 };
 
-export const cache = new InMemoryCache({
-    typePolicies: {
-        Item: {
-            fields: {
-                color: {
-                    read(_, { readField }) {
-                        return qualityColors[readField("quality")];
-                    },
-                },
-            },
-        },
-        Stat: {
-            fields: {
-                adjusted: {
-                    read(_, { readField }) {
-                        return adjusted(readField("name"), readField("value"));
-                    },
-                },
-                formatted: {
-                    read(_, { readField }) {
-                        return formatted(readField("name"), readField("converted"));
-                    },
-                },
-                abbreviation: {
-                    read(_, { readField }) {
-                        return statShortNames[readField("name")];
-                    },
-                },
+const colorRead: FieldReadFunction<string> = (_, { readField }) =>
+    qualityColors[readField<string>("quality") as string];
+
+const adjustedRead: FieldReadFunction<number> = (_, { readField }) =>
+    adjusted(readField<string>("name"), readField<number>("value") as number);
+
+const formattedRead: FieldReadFunction<string | number> = (_, { readField }) =>
+    formatted(readField<string>("name"), readField<number>("converted") as number);
+
+const abbreviationRead: FieldReadFunction<string> = (_, { readField }) =>
+    statShortNames[readField<string>("name") as string];
+
+const typePolicies: TypePolicies = {
+    Item: {
+        fields: {
+            color: {
+                read: colorRead,
             },
         },
     },
+    Stat: {
+        fields: {
+            adjusted: {
+                read: adjustedRead,
+            },
+            formatted: {
+                read: formattedRead,
+            },
+            abbreviation: {
+                read: abbreviationRead,
+            },
+        },
+    },
+};
+
+export const cache = new InMemoryCache({
+    typePolicies,
 });


### PR DESCRIPTION
## Summary

Converts `src/lib/cache.js` to TypeScript (`src/lib/cache.ts`) via `git mv` (history preserved). This is the "Convert `lib/cache.js` (typed field policies)" roadmap bullet.

The Apollo Client `InMemoryCache` field policies are now properly typed with Apollo's own types instead of `any`:
- The `typePolicies` object is annotated as `TypePolicies`.
- Each field `read` function is extracted into a named `FieldReadFunction<T>` (`color` → `string`, `adjusted` → `number`, `formatted` → `string | number`, `abbreviation` → `string`).
- `readField` calls use its generic form (`readField<string>("name")`, `readField<number>("value")`) to type the values pulled from the cache.
- Helper functions `adjusted(key, value)` and `formatted(key, value)` and the `qualityColors` / `statShortNames` lookup maps are annotated.

This is a **type-conversion-only** change — no runtime behavior was modified and no logic was refactored.

## Importer edits

None. `src/app/home.tsx` imports `{ cache }` from `../lib/cache` and continues to resolve to the renamed `.ts` file with no change required; `typecheck` and `build` both pass without touching it.

## Mechanics decisions (per CLAUDE.md "decide on mechanics")

- **Lookup maps typed as `Record<string, string>`.** The original JS indexed these maps with the raw `readField(...)` result, which may be `undefined` and yields `undefined` for unknown keys at runtime. `Record<string, string>` preserves that exact behavior (no narrowing of the key union, no new lookup-miss handling).
- **`as string` / `as number` assertions at the `readField` seam.** `readField<V>(...)` returns `SafeReadonly<V> | undefined`. The original code passed these values straight into index access and the helper functions, so the runtime already tolerated `undefined`. The assertions only satisfy the type checker while keeping behavior identical; they are not `any`, so the no-new-`any` rule holds.
- **Read functions extracted to named consts.** Purely for readability and to attach the `FieldReadFunction<T>` annotation cleanly; the policy structure passed to `InMemoryCache` is unchanged.

## Risk / test evidence

Pure type annotations; the emitted JS is behaviorally identical. All five gates pass locally:
- `npm run typecheck` — pass
- `npm run lint` — pass (only pre-existing `next lint` deprecation / multi-lockfile workspace warnings)
- `npm test` — pass (11 files, 52 tests)
- `npm run format:check` — pass
- `npm run build` — pass (static export `✓`; the Apollo `uri` deprecation console messages during SSG are pre-existing in `home.tsx` and unrelated to this change)

Part of #308.

## Conflict notes

This PR only touches `src/lib/cache.ts` (the renamed `src/lib/cache.js`). `src/app/home.tsx` was **not** edited. It therefore does not overlap with the parallel UI-entities or Weapons conversion PRs and is expected to be conflict-free with them.

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_