### PR TITLE
Phase 3: replace scene-augmentation casts with a typed scene interface

### DIFF
--- a/src/entities/Enemy/Enemy.ts
+++ b/src/entities/Enemy/Enemy.ts
@@ -1,4 +1,4 @@
-import { Core, Math as PhaserMath, GameObjects, Geom, Scene, Physics, Types } from "phaser";
+import { Core, Math as PhaserMath, GameObjects, Geom, Physics, Types } from "phaser";
 import { v4 as uuid } from "uuid";
 import AssignResource, { AssignResourceType } from "@entities/Resources/AssignResource";
 import Monster from "./Monster";
@@ -7,6 +7,7 @@ import Crafting from "@entities/Loot/Crafting";
 import Gem from "@entities/Loot/Gem";
 import Banes from "@entities/UI/Banes";
 import type { EnemyOptions, EnemyAttributes, LootTable, TargetType } from "@/types/game";
+import type { GameSceneLike } from "@/types/scene";
 
 interface EnemyStats extends EnemyAttributes {
     health_value?: number;
@@ -159,7 +160,7 @@ class Enemy extends GameObjects.Container {
             this.point.y = this.y;
             this.distance_to_player = PhaserMath.Distance.BetweenPoints(
                 this,
-                (this.scene as Scene & { player: { x: number; y: number } }).player
+                (this.scene as GameSceneLike).player
             );
 
             if (this.distance_to_player < this.attack_radius && this.states.attack === "primed")
@@ -179,7 +180,7 @@ class Enemy extends GameObjects.Container {
                 if (this.states.movement !== "chasing") this.setChasing();
                 this.move({ bias: this.caution });
             } else {
-                if (this.target === (this.scene as Scene & { player: unknown }).player) {
+                if (this.target === (this.scene as GameSceneLike).player) {
                     this.target = null;
                     this.setIdle();
                     this.setWandering();
@@ -245,13 +246,10 @@ class Enemy extends GameObjects.Container {
         this.spawn_stop.destroy();
         this.state = "spawned";
 
-        this.scene.physics.add.collider(
-            (this.scene as Scene & { player: { hero: Phaser.Physics.Arcade.Sprite } }).player.hero,
-            this
-        );
+        this.scene.physics.add.collider((this.scene as GameSceneLike).player.hero, this);
         this.collider = this.scene.physics.add.collider(
-            (this.scene as Scene & { active_enemies: Phaser.GameObjects.Group }).active_enemies,
-            (this.scene as Scene & { active_enemies: Phaser.GameObjects.Group }).active_enemies
+            (this.scene as GameSceneLike).active_enemies,
+            (this.scene as GameSceneLike).active_enemies
         );
 
         this.on("pointerdown", () => {
@@ -298,7 +296,7 @@ class Enemy extends GameObjects.Container {
         if (this.wandering_looped_timer) {
             this.wandering_looped_timer.remove();
         }
-        this.target = (this.scene as Scene & { player: TargetType }).player;
+        this.target = (this.scene as GameSceneLike).player;
         this.destination = null;
     }
 
@@ -332,14 +330,14 @@ class Enemy extends GameObjects.Container {
     select(): void {
         this.graphics.selected.visible = true;
         this.selected = true;
-        (this.scene as Scene & { selected?: Enemy }).selected = this;
+        (this.scene as GameSceneLike).selected = this;
     }
 
     deselect(): void {
         if (this.selected) {
             this.graphics.selected.visible = false;
             this.selected = false;
-            (this.scene as Scene & { selected?: Enemy | null }).selected = null;
+            (this.scene as GameSceneLike).selected = null;
         }
     }
 
@@ -361,10 +359,8 @@ class Enemy extends GameObjects.Container {
         this.active = false;
         if (this.input) this.input.enabled = false;
         this.scene.physics.world.disable(this);
-        (this.scene as Scene & { enemies: Phaser.GameObjects.Group }).enemies.remove(this);
-        (this.scene as Scene & { active_enemies: Phaser.GameObjects.Group }).active_enemies.remove(
-            this
-        );
+        (this.scene as GameSceneLike).enemies.remove(this);
+        (this.scene as GameSceneLike).active_enemies.remove(this);
         this.decompose();
         this.dropLoot();
     }

--- a/src/entities/Loot/Coin.ts
+++ b/src/entities/Loot/Coin.ts
@@ -2,7 +2,7 @@ import { GameObjects, Scene, Physics } from "phaser";
 import store from "@store";
 import { addCoins } from "@store/gameReducer";
 import getRandomVelocity from "@helpers/getRandomVelocity";
-import type GameScene from "@scenes/GameScene";
+import type { GameSceneLike } from "@/types/scene";
 
 interface CoinConfig {
     scene: Scene;
@@ -16,7 +16,7 @@ class Coin extends GameObjects.Sprite {
     constructor(config: CoinConfig) {
         super(config.scene, config.x, config.y, "coin-spin");
         config.scene.physics.world.enable(this);
-        config.scene.add.existing(this).setDepth((this.scene as GameScene).depth_group.UI);
+        config.scene.add.existing(this).setDepth((this.scene as GameSceneLike).depth_group.UI);
 
         this.anims.play("coin");
         this.body.setVelocity(getRandomVelocity(25, 50), getRandomVelocity(25, 50)).setDrag(100);
@@ -28,7 +28,7 @@ class Coin extends GameObjects.Sprite {
 
     activate(): void {
         this.scene.physics.add.collider(
-            (this.scene as GameScene).player,
+            (this.scene as GameSceneLike).player,
             this,
             this.touch,
             undefined,

--- a/src/entities/Loot/Crafting.ts
+++ b/src/entities/Loot/Crafting.ts
@@ -2,7 +2,7 @@ import { GameObjects, Scene } from "phaser";
 import store from "@store";
 import { addCrafting } from "@store/gameReducer";
 import getRandomVelocity from "@helpers/getRandomVelocity";
-import type GameScene from "@scenes/GameScene";
+import type { GameSceneLike } from "@/types/scene";
 
 interface CraftingConfig {
     scene: Scene;
@@ -18,7 +18,7 @@ class Crafting extends GameObjects.Sprite {
     constructor(config: CraftingConfig) {
         super(config.scene, config.x, config.y, "crafting", config.key);
         config.scene.physics.world.enable(this);
-        config.scene.add.existing(this).setDepth((this.scene as GameScene).depth_group.UI);
+        config.scene.add.existing(this).setDepth((this.scene as GameSceneLike).depth_group.UI);
 
         this.name = config.key;
 
@@ -32,7 +32,7 @@ class Crafting extends GameObjects.Sprite {
 
     activate(): void {
         this.scene.physics.add.collider(
-            (this.scene as GameScene).player,
+            (this.scene as GameSceneLike).player,
             this,
             this.touch,
             undefined,

--- a/src/entities/Loot/Gem.ts
+++ b/src/entities/Loot/Gem.ts
@@ -3,7 +3,7 @@ import store from "@store";
 import { addCoins } from "@store/gameReducer";
 import getRandomVelocity from "@helpers/getRandomVelocity";
 import random from "lodash/random";
-import type GameScene from "@scenes/GameScene";
+import type { GameSceneLike } from "@/types/scene";
 
 interface GemConfig {
     scene: Scene;
@@ -19,7 +19,7 @@ class Gem extends GameObjects.Sprite {
     constructor(config: GemConfig) {
         super(config.scene, config.x, config.y, "gem-shine");
         config.scene.physics.world.enable(this);
-        config.scene.add.existing(this).setDepth((this.scene as GameScene).depth_group.UI);
+        config.scene.add.existing(this).setDepth((this.scene as GameSceneLike).depth_group.UI);
 
         this.anims.playAfterDelay("gem", random(1000, 2000));
         this.body.setVelocity(getRandomVelocity(35, 70), getRandomVelocity(35, 70)).setDrag(100);
@@ -40,7 +40,7 @@ class Gem extends GameObjects.Sprite {
 
     activate(): void {
         this.collider = this.scene.physics.add.collider(
-            (this.scene as GameScene).player,
+            (this.scene as GameSceneLike).player,
             this,
             this.touch,
             undefined,

--- a/src/entities/Player/Player.ts
+++ b/src/entities/Player/Player.ts
@@ -16,6 +16,7 @@ import mapStateToData from "@helpers/mapStateToData";
 import CombatText from "../UI/CombatText";
 import type { PlayerOptions, PlayerStats } from "@/types/game";
 import type Enemy from "@entities/Enemy/Enemy";
+import type { GameSceneLike } from "@/types/scene";
 
 const converter = require("number-to-words");
 interface Destination {
@@ -208,7 +209,7 @@ class Player extends GameObjects.Container {
             this.idle();
         }
 
-        if ((this.scene as Scene & { selected?: Enemy }).selected) this.goToRange();
+        if ((this.scene as GameSceneLike).selected) this.goToRange();
 
         // Self cast key
         if (keys.space.isDown) {
@@ -302,7 +303,7 @@ class Player extends GameObjects.Container {
     }
 
     goToRange(): void {
-        let target = (this.scene as Scene & { selected?: Enemy }).selected;
+        let target = (this.scene as GameSceneLike).selected;
         if (!target) return;
         this.moveToPosition(target);
         let distance = PhaserMath.Distance.Between(target.x, target.y, this.x, this.y);
@@ -315,7 +316,7 @@ class Player extends GameObjects.Container {
         } else {
             if (!this.attack_delay) {
                 this.attack_delay = this.scene.time.delayedCall(
-                    (this.scene as Scene & { global_attack_delay: number }).global_attack_delay,
+                    (this.scene as GameSceneLike).global_attack_delay,
                     this.walk,
                     [],
                     this
@@ -382,7 +383,7 @@ class Player extends GameObjects.Container {
         // 	wander: 0,
         // 	gravity: 0
         // }))
-        if (!(this.scene as Scene & { selected?: Enemy }).selected) this.idle();
+        if (!(this.scene as GameSceneLike).selected) this.idle();
     }
 
     setExperience(exp: number = store.getState().game.xp, count: number = 1): void {

--- a/src/entities/Spells/EarthShield.ts
+++ b/src/entities/Spells/EarthShield.ts
@@ -2,7 +2,7 @@ import Spell from "./Spell";
 import type { SpellOptions } from "@/types/game";
 import type Enemy from "@entities/Enemy/Enemy";
 import type { Types, Physics } from "phaser";
-import type GameScene from "@scenes/GameScene";
+import type { GameSceneLike } from "@/types/scene";
 
 class EarthShield extends Spell {
     public type: string;
@@ -64,7 +64,7 @@ class EarthShield extends Spell {
         this.body.setOffset(40, 20); //TODO: Must be a better way!?
         this.body.immovable = true;
         this.scene.physics.add.collider(
-            (this.scene as GameScene).active_enemies,
+            (this.scene as GameSceneLike).active_enemies,
             this,
             this.touch,
             undefined,

--- a/src/entities/Spells/Multishot.ts
+++ b/src/entities/Spells/Multishot.ts
@@ -1,6 +1,7 @@
 import Spell from "./Spell";
 import targetVector from "@helpers/targetVector";
 import type { SpellOptions, EntityWithVector, EnemyOptions } from "@/types/game";
+import type { GameSceneLike } from "@/types/scene";
 
 class Multishot extends Spell {
     public type: string;
@@ -43,7 +44,9 @@ class Multishot extends Spell {
     }
 
     startAnimation(): void {
-        const enemiesInRange: EnemyOptions[] = (this.scene as any).enemies.children.entries
+        const enemiesInRange: EnemyOptions[] = (
+            (this.scene as GameSceneLike).enemies.children.entries as unknown as EnemyOptions[]
+        )
             .filter((enemy: EnemyOptions) => {
                 enemy.vector = targetVector(this.player as any, enemy as any);
                 if ((enemy.vector?.range ?? 0) < this.range) return enemy;

--- a/src/entities/Spells/Spell.ts
+++ b/src/entities/Spells/Spell.ts
@@ -1,7 +1,8 @@
-import { GameObjects, Display, Scene, Scenes } from "phaser";
+import { GameObjects, Display, Scenes } from "phaser";
 import store from "@store";
 import type { SpellOptions, TargetType } from "@/types/game";
 import type Player from "@entities/Player/Player";
+import type { GameSceneLike } from "@/types/scene";
 
 interface SpellValue {
     crit: boolean;
@@ -208,7 +209,7 @@ class Spell extends GameObjects.Sprite {
         const button = this.scene.add
             .sprite(0, 0, "icon", this.icon_name)
             .setInteractive()
-            .setDepth((this.scene as Scene & { depth_group: { UI: number } }).depth_group.UI)
+            .setDepth((this.scene as GameSceneLike).depth_group.UI)
             .setAlpha(0.4)
             .setScale(1.5)
             .setScrollFactor(0);
@@ -221,13 +222,10 @@ class Spell extends GameObjects.Sprite {
         const text = this.scene.add
             .text(-2, -2, this.cooldown.toString(), styles)
             .setOrigin(0.5)
-            .setDepth((this.scene as Scene & { depth_group: { UI: number } }).depth_group.UI)
+            .setDepth((this.scene as GameSceneLike).depth_group.UI)
             .setVisible(false);
 
-        Display.Align.In.BottomLeft(
-            button,
-            (this.scene as Scene & { UI: { frames: GameObjects.Sprite[] } }).UI.frames[this.slot]
-        );
+        Display.Align.In.BottomLeft(button, (this.scene as GameSceneLike).UI.frames[this.slot]);
         Display.Align.In.Center(text, button, 0, 0);
 
         return { button: button, text: text };

--- a/src/entities/Spells/Whirlwind.ts
+++ b/src/entities/Spells/Whirlwind.ts
@@ -1,6 +1,7 @@
 import Spell from "./Spell";
 import targetVector from "@helpers/targetVector";
 import type { SpellOptions, EnemyOptions } from "@/types/game";
+import type { GameSceneLike } from "@/types/scene";
 class Whirlwind extends Spell {
     public type: string;
     public range: number;
@@ -36,7 +37,9 @@ class Whirlwind extends Spell {
     }
 
     effect(target: any): void {
-        const enemiesInRange = (this.scene as any).enemies.children.entries
+        const enemiesInRange = (
+            (this.scene as GameSceneLike).enemies.children.entries as unknown as EnemyOptions[]
+        )
             .filter((enemy: EnemyOptions) => {
                 enemy.vector = targetVector(this.player as any, enemy as any);
                 if (enemy?.vector?.range && enemy.vector.range < this.range) return enemy;

--- a/src/entities/UI/HUD.ts
+++ b/src/entities/UI/HUD.ts
@@ -3,19 +3,11 @@ import { toggleHUD, toggleUi, addLoot, loadGame } from "@store/gameReducer";
 import store from "@store";
 import mapStateToData from "@helpers/mapStateToData";
 import { readSave, writeSave, removeSave, SAVE_SLOTS } from "@services/saveStorage";
+import type { GameSceneLike } from "@/types/scene";
 
 const styles = {
     font: "12px monospace",
     fill: "#ffffff",
-};
-
-// The HUD reads a few fields off the GameScene that are not part of the base
-// Phaser Scene (and some are private on GameScene). Scene-augmentation casts
-// are the established pattern here and are tracked for a separate cleanup PR.
-type HudScene = Scene & {
-    zone: GameObjects.Zone;
-    wave: number;
-    depth_group: Record<string, number>;
 };
 
 // The coin/wave readouts are plain containers with a `text` child stashed on
@@ -50,7 +42,7 @@ class UI extends GameObjects.Container {
         this.buttons.forEach((button) => this.add(button));
 
         // Position buttons in the bottom right
-        const { x, y, width, height } = (this.scene as HudScene).zone;
+        const { x, y, width, height } = (this.scene as GameSceneLike).zone;
         Actions.IncXY(this.buttons, x + width, y + height, -35);
 
         // Maps coins, wave and showUi sections of the store to various functions.
@@ -92,13 +84,13 @@ class UI extends GameObjects.Container {
 
         this.scene.add
             .existing(this)
-            .setDepth((this.scene as HudScene).depth_group.UI)
+            .setDepth((this.scene as GameSceneLike).depth_group.UI)
             .setScrollFactor(0);
     }
 
     setSpellFrames(): void {
-        let x = Display.Bounds.GetLeft((this.scene as HudScene).zone);
-        let y = Display.Bounds.GetBottom((this.scene as HudScene).zone);
+        let x = Display.Bounds.GetLeft((this.scene as GameSceneLike).zone);
+        let y = Display.Bounds.GetBottom((this.scene as GameSceneLike).zone);
         for (let i = 0; i < this.spells; i++) {
             let frame = this.scene.add
                 .sprite(x + this.spacing * i, y, "icon", "icon_blank")
@@ -111,7 +103,7 @@ class UI extends GameObjects.Container {
 
     setCoinCount(): void {
         this.coins = this.scene.add.container(0, 0) as LabelledContainer;
-        Display.Align.In.TopRight(this.coins, (this.scene as HudScene).zone, -80);
+        Display.Align.In.TopRight(this.coins, (this.scene as GameSceneLike).zone, -80);
 
         this.coins.add(this.scene.add.sprite(0, 0, "coin-spin"));
         this.coins.text = this.scene.add.text(15, 0, "Coins: ", styles).setOrigin(0, 0.5);
@@ -122,11 +114,11 @@ class UI extends GameObjects.Container {
 
     setWaveCount(): void {
         this.wave = this.scene.add.container(0, 0) as LabelledContainer;
-        Display.Align.In.TopRight(this.wave, (this.scene as HudScene).zone, -190);
+        Display.Align.In.TopRight(this.wave, (this.scene as GameSceneLike).zone, -190);
 
         this.wave.add(this.scene.add.sprite(0, 0, "dungeon", "ghast_baby"));
         this.wave.text = this.scene.add
-            .text(15, 0, "Wave: " + ((this.scene as HudScene).wave + 1), styles)
+            .text(15, 0, "Wave: " + ((this.scene as GameSceneLike).wave + 1), styles)
             .setOrigin(0, 0.5);
         this.wave.add(this.wave.text);
 

--- a/src/entities/Weapons/AreaEffect.ts
+++ b/src/entities/Weapons/AreaEffect.ts
@@ -1,5 +1,5 @@
 import { GameObjects, Physics, Scene } from "phaser";
-import type GameScene from "@scenes/GameScene";
+import type { GameSceneLike } from "@/types/scene";
 
 class AreaEffect extends GameObjects.Sprite {
     public body: Physics.Arcade.Body;
@@ -11,14 +11,14 @@ class AreaEffect extends GameObjects.Sprite {
         scene.add.existing(this);
 
         this.scene.physics.add.overlap(
-            (this.scene as GameScene).active_enemies,
+            (this.scene as GameSceneLike).active_enemies,
             this,
             this.overlap,
             this.throttle,
             this
         );
         this.scene.physics.add.overlap(
-            (this.scene as GameScene).player,
+            (this.scene as GameSceneLike).player,
             this,
             this.overlap,
             this.throttle,

--- a/src/entities/Weapons/Trap.ts
+++ b/src/entities/Weapons/Trap.ts
@@ -1,6 +1,6 @@
 import { GameObjects, Physics, Scene, Time, Types } from "phaser";
 import { dropIn } from "@helpers/spawnStyle";
-import type GameScene from "@scenes/GameScene";
+import type { GameSceneLike } from "@/types/scene";
 
 class Trap extends GameObjects.Sprite {
     public body: Physics.Arcade.Body;
@@ -48,7 +48,7 @@ class Trap extends GameObjects.Sprite {
 
     spawnedHandler(): void {
         this.enemyCollider = this.scene.physics.add.collider(
-            (this.scene as GameScene).active_enemies,
+            (this.scene as GameSceneLike).active_enemies,
             this,
             this.collide,
             undefined,
@@ -59,7 +59,7 @@ class Trap extends GameObjects.Sprite {
         // (Phaser invokes it with the two colliding objects), so cast to preserve
         // the existing runtime behavior without altering the call.
         this.playerCollider = this.scene.physics.add.collider(
-            (this.scene as GameScene).player,
+            (this.scene as GameSceneLike).player,
             this,
             this.destroy as unknown as Types.Physics.Arcade.ArcadePhysicsCallback,
             undefined,

--- a/src/types/scene.ts
+++ b/src/types/scene.ts
@@ -1,0 +1,35 @@
+import type { Scene, GameObjects } from "phaser";
+import type { PlayerType } from "@entities/Player/AssignClass";
+import type Enemy from "@entities/Enemy/Enemy";
+import type UI from "@entities/UI/HUD";
+
+// The surface of the gameplay scene (GameScene / TownScene) that entities,
+// spells, loot and the HUD read off `this.scene`. These members are not part of
+// the base Phaser `Scene`, so the call sites historically cast with inline
+// `this.scene as Scene & { ... }` augmentations. `GameSceneLike` replaces every
+// one of those scattered casts with a single named shape (issue #308).
+//
+// This is intentionally a standalone interface that the entities cast to, rather
+// than something the scene classes `implements`: a couple of the members below
+// are consumed off the scene but are not actually declared on GameScene /
+// TownScene (see the per-member notes), so `implements` would force adding
+// never-written fields and misrepresent the real class. The interface models
+// what the consumers genuinely read; keeping it separate documents that seam
+// honestly without changing any runtime behaviour.
+export interface GameSceneLike extends Scene {
+    player: PlayerType;
+    enemies: GameObjects.Group;
+    active_enemies: GameObjects.Group;
+    // Written by Enemy.select()/deselect() and read by Player; the scene does
+    // not declare this field, so it is `undefined` until an enemy is selected.
+    selected: Enemy | null | undefined;
+    depth_group: Record<string, number>;
+    zone: GameObjects.Zone;
+    // Read by the HUD wave readout. Note: neither scene declares `wave` (it
+    // lives in the Redux store), so at runtime this is `undefined` and the
+    // initial "Wave: NaN" is immediately overwritten by the `wave` store
+    // subscription. Preserved as-is; flagged for a separate fix.
+    wave: number;
+    UI: UI;
+    global_attack_delay: number;
+}


### PR DESCRIPTION
## What changed

Replaces the scattered scene-augmentation casts (`this.scene as Scene & {...}`), the per-entity `this.scene as GameScene` casts, and the two `this.scene as any` casts with a single, explicit, exported scene interface.

### Interface

- **Name:** `GameSceneLike` (extends `Phaser.Scene`)
- **Location:** `src/types/scene.ts` (imported via the existing `@/*` alias as `@/types/scene` — no new path alias, so `tsconfig.json`/`vitest.config.ts` are untouched)
- **Members** (modelled to the concrete types the code already relies on):
  - `player: PlayerType`
  - `enemies: GameObjects.Group`
  - `active_enemies: GameObjects.Group`
  - `selected: Enemy | null | undefined` (read **and** written — Enemy writes it, Player reads it)
  - `depth_group: Record<string, number>`
  - `zone: GameObjects.Zone`
  - `wave: number`
  - `UI: UI` (the HUD class, whose `frames: GameObjects.Sprite[]` the Spell reads)
  - `global_attack_delay: number`

### implements vs cast decision

Used a **standalone interface + `as GameSceneLike` casts**, *not* `GameScene implements GameSceneLike`. Two of the consumed members are read off the scene but are **not declared on either scene class**, so `implements` would have forced adding never-written fields and misrepresented the real classes:

- **`wave`** — read by the HUD, but neither `GameScene` nor `TownScene` declares it; `wave` actually lives in the Redux store (`store.getState().game.wave`).
- **`selected`** — written ad-hoc by `Enemy.select()/deselect()` and read by `Player`, never declared as a scene field.

Keeping the interface standalone documents the entity↔scene seam honestly without asserting a false relationship.

**No scene visibility or declaration changes were made** — `GameScene.ts` and `TownScene.ts` are not modified by this PR.

### Pre-existing behaviour preserved (flagged, not fixed)

The HUD computes `"Wave: " + ((this.scene as GameSceneLike).wave + 1)`. Since the scene has no `wave` field, this reads `undefined` and the initial render is `"Wave: NaN"`, which is then immediately overwritten by the `mapStateToData("wave", ...)` store subscription. This is a latent bug carried over unchanged from the original `HudScene` cast; preserved as-is and noted in a comment on the `wave` member in `src/types/scene.ts`.

The two `as any` casts in Multishot/Whirlwind became `(this.scene as GameSceneLike).enemies.children.entries as unknown as EnemyOptions[]`. The `unknown` step is required because Phaser types `entries` as `GameObjects.GameObject[]` while the existing `.filter`/`.sort` callbacks and result type are `EnemyOptions[]`; this preserves the exact runtime chain without introducing `any`.

## Confirmation

- No `Scene & {` augmentation casts remain in `src/` (only a reference inside a doc comment in `src/types/scene.ts`).
- No `this.scene as any` remain in `src/`.
- No new `any`; the two existing `as any` are removed. No `@ts-ignore`.

## Files changed

- `src/types/scene.ts` (new)
- `src/entities/Enemy/Enemy.ts`
- `src/entities/Player/Player.ts`
- `src/entities/Spells/Spell.ts`
- `src/entities/Spells/Multishot.ts`
- `src/entities/Spells/Whirlwind.ts`
- `src/entities/Spells/EarthShield.ts`
- `src/entities/Loot/Coin.ts`, `Gem.ts`, `Crafting.ts`
- `src/entities/Weapons/Trap.ts`, `AreaEffect.ts`
- `src/entities/UI/HUD.ts` (local `HudScene` type removed)

## Test evidence (all five gates pass locally)

- `npm run typecheck` — pass (`tsc --noEmit`, no errors)
- `npm run lint` — pass (no ESLint warnings or errors)
- `npm test` — pass (11 files, 52 tests)
- `npm run format:check` — pass (all files match Prettier)
- `npm run build` — pass (static export succeeds)

Part of #308

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_