### PR TITLE
chore: gitignore Claude Code agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 /build
 /dist
 
+# agent worktrees (ephemeral, created by Claude Code agent isolation)
+/.claude/worktrees/
+
 # misc
 .DS_Store
 *.pem


### PR DESCRIPTION
## Summary

Adds `/.claude/worktrees/` to `.gitignore`. Claude Code's agent isolation creates ephemeral git worktrees under `.claude/worktrees/` when running parallel writer agents; these are throwaway checkouts and should never be tracked or trip the repo's "untracked files" stop-hook.

```
+# agent worktrees (ephemeral, created by Claude Code agent isolation)
+/.claude/worktrees/
```

## Risk

None — single-line `.gitignore` addition, no code or build impact. The path only exists transiently during agent runs.

## Test evidence

Trivial ignore rule; no code paths touched. Gate jobs (`quality`, `server`, `armory`, CodeQL) run on the PR.

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_