### PR TITLE
Phase 3: eliminate `any` across entities/spells/UI and enable no-explicit-any

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from "@eslint/eslintrc";
+import tseslint from "@typescript-eslint/eslint-plugin";
 
 const compat = new FlatCompat({
     // import.meta.dirname is available after Node.js v20.11.0
@@ -12,6 +13,19 @@ const eslintConfig = [
             "@next/next/no-img-element": "off",
         },
     }),
+    {
+        // Phase 3 (#308): forbid `any` across the TypeScript sources. The
+        // @typescript-eslint plugin/parser ship transitively with
+        // eslint-config-next, so no new dependency is required; we register the
+        // plugin here so the rule resolves under flat config.
+        files: ["**/*.ts", "**/*.tsx"],
+        plugins: {
+            "@typescript-eslint": tseslint,
+        },
+        rules: {
+            "@typescript-eslint/no-explicit-any": "error",
+        },
+    },
     {
         ignores: [
             ".next/**",

--- a/src/entities/Enemy/Enemy.ts
+++ b/src/entities/Enemy/Enemy.ts
@@ -6,7 +6,13 @@ import Coin from "@entities/Loot/Coin";
 import Crafting from "@entities/Loot/Crafting";
 import Gem from "@entities/Loot/Gem";
 import Banes from "@entities/UI/Banes";
-import type { EnemyOptions, EnemyAttributes, LootTable, TargetType } from "@/types/game";
+import type {
+    EnemyOptions,
+    EnemyAttributes,
+    LootTable,
+    TargetType,
+    EntityWithVector,
+} from "@/types/game";
 import type { GameSceneLike } from "@/types/scene";
 
 interface EnemyStats extends EnemyAttributes {
@@ -71,6 +77,8 @@ class Enemy extends GameObjects.Container {
     public swing: Phaser.Time.TimerEvent | null = null;
     public collider: Physics.Arcade.Collider;
     public body: Physics.Arcade.Body;
+    // Transient targeting vector cached by the Whirlwind/Multishot range scans.
+    public vector?: EntityWithVector;
 
     constructor(config: EnemyOptions) {
         super(config.scene, config.x, config.y - 300);

--- a/src/entities/Player/Player.ts
+++ b/src/entities/Player/Player.ts
@@ -55,6 +55,8 @@ class Player extends GameObjects.Container {
     public attack_delay: Phaser.Time.TimerEvent | null;
     public swing: Phaser.Time.TimerEvent | null = null;
     public body: Physics.Arcade.Body;
+    // Set/reset by each Spell to clear the previously primed spell (see Spell).
+    public clearLastPrimedSpell: () => void;
 
     constructor({
         scene,

--- a/src/entities/Spells/Consecration.ts
+++ b/src/entities/Spells/Consecration.ts
@@ -1,6 +1,7 @@
 import Spell from "./Spell";
 import AreaEffect from "../Weapons/AreaEffect";
 import type { SpellOptions } from "@/types/game";
+import type Enemy from "@entities/Enemy/Enemy";
 
 class Consecration extends Spell {
     public type: string;
@@ -52,7 +53,7 @@ class Consecration extends Spell {
         this.item.on("player:area:overlap", this.playerEffect, this);
     }
 
-    effect(target?: any): void {
+    effect(target?: Enemy): void {
         if (target?.body) {
             // Scales value bases on player stat.
             const value = this.setValue({ base: 3, key: "magic_power" });

--- a/src/entities/Spells/EarthShield.ts
+++ b/src/entities/Spells/EarthShield.ts
@@ -1,5 +1,5 @@
 import Spell from "./Spell";
-import type { SpellOptions } from "@/types/game";
+import type { SpellOptions, ArcadeCollisionObject } from "@/types/game";
 import type Enemy from "@entities/Enemy/Enemy";
 import type { Types, Physics } from "phaser";
 import type { GameSceneLike } from "@/types/scene";
@@ -105,7 +105,9 @@ class EarthShield extends Spell {
         this.setScale(1);
     }
 
-    touch(enemy: any): void {
+    // Arcade collide callback against `active_enemies`, so the object is an Enemy.
+    touch(object: ArcadeCollisionObject): void {
+        const enemy = object as Enemy;
         if (this.ready) {
             // The actual hit.
             const value = this.setValue({ base: 10, key: "magic_power" });

--- a/src/entities/Spells/Enrage.ts
+++ b/src/entities/Spells/Enrage.ts
@@ -1,7 +1,11 @@
 import Boon from "./Boon";
 import type { SpellOptions } from "@/types/game";
+import type { EffectValue } from "@entities/UI/StatusEffects";
 
+// Index signature lets the concrete stat-modifier map satisfy the
+// `Record<string, EffectValue>` that StatusEffects (Boons/Banes) consumes.
 interface EnrageValue {
+    [key: string]: EffectValue;
     critical_chance: number;
     attack_power: (baseAttackPower: number) => number;
     health_regen_value: (baseRegenValue: number) => number;

--- a/src/entities/Spells/Faith.ts
+++ b/src/entities/Spells/Faith.ts
@@ -1,5 +1,6 @@
 import Spell from "./Spell";
 import type { SpellOptions } from "@/types/game";
+import type Player from "@entities/Player/Player";
 
 class Faith extends Spell {
     public frequency: number;
@@ -40,7 +41,7 @@ class Faith extends Spell {
         this.scene.events[state]("pointerdown:enemy", this.clearSpell, this);
     }
 
-    effect(target: any): void {
+    effect(target: Player): void {
         const timer_config = {
             delay: this.frequency * 1000,
             repeat: Math.round(this.duration / this.frequency) - 1,
@@ -53,7 +54,7 @@ class Faith extends Spell {
         target.health.adjustValue(value.amount, this.type, false);
     }
 
-    overTimeEffect(target: any): void {
+    overTimeEffect(target: Player): void {
         // Scales value bases on player stat
         const value = this.setValue({ base: 20, key: "magic_power" });
         target.health.adjustValue(value.amount, this.type, value.crit);

--- a/src/entities/Spells/Frostbolt.ts
+++ b/src/entities/Spells/Frostbolt.ts
@@ -1,8 +1,12 @@
 import Spell from "./Spell";
 import type { SpellOptions } from "@/types/game";
 import type Enemy from "@entities/Enemy/Enemy";
+import type { EffectValue } from "@entities/UI/StatusEffects";
 
+// Index signature lets the concrete stat-modifier map satisfy the
+// `Record<string, EffectValue>` that StatusEffects (Boons/Banes) consumes.
 interface FrostboltValue {
+    [key: string]: EffectValue;
     speed: (baseSpeed: number) => number;
 }
 
@@ -46,7 +50,7 @@ class Frostbolt extends Spell {
         this.scene.events[state]("pointerdown:player", this.clearSpell, this);
     }
 
-    effect(target: any): void {
+    effect(target: Enemy): void {
         // Returns crit boolean and modified value using spell base value.
         const value = this.setValue({ base: 35, key: "magic_power" });
         target.health.adjustValue(-value.amount, this.type, value.crit);

--- a/src/entities/Spells/Invocation.ts
+++ b/src/entities/Spells/Invocation.ts
@@ -1,7 +1,11 @@
 import Boon from "./Boon";
 import type { SpellOptions } from "@/types/game";
+import type { EffectValue } from "@entities/UI/StatusEffects";
 
+// Index signature lets the concrete stat-modifier map satisfy the
+// `Record<string, EffectValue>` that StatusEffects (Boons/Banes) consumes.
 interface InvocationValue {
+    [key: string]: EffectValue;
     resource_regen_value: (baseRegenValue: number) => number;
     resource_regen_rate: number;
 }

--- a/src/entities/Spells/ManaShield.ts
+++ b/src/entities/Spells/ManaShield.ts
@@ -1,5 +1,6 @@
 import Spell from "./Spell";
 import type { SpellOptions } from "@/types/game";
+import type Player from "@entities/Player/Player";
 
 class ManaShield extends Spell {
     public type: string;
@@ -32,7 +33,7 @@ class ManaShield extends Spell {
         this.scene.events[state]("pointerdown:enemy", this.clearSpell, this);
     }
 
-    effect(target: any): void {
+    effect(target: Player): void {
         this.setVisible(true);
         // Scales value bases on player stat
         const value = this.setValue({ base: 130, key: "magic_power" });

--- a/src/entities/Spells/Multishot.ts
+++ b/src/entities/Spells/Multishot.ts
@@ -1,6 +1,8 @@
+import { GameObjects } from "phaser";
 import Spell from "./Spell";
 import targetVector from "@helpers/targetVector";
-import type { SpellOptions, EntityWithVector, EnemyOptions } from "@/types/game";
+import type { SpellOptions } from "@/types/game";
+import type Enemy from "@entities/Enemy/Enemy";
 import type { GameSceneLike } from "@/types/scene";
 
 class Multishot extends Spell {
@@ -35,7 +37,7 @@ class Multishot extends Spell {
         if (state === "on") this.castSpell(this.player);
     }
 
-    effect(target?: any): void {
+    effect(target?: Enemy): void {
         // Scales value bases on player stat.
         if (target) {
             const value = this.setValue({ base: 30, key: "attack_power" });
@@ -44,20 +46,20 @@ class Multishot extends Spell {
     }
 
     startAnimation(): void {
-        const enemiesInRange: EnemyOptions[] = (
-            (this.scene as GameSceneLike).enemies.children.entries as unknown as EnemyOptions[]
+        const enemiesInRange: Enemy[] = (
+            (this.scene as GameSceneLike).enemies.children.entries as unknown as Enemy[]
         )
-            .filter((enemy: EnemyOptions) => {
-                enemy.vector = targetVector(this.player as any, enemy as any);
+            .filter((enemy: Enemy) => {
+                enemy.vector = targetVector(this.player, enemy);
                 if ((enemy.vector?.range ?? 0) < this.range) return enemy;
                 return null;
             })
-            .sort(function (a: EnemyOptions, b: EnemyOptions) {
+            .sort(function (a: Enemy, b: Enemy) {
                 return (a.vector?.range ?? 0) - (b.vector?.range ?? 0);
             })
             .slice(0, this.cap);
 
-        enemiesInRange.forEach((enemy: EnemyOptions) => {
+        enemiesInRange.forEach((enemy: Enemy) => {
             this.target = enemy;
             this.effect(enemy);
 
@@ -69,7 +71,7 @@ class Multishot extends Spell {
         });
     }
 
-    updateAnimation(effect: any, target: any): void {
+    updateAnimation(effect: GameObjects.Sprite, target: Enemy): void {
         effect.x = target.x;
         effect.y = target.y;
     }

--- a/src/entities/Spells/PowerInfusion.ts
+++ b/src/entities/Spells/PowerInfusion.ts
@@ -1,7 +1,11 @@
 import Boon from "./Boon";
 import type { SpellOptions } from "@/types/game";
+import type { EffectValue } from "@entities/UI/StatusEffects";
 
+// Index signature lets the concrete stat-modifier map satisfy the
+// `Record<string, EffectValue>` that StatusEffects (Boons/Banes) consumes.
 interface PowerInfusionValue {
+    [key: string]: EffectValue;
     critical_chance: number;
     attack_power: (baseAttackPower: number) => number;
     magic_power: (baseMagicPower: number) => number;

--- a/src/entities/Spells/SiphonSoul.ts
+++ b/src/entities/Spells/SiphonSoul.ts
@@ -31,8 +31,9 @@ class SiphonSoul extends Spell {
 
         super({ ...defaults, ...config });
 
-        // This is what the spell scales from.
-        this.power = this.player.stats.magic_power / 10;
+        // This is what the spell scales from. Player stats always include
+        // magic_power; the `?? 0` only satisfies the optional type.
+        this.power = (this.player.stats.magic_power ?? 0) / 10;
         this.deathZone = new Phaser.Geom.Circle(this.player.x, this.player.y, 20);
         this.particleDuration = this.duration + this.cooldown;
     }
@@ -46,7 +47,7 @@ class SiphonSoul extends Spell {
         this.scene.events[state]("pointerdown:player", this.clearSpell, this);
     }
 
-    effect(target: any): void {
+    effect(target: Enemy): void {
         // Root the target in place.
         target.body.setMaxVelocity(0, 0);
         target.monster.anims.pause();

--- a/src/entities/Spells/Smite.ts
+++ b/src/entities/Spells/Smite.ts
@@ -1,5 +1,6 @@
 import Spell from "./Spell";
 import type { SpellOptions } from "@/types/game";
+import type Enemy from "@entities/Enemy/Enemy";
 
 class Smite extends Spell {
     public type: string;
@@ -30,7 +31,7 @@ class Smite extends Spell {
         this.scene.events[state]("pointerdown:player", this.clearSpell, this);
     }
 
-    effect(target: any): void {
+    effect(target: Enemy): void {
         // Returns crit boolean and modified value using spell base value.
         const value = this.setValue({ base: 30, key: "magic_power" });
         const heal = this.setValue({ base: 15, key: "magic_power" });

--- a/src/entities/Spells/SnareTrap.ts
+++ b/src/entities/Spells/SnareTrap.ts
@@ -1,6 +1,7 @@
 import Spell from "./Spell";
 import Trap from "../Weapons/Trap";
-import type { SpellOptions } from "@/types/game";
+import type { SpellOptions, TargetType } from "@/types/game";
+import type Enemy from "@entities/Enemy/Enemy";
 
 class SnareTrap extends Spell {
     public type: string;
@@ -42,7 +43,7 @@ class SnareTrap extends Spell {
         this.scene.events[state]("pointerdown:player", this.clearSpell, this);
     }
 
-    triggerTrap(target: any): void {
+    triggerTrap(target: Enemy): void {
         target.body.setMaxVelocity(0);
         target.monster.anims.pause();
         target.body.checkCollision.none = true;
@@ -67,10 +68,15 @@ class SnareTrap extends Spell {
         this.item.once("trap:collide", this.effect, this);
     }
 
-    effect(target: any): void {
+    // Invoked from two emitters: `pointerdown:game` passes the scene (no body, so
+    // a trap is laid) and `trap:collide` passes the colliding Enemy (triggered).
+    // Kept base-compatible (`TargetType`); the body check distinguishes them.
+    effect(target?: TargetType): void {
         // Only trigger if the target have a body.
         // Game scene does not so lay the trap rather then trigger the trap.
-        target.body ? this.triggerTrap(target) : this.layTrap();
+        target && "body" in target && target.body
+            ? this.triggerTrap(target as Enemy)
+            : this.layTrap();
         this.clearSpell();
     }
 }

--- a/src/entities/Spells/Spell.ts
+++ b/src/entities/Spells/Spell.ts
@@ -1,6 +1,6 @@
 import { GameObjects, Display, Scenes } from "phaser";
 import store from "@store";
-import type { SpellOptions, TargetType } from "@/types/game";
+import type { SpellOptions, TargetType, PlayerStats } from "@/types/game";
 import type Player from "@entities/Player/Player";
 import type { GameSceneLike } from "@/types/scene";
 
@@ -10,7 +10,10 @@ interface SpellValue {
 }
 
 class Spell extends GameObjects.Sprite {
-    public player: any; // Player or Enemy with resource property
+    // The owning combatant. Every ability in the game is created by the Player
+    // (see Player's `abilities.map(...)`), and the spell reads Player-only members
+    // (resource/shield/isCritical/clearLastPrimedSpell), so the seam is a Player.
+    public player: Player;
     public cost: { [key: string]: number };
     public typedCost: number;
     public hasAnimation: boolean;
@@ -27,7 +30,9 @@ class Spell extends GameObjects.Sprite {
     public text: GameObjects.Text;
     public cooldownTimer: Phaser.Tweens.Tween;
     public target: TargetType | undefined;
-    public animation: any;
+    // Holds whatever the (subclass-overridable) startAnimation() returns. The
+    // base returns void and the value is never read back, so it stays untyped.
+    public animation: unknown;
 
     constructor({ scene, x, y, key, ...config }: SpellOptions) {
         super(scene, x, y, key);
@@ -266,7 +271,9 @@ class Spell extends GameObjects.Sprite {
         key: string;
         reducer?: (v: number) => number;
     }): SpellValue {
-        const power = (store.getState().game.stats as any)[key] || 0;
+        const stats: PlayerStats = store.getState().game.stats;
+        const statValue = stats[key];
+        const power = typeof statValue === "number" ? statValue : 0;
         // Value based on base + scaled percentage of base from power + flat percent of power
         const scaled = base + base * (power / 100) + power / 10;
         // Check for crit

--- a/src/entities/Spells/Whirlwind.ts
+++ b/src/entities/Spells/Whirlwind.ts
@@ -1,6 +1,7 @@
 import Spell from "./Spell";
 import targetVector from "@helpers/targetVector";
-import type { SpellOptions, EnemyOptions } from "@/types/game";
+import type { SpellOptions } from "@/types/game";
+import type Enemy from "@entities/Enemy/Enemy";
 import type { GameSceneLike } from "@/types/scene";
 class Whirlwind extends Spell {
     public type: string;
@@ -36,16 +37,16 @@ class Whirlwind extends Spell {
         if (state === "on") this.castSpell(this.player);
     }
 
-    effect(target: any): void {
+    effect(target: Enemy): void {
         const enemiesInRange = (
-            (this.scene as GameSceneLike).enemies.children.entries as unknown as EnemyOptions[]
+            (this.scene as GameSceneLike).enemies.children.entries as unknown as Enemy[]
         )
-            .filter((enemy: EnemyOptions) => {
-                enemy.vector = targetVector(this.player as any, enemy as any);
+            .filter((enemy: Enemy) => {
+                enemy.vector = targetVector(this.player, enemy);
                 if (enemy?.vector?.range && enemy.vector.range < this.range) return enemy;
                 return null;
             })
-            .sort(function (a: EnemyOptions, b: EnemyOptions) {
+            .sort(function (a: Enemy, b: Enemy) {
                 return (a.vector?.range ?? 0) - (b.vector?.range ?? 0);
             });
 
@@ -55,14 +56,14 @@ class Whirlwind extends Spell {
         // Scales value bases on player stat.
         const value = this.setValue({ base: 30, key: "attack_power" });
 
-        enemiesInRange.forEach((target: any) => {
+        enemiesInRange.forEach((target: Enemy) => {
             if (target && target.health) {
                 target.health.adjustValue(-value.amount * mod, this.type, value.crit);
             }
         });
     }
 
-    powerCap(enemies: EnemyOptions[]): number {
+    powerCap(enemies: Enemy[]): number {
         const split = enemies.length < this.cap ? this.cap : enemies.length;
         const spread = this.cap / split;
         return spread;

--- a/src/entities/Weapons/AreaEffect.ts
+++ b/src/entities/Weapons/AreaEffect.ts
@@ -1,5 +1,12 @@
 import { GameObjects, Physics, Scene } from "phaser";
+import type Enemy from "@entities/Enemy/Enemy";
+import type Player from "@entities/Player/Player";
+import type { ArcadeCollisionObject } from "@/types/game";
 import type { GameSceneLike } from "@/types/scene";
+
+// The objects this area effect overlaps with: the player and active enemies.
+// Both carry a custom `uuid`; `name` is the Phaser GameObject name.
+type OverlapTarget = Player | Enemy;
 
 class AreaEffect extends GameObjects.Sprite {
     public body: Physics.Arcade.Body;
@@ -45,10 +52,10 @@ class AreaEffect extends GameObjects.Sprite {
         );
     }
 
-    // `target` is the Arcade overlap callback arg (a colliding GameObject with
-    // custom `name`/`uuid`); kept as `any` to match the established collider-
-    // callback house style. Typed uniformly in the #308 "eliminate any" pass.
-    overlap(target: any): void {
+    // Arcade overlap callback. The bodies registered above are the player and
+    // active enemies, so the colliding object is a Player or Enemy.
+    overlap(object: ArcadeCollisionObject): void {
+        const target = object as OverlapTarget;
         const type = target.name === "player" ? "player" : "enemy";
         // Non-null assertion preserves the JS behavior: timestamps is only
         // deleted immediately before destroy(), after which overlap() (a
@@ -57,9 +64,9 @@ class AreaEffect extends GameObjects.Sprite {
         this.emit(`${type}:area:overlap`, target);
     }
 
-    // `target`: Arcade overlap process-callback arg; `any` per the collider-
-    // callback house style, typed uniformly in the #308 "eliminate any" pass.
-    throttle(target: any): boolean {
+    // Arcade overlap process-callback. Same Player|Enemy target as overlap().
+    throttle(object: ArcadeCollisionObject): boolean {
+        const target = object as OverlapTarget;
         return this.timestamps![target.uuid]
             ? this.scene.game.getTime() - this.timestamps![target.uuid] > 1000
             : !this.timestamps![target.uuid];

--- a/src/entities/Weapons/Trap.ts
+++ b/src/entities/Weapons/Trap.ts
@@ -1,5 +1,6 @@
 import { GameObjects, Physics, Scene, Time, Types } from "phaser";
 import { dropIn } from "@helpers/spawnStyle";
+import type { ArcadeCollisionObject } from "@/types/game";
 import type { GameSceneLike } from "@/types/scene";
 
 class Trap extends GameObjects.Sprite {
@@ -36,11 +37,13 @@ class Trap extends GameObjects.Sprite {
         this.once(GameObjects.Events.DESTROY, this.cleanup, this);
     }
 
-    // `target` is the Arcade collide callback arg (a colliding GameObject with
-    // a custom `spawned` flag); kept as `any` to match the established collider-
-    // callback house style. Typed uniformly in the #308 "eliminate any" pass.
-    collide(target: any): void {
-        if (target.spawned) {
+    // Arcade collide callback. Phaser types each colliding object as
+    // `GameObjectWithBody | Tile`. The original JS reads a `spawned` flag off the
+    // target before emitting; preserved exactly (no shipped colliding object
+    // actually sets `spawned`, so this guard is effectively always falsy — a
+    // pre-existing quirk left untouched per the "preserve & flag" rule).
+    collide(target: ArcadeCollisionObject): void {
+        if ((target as { spawned?: boolean }).spawned) {
             this.emit("trap:collide", target);
             this.destroy();
         }

--- a/src/scenes/TownScene.ts
+++ b/src/scenes/TownScene.ts
@@ -1,5 +1,6 @@
-import { Scene, GameObjects, Input, Tilemaps } from "phaser";
+import { Scene, GameObjects, Input, Tilemaps, Types } from "phaser";
 import AssignClass from "@entities/Player/AssignClass";
+import type { ArcadeCollisionObject } from "@/types/game";
 import store from "@store";
 import { toggleHUD, setCurrentArea, setPlayerPosition } from "@store/gameReducer";
 import type { PlayerType } from "@entities/Player/AssignClass";
@@ -356,11 +357,13 @@ export default class TownScene extends Scene {
         }
 
         // Create collision bodies from object layer (scaled 2x to match map)
-        collisionLayer.objects.forEach((obj: any, index: number) => {
-            const scaledX = obj.x * 2;
-            const scaledY = obj.y * 2;
-            const scaledWidth = obj.width * 2;
-            const scaledHeight = obj.height * 2;
+        collisionLayer.objects.forEach((obj: Types.Tilemaps.TiledObject, index: number) => {
+            // Tiled rect/ellipse objects always carry x/y/width/height; the
+            // non-null assertions preserve the original arithmetic exactly.
+            const scaledX = obj.x! * 2;
+            const scaledY = obj.y! * 2;
+            const scaledWidth = obj.width! * 2;
+            const scaledHeight = obj.height! * 2;
 
             let collisionBody: GameObjects.GameObject;
 
@@ -420,10 +423,10 @@ export default class TownScene extends Scene {
 
         this.interactionZones = this.add.group();
 
-        poiLayer.objects.forEach((poi: any) => {
+        poiLayer.objects.forEach((poi: Types.Tilemaps.TiledObject) => {
             // Create interaction zone around each POI (scaled 2x to match map)
-            const scaledX = poi.x * 2;
-            const scaledY = poi.y * 2;
+            const scaledX = poi.x! * 2;
+            const scaledY = poi.y! * 2;
             const zone = this.add.zone(scaledX, scaledY, 32, 32); // 64x64 pixel interaction area (2x scaled)
             this.physics.world.enable(zone);
 
@@ -476,7 +479,7 @@ export default class TownScene extends Scene {
         // UI elements will be added later
     }
 
-    private handleZoneOverlap(player: any, zone: GameObjects.Zone): void {
+    private handleZoneOverlap(player: ArcadeCollisionObject, zone: GameObjects.Zone): void {
         const zoneType = zone.getData("type");
         const zoneName = zone.getData("name");
         this.handleInteraction(zoneType, zoneName);

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,7 +1,16 @@
-import type { Scene, GameObjects, Math as PhaserMath } from "phaser";
+import type { Scene, GameObjects, Math as PhaserMath, Types, Physics, Tilemaps } from "phaser";
 import type Player from "@entities/Player/Player";
 import type Enemy from "@entities/Enemy/Enemy";
 import type { SpellType } from "@entities/Spells/AssignSpell";
+
+// The object Arcade physics passes to collide/overlap callbacks. Mirrors the
+// union in `Phaser.Types.Physics.Arcade.ArcadePhysicsCallback`; callbacks accept
+// this (so they satisfy the callback signature) then narrow to the real entity.
+export type ArcadeCollisionObject =
+    | Types.Physics.Arcade.GameObjectWithBody
+    | Physics.Arcade.Body
+    | Physics.Arcade.StaticBody
+    | Tilemaps.Tile;
 
 // Constants
 export const EQUIPMENT_SLOTS = {
@@ -292,7 +301,9 @@ export interface SpellOptions {
     x: number;
     y: number;
     key: string;
-    player: Player | Enemy;
+    // Every spell is created by the Player (see Player's ability map). The spell
+    // reads Player-only members, so the owner is modelled as a Player.
+    player: Player;
     cost?: { [key: string]: number };
     cooldown?: number;
     name?: string;

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -16,14 +16,24 @@ import type { RootState } from "@store";
 
 export const MenuContext = createContext<string>("character");
 
+// The menu registry stores components with differing prop contracts and renders
+// the active one by spreading its (optional) `props`. A common prop-erased
+// component type lets the heterogeneous components share one registry entry.
+type MenuComponent = React.ComponentType<Record<string, unknown>>;
+
 interface MenuConfig {
-    component: React.ComponentType<any>;
+    component: MenuComponent;
     title: string;
     navigation?: boolean;
     props?: Record<string, unknown>;
     close?: boolean;
     type?: string;
 }
+
+// The concrete components declare their own prop shapes; the registry treats
+// them uniformly, so each is widened to the shared MenuComponent type.
+const asMenuComponent = <P,>(component: React.ComponentType<P>): MenuComponent =>
+    component as unknown as MenuComponent;
 
 const UI: React.FC = () => {
     const dispatch = useDispatch();
@@ -37,41 +47,41 @@ const UI: React.FC = () => {
 
     const config: Record<string, MenuConfig> = {
         arcanum: {
-            component: Arcanum,
+            component: asMenuComponent(Arcanum),
             title: "Arcanum",
             navigation: true,
         },
         armory: {
-            component: Armory,
+            component: asMenuComponent(Armory),
             title: "Armory",
             navigation: true,
         },
         character: {
-            component: Character,
+            component: asMenuComponent(Character),
             title: "Character",
             navigation: true,
         },
         equipment: {
-            component: Equipment,
+            component: asMenuComponent(Equipment),
             title: "Equipment",
             navigation: true,
         },
         load: {
-            component: Save,
+            component: asMenuComponent(Save),
             title: "Load Game",
             props: { load: true },
             close: true,
         },
         save: {
-            component: Save,
+            component: asMenuComponent(Save),
             title: "Pick a Game Save",
         },
         select: {
-            component: CharacterSelect,
+            component: asMenuComponent(CharacterSelect),
             title: "Character Select",
         },
         system: {
-            component: System,
+            component: asMenuComponent(System),
             title: "System",
             close: true,
         },

--- a/src/ui/components/atoms/DroppableSlot.tsx
+++ b/src/ui/components/atoms/DroppableSlot.tsx
@@ -29,7 +29,9 @@ const DroppableSlot: React.FC<DroppableSlotProps> = ({ loot, slot, unequipLoot }
 
     return (
         <div
-            ref={drop as any}
+            ref={(node) => {
+                drop(node);
+            }}
             className={"droppable-slot"}
             onClick={() => loot && unequipLoot(loot)}
         >

--- a/src/ui/components/molecules/CharacterCard.tsx
+++ b/src/ui/components/molecules/CharacterCard.tsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { selectCharacter } from "@store/gameReducer";
 import { connect } from "react-redux";
+import type { PlayerName } from "@entities/Player/AssignClass";
 
 import Button from "../atoms/Button";
 
 interface CharacterCardProps {
-    selectCharacter: any;
-    type: string;
+    // Injected by `connect`'s mapDispatchToProps; dispatches the selectCharacter action.
+    selectCharacter: (character: PlayerName) => void;
+    type: PlayerName;
 }
 
 const CharacterCard: React.FC<CharacterCardProps> = ({ selectCharacter, type }) => {

--- a/src/ui/components/molecules/LootListDrag.tsx
+++ b/src/ui/components/molecules/LootListDrag.tsx
@@ -64,7 +64,12 @@ const LootListDrag: React.FC<LootListDragProps> = ({ cols = 6, list, name }) => 
         });
 
         return (
-            <div ref={drag as any} className={isDragging ? "dragging" : ""}>
+            <div
+                ref={(node) => {
+                    drag(node);
+                }}
+                className={isDragging ? "dragging" : ""}
+            >
                 <Loot
                     loot={props.loot}
                     isSelected={props.isSelected}
@@ -86,7 +91,12 @@ const LootListDrag: React.FC<LootListDragProps> = ({ cols = 6, list, name }) => 
     });
 
     return (
-        <div ref={drop as any} className="loot-grid">
+        <div
+            ref={(node) => {
+                drop(node);
+            }}
+            className="loot-grid"
+        >
             {list &&
                 list.map((loot, i) => {
                     // Check for matching selected uuid

--- a/src/ui/components/organisms/GroupedAttributes.tsx
+++ b/src/ui/components/organisms/GroupedAttributes.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import Attributes from "@components/Attributes";
 import pick from "lodash/pick";
+import type { PlayerStats } from "@/types/game";
 
 interface GroupedAttributesProps {
-    stats: Record<string, number>;
+    stats: PlayerStats;
 }
+
+// The picked groups only ever hold the numeric stat values shown below; the
+// assertion narrows the PlayerStats index signature (number | string | undefined)
+// to the Record<string, number> that Attributes consumes, without altering any
+// runtime values.
+type NumericStats = Record<string, number>;
 
 const GroupedAttributes: React.FC<GroupedAttributesProps> = ({ stats }) => {
     const offence_stats = pick(stats, [
@@ -12,14 +19,17 @@ const GroupedAttributes: React.FC<GroupedAttributesProps> = ({ stats }) => {
         "magic_power",
         "attack_speed",
         "critical_chance",
-    ]);
+    ]) as NumericStats;
     const defence_stats = pick(stats, [
         "health_regen_rate",
         "health_regen_value",
         "defence",
         "speed",
-    ]);
-    const support_stats = pick(stats, ["resource_regen_rate", "resource_regen_value"]);
+    ]) as NumericStats;
+    const support_stats = pick(stats, [
+        "resource_regen_rate",
+        "resource_regen_value",
+    ]) as NumericStats;
 
     return (
         <>

--- a/src/ui/components/templates/Character.tsx
+++ b/src/ui/components/templates/Character.tsx
@@ -38,7 +38,7 @@ const Character: React.FC = () => {
                         value={stats.resource_max || 0}
                     />
                 </div>
-                <GroupedAttributes stats={stats as any} />
+                <GroupedAttributes stats={stats} />
             </section>
             <section className="equipment-display">
                 <Slot

--- a/src/ui/components/templates/Equipment.tsx
+++ b/src/ui/components/templates/Equipment.tsx
@@ -35,7 +35,7 @@ const Equipment: React.FC = () => {
                         value={stats.resource_max || 0}
                     />
                 </div>
-                <GroupedAttributes stats={stats as any} />
+                <GroupedAttributes stats={stats} />
             </section>
             <section className="equipment-section">
                 <DroppableSlot slot="helm" loot={helm} />

--- a/src/ui/components/templates/Save.tsx
+++ b/src/ui/components/templates/Save.tsx
@@ -74,7 +74,7 @@ const Save: React.FC<SaveProps> = ({ load = false }) => {
                                     <Button
                                         text={"Load"}
                                         onClick={() => {
-                                            dispatch(loadGame(save.game as any));
+                                            dispatch(loadGame(save.game));
                                             if (character) dispatch(selectCharacter(character));
                                         }}
                                     />

--- a/src/ui/operations/helpers.ts
+++ b/src/ui/operations/helpers.ts
@@ -21,19 +21,31 @@ export const statsArrayToObject = (stats: StatItem[]): StatObject =>
         return acc;
     }, {} as StatObject);
 
+// Objects are sorted by a single (string- or number-valued) property; the
+// comparison mirrors the original JS `>`/`<` semantics. The generic is left
+// unconstrained (callers pass GraphQL items whose runtime sort keys are not on
+// their declared type), reading the keyed value through a string-index view.
+type Comparable = number | string;
+
+const readKey = (obj: unknown, key: string): Comparable => (obj as Record<string, Comparable>)[key];
+
 export const sortAscending =
     (key: string) =>
-    <T extends Record<string, any>>(a: T, b: T): number => {
-        if (a[key] > b[key]) return 1;
-        if (a[key] < b[key]) return -1;
+    <T>(a: T, b: T): number => {
+        const av = readKey(a, key);
+        const bv = readKey(b, key);
+        if (av > bv) return 1;
+        if (av < bv) return -1;
         return 0;
     };
 
 export const sortDescending =
     (key: string) =>
-    <T extends Record<string, any>>(a: T, b: T): number => {
-        if (a[key] < b[key]) return 1;
-        if (a[key] > b[key]) return -1;
+    <T>(a: T, b: T): number => {
+        const av = readKey(a, key);
+        const bv = readKey(b, key);
+        if (av < bv) return 1;
+        if (av > bv) return -1;
         return 0;
     };
 
@@ -42,10 +54,7 @@ interface SortOptions {
     order?: "asc" | "desc";
 }
 
-export const sortBy = <T extends Record<string, any>>(
-    array: T[],
-    { key, order = "asc" }: SortOptions
-): T[] => {
+export const sortBy = <T>(array: T[], { key, order = "asc" }: SortOptions): T[] => {
     return order === "asc"
         ? array.slice().sort(sortAscending(key))
         : array.slice().sort(sortDescending(key));


### PR DESCRIPTION
## Summary

Removes every explicit `any` from `src/` and enables `@typescript-eslint/no-explicit-any` as an **error** so it can't return. Part of #308 — this **completes the `any ≤ 5` half of the #308 gate**.

**Residual `any` count in `src/`: 0** (no documented exceptions needed). The only remaining word-boundary `any` matches are English prose inside comments; `eslint` reports `0` `no-explicit-any` violations.

## How each category was typed

**Spell owner (`Spell.ts#player`)**
- `Spell#player` is now `Player` (every ability is created by the Player and reads Player-only members: `resource`/`shield`/`isCritical`/`clearLastPrimedSpell`). `SpellOptions.player` narrowed from `Player | Enemy` to `Player`, and `Player` gains the dynamic `clearLastPrimedSpell: () => void` property it was already assigned at runtime.
- `Spell#animation` → `unknown` (write-only). `setValue` reads `store.getState().game.stats` through the existing `PlayerStats` index signature instead of `(… as any)[key]`.

**Collision/overlap callback targets**
- Added a shared `ArcadeCollisionObject` alias in `types/game.ts` mirroring `Phaser.Types.Physics.Arcade.ArcadePhysicsCallback`'s object union. `Trap.collide`, `AreaEffect.overlap`/`throttle`, and `EarthShield.touch` take it (so they satisfy the callback signature when passed as arguments — method bivariance doesn't apply there) then narrow to the concrete entity.
- Spell `effect`/`overTimeEffect`/`triggerTrap` targets typed to `Enemy` or `Player` per the emitter that drives them. `SnareTrap.effect` keeps the base-compatible `TargetType` signature and distinguishes the scene-vs-enemy case via the existing `"body" in target` check.
- `Whirlwind`/`Multishot` range scans typed to `Enemy[]`; `Enemy` gains the transient `vector?: EntityWithVector` field these two spells cache (replacing the `as any` casts around `targetVector`).

**Status-effect value maps**
- Narrowing `player`/targets exposed that `Enrage`/`Invocation`/`PowerInfusion`/`Frostbolt` value interfaces didn't satisfy `StatusEffect.value: Record<string, EffectValue>`. Added an `[key: string]: EffectValue` index signature to each (every member is already an `EffectValue`).

**TownScene handlers**
- `obj`/`poi` typed to `Types.Tilemaps.TiledObject` (non-null assertions preserve the exact `x * 2` arithmetic); `handleZoneOverlap` first arg typed to `ArcadeCollisionObject`.

**UI / react-dnd**
- `LootListDrag` and `DroppableSlot` drag/drop connectors use typed callback refs (`ref={(node) => { drag(node); }}`) instead of `ref={… as any}`.
- `CharacterCard`: `selectCharacter`/`type` typed via `PlayerName`.
- `GroupedAttributes` accepts `PlayerStats` and narrows the picked groups to `Record<string, number>` (a typed assertion, not `any`), removing the `as any` at both call sites; `Save` drops `as any` on `loadGame(save.game)` (already `GameState`).
- `UI.tsx` menu registry uses a prop-erased `MenuComponent` type + an `asMenuComponent` widening helper for the heterogeneous menu components.
- `ui/operations/helpers.ts` sort helpers (surfaced by the new rule) use an unconstrained generic with a typed `readKey` view instead of `Record<string, any>`.

## ESLint change
- Registered the `@typescript-eslint` plugin in `eslint.config.mjs` and enabled `@typescript-eslint/no-explicit-any: "error"` for `**/*.ts` / `**/*.tsx` (covers `src/` and tests).
- **No dependency added** — `@typescript-eslint/eslint-plugin` + parser already ship transitively with `eslint-config-next` and resolve cleanly.

## Behavior preservation
- Pure type-level changes; no runtime/gameplay logic altered. Non-null assertions and `?? 0` guards are used where a value is always present at runtime so arithmetic is byte-identical.
- Flagged (not fixed) the pre-existing quirk in `Trap.collide`: it reads a `spawned` flag that no shipped colliding object actually sets (so the guard is effectively always falsy). Preserved exactly, with a comment.

## Test evidence (all five gates pass locally)
- `npm run typecheck` — pass (0 errors)
- `npm run lint` — pass (✔ No ESLint warnings or errors, with the new rule active)
- `npm test` — pass (11 files, 52 tests)
- `npm run format:check` — pass (all files match Prettier)
- `npm run build` — pass (static export succeeds; the Apollo SSR warnings are pre-existing static-export noise)

Residual-`any` confirmation: `eslint "src/**/*.{ts,tsx}"` reports `0` `no-explicit-any` errors; the only `\bany\b` matches in `src/` are prose in comments.

Part of #308.

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_