### PR TITLE
Phase 3: enable strictPropertyInitialization; evaluate noUncheckedIndexedAccess

### DIFF
--- a/src/entities/Enemy/Enemy.ts
+++ b/src/entities/Enemy/Enemy.ts
@@ -67,16 +67,16 @@ class Enemy extends GameObjects.Container {
     public health: AssignResourceType;
     public banes: Banes;
     public spawn_stop: Physics.Arcade.Image;
-    public point: PhaserMath.Vector2;
-    public distance_to_player: number;
-    public destination: PhaserMath.Vector2 | null;
-    public caution: number;
-    public circling: Phaser.Tweens.Tween | null;
+    public point!: PhaserMath.Vector2;
+    public distance_to_player!: number;
+    public destination!: PhaserMath.Vector2 | null;
+    public caution!: number;
+    public circling!: Phaser.Tweens.Tween | null;
     public wandering_looped_timer: Phaser.Time.TimerEvent | null = null;
-    public selected: boolean;
+    public selected!: boolean;
     public swing: Phaser.Time.TimerEvent | null = null;
-    public collider: Physics.Arcade.Collider;
-    public body: Physics.Arcade.Body;
+    public collider!: Physics.Arcade.Collider;
+    public body!: Physics.Arcade.Body;
     // Transient targeting vector cached by the Whirlwind/Multishot range scans.
     public vector?: EntityWithVector;
 

--- a/src/entities/Enemy/Monster.ts
+++ b/src/entities/Enemy/Monster.ts
@@ -11,7 +11,7 @@ interface MonsterConfig {
 
 class Monster extends GameObjects.Sprite {
     public key: string;
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
 
     constructor(config: MonsterConfig) {
         super(config.scene, 0, 0, config.key);

--- a/src/entities/Loot/Coin.ts
+++ b/src/entities/Loot/Coin.ts
@@ -11,7 +11,7 @@ interface CoinConfig {
 }
 
 class Coin extends GameObjects.Sprite {
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
 
     constructor(config: CoinConfig) {
         super(config.scene, config.x, config.y, "coin-spin");

--- a/src/entities/Loot/Crafting.ts
+++ b/src/entities/Loot/Crafting.ts
@@ -13,7 +13,7 @@ interface CraftingConfig {
 
 class Crafting extends GameObjects.Sprite {
     public name: string;
-    public body: Phaser.Physics.Arcade.Body;
+    public body!: Phaser.Physics.Arcade.Body;
 
     constructor(config: CraftingConfig) {
         super(config.scene, config.x, config.y, "crafting", config.key);

--- a/src/entities/Loot/Gem.ts
+++ b/src/entities/Loot/Gem.ts
@@ -12,7 +12,7 @@ interface GemConfig {
 }
 
 class Gem extends GameObjects.Sprite {
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
     public activateTimer?: Time.TimerEvent;
     public collider?: Physics.Arcade.Collider;
 

--- a/src/entities/Loot/Item.ts
+++ b/src/entities/Loot/Item.ts
@@ -34,9 +34,9 @@ interface StatIterator {
 }
 
 class Item {
-    public base: number;
-    public multiplier: number;
-    public keys: { min: number; max: number };
+    public base!: number;
+    public multiplier!: number;
+    public keys!: { min: number; max: number };
     public stat_pool: number;
     public stats: { [key: string]: AdjustedStat };
     public info: Record<string, unknown>;

--- a/src/entities/Player/Hero.ts
+++ b/src/entities/Player/Hero.ts
@@ -6,7 +6,7 @@ interface HeroConfig {
 }
 
 class Hero extends GameObjects.Sprite {
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
 
     constructor(config: HeroConfig) {
         super(config.scene, 0, 0, config.key);

--- a/src/entities/Player/Player.ts
+++ b/src/entities/Player/Player.ts
@@ -46,17 +46,17 @@ class Player extends GameObjects.Container {
     public resource: AssignResourceType;
     public shield: AssignResourceType;
     public weapon: Weapon;
-    public stats: PlayerStats;
+    public stats!: PlayerStats;
     public spells: AssignSpell[];
-    public mouse: Phaser.Input.Pointer;
-    public point: PhaserMath.Vector2;
-    public spellPrimed: boolean;
-    public dragging: boolean;
-    public attack_delay: Phaser.Time.TimerEvent | null;
+    public mouse!: Phaser.Input.Pointer;
+    public point!: PhaserMath.Vector2;
+    public spellPrimed!: boolean;
+    public dragging!: boolean;
+    public attack_delay!: Phaser.Time.TimerEvent | null;
     public swing: Phaser.Time.TimerEvent | null = null;
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
     // Set/reset by each Spell to clear the previously primed spell (see Spell).
-    public clearLastPrimedSpell: () => void;
+    public clearLastPrimedSpell!: () => void;
 
     constructor({
         scene,

--- a/src/entities/Spells/Consecration.ts
+++ b/src/entities/Spells/Consecration.ts
@@ -8,7 +8,7 @@ class Consecration extends Spell {
     public range: number;
     public cap: number;
     public lifespan: number;
-    public item: AreaEffect;
+    public item!: AreaEffect;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/EarthShield.ts
+++ b/src/entities/Spells/EarthShield.ts
@@ -14,8 +14,8 @@ class EarthShield extends Spell {
     public radius: number;
     public lifespanTimer: Phaser.Time.TimerEvent | null = null;
     public motion: Phaser.Tweens.Tween | null = null;
-    public throttleDelay: Phaser.Time.TimerEvent;
-    public body: Phaser.Physics.Arcade.Body;
+    public throttleDelay!: Phaser.Time.TimerEvent;
+    public body!: Phaser.Physics.Arcade.Body;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/Enrage.ts
+++ b/src/entities/Spells/Enrage.ts
@@ -16,7 +16,7 @@ class Enrage extends Boon {
     public type: string;
     public duration: number;
     public value: EnrageValue;
-    public timer: Phaser.Time.TimerEvent;
+    public timer!: Phaser.Time.TimerEvent;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/Faith.ts
+++ b/src/entities/Spells/Faith.ts
@@ -6,7 +6,7 @@ class Faith extends Spell {
     public frequency: number;
     public duration: number;
     public type: string;
-    public timer: Phaser.Time.TimerEvent;
+    public timer!: Phaser.Time.TimerEvent;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/Frostbolt.ts
+++ b/src/entities/Spells/Frostbolt.ts
@@ -14,7 +14,7 @@ class Frostbolt extends Spell {
     public type: string;
     public duration: number;
     public value: FrostboltValue;
-    public timer: Phaser.Time.TimerEvent;
+    public timer!: Phaser.Time.TimerEvent;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/Invocation.ts
+++ b/src/entities/Spells/Invocation.ts
@@ -11,10 +11,10 @@ interface InvocationValue {
 }
 
 class Invocation extends Boon {
-    public type: string;
-    public duration: number;
-    public value: InvocationValue;
-    public timer: Phaser.Time.TimerEvent;
+    public type!: string;
+    public duration!: number;
+    public value!: InvocationValue;
+    public timer!: Phaser.Time.TimerEvent;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/PowerInfusion.ts
+++ b/src/entities/Spells/PowerInfusion.ts
@@ -18,7 +18,7 @@ class PowerInfusion extends Boon {
     public type: string;
     public duration: number;
     public value: PowerInfusionValue;
-    public timer: Phaser.Time.TimerEvent;
+    public timer!: Phaser.Time.TimerEvent;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/SiphonSoul.ts
+++ b/src/entities/Spells/SiphonSoul.ts
@@ -3,15 +3,15 @@ import type { SpellOptions } from "@/types/game";
 import type Enemy from "@entities/Enemy/Enemy";
 
 class SiphonSoul extends Spell {
-    public type: string;
-    public duration: number;
+    public type!: string;
+    public duration!: number;
     public particleDuration: number;
     public power: number;
     public emitter: Phaser.GameObjects.Particles.ParticleEmitter | undefined;
     public gravityWell: Phaser.GameObjects.Particles.GravityWell | undefined;
-    public durationAnimationTimer: Phaser.Time.TimerEvent;
-    public particleAnimationTimer: Phaser.Time.TimerEvent;
-    public debugGraphics: Phaser.GameObjects.Graphics;
+    public durationAnimationTimer!: Phaser.Time.TimerEvent;
+    public particleAnimationTimer!: Phaser.Time.TimerEvent;
+    public debugGraphics!: Phaser.GameObjects.Graphics;
     public deathZone: Phaser.Geom.Circle;
 
     constructor(config: SpellOptions) {

--- a/src/entities/Spells/SnareTrap.ts
+++ b/src/entities/Spells/SnareTrap.ts
@@ -7,7 +7,7 @@ class SnareTrap extends Spell {
     public type: string;
     public duration: number;
     public lifespan: number;
-    public item: Trap;
+    public item!: Trap;
 
     constructor(config: SpellOptions) {
         const defaults = {

--- a/src/entities/Spells/Spell.ts
+++ b/src/entities/Spells/Spell.ts
@@ -13,22 +13,22 @@ class Spell extends GameObjects.Sprite {
     // The owning combatant. Every ability in the game is created by the Player
     // (see Player's `abilities.map(...)`), and the spell reads Player-only members
     // (resource/shield/isCritical/clearLastPrimedSpell), so the seam is a Player.
-    public player: Player;
-    public cost: { [key: string]: number };
+    public player!: Player;
+    public cost!: { [key: string]: number };
     public typedCost: number;
     public hasAnimation: boolean;
     public enabled: boolean;
-    public cooldown: number;
-    public name: string;
-    public icon_name: string;
-    public hotkey: string;
-    public slot: number;
-    public loop: boolean;
-    public cooldownDelay: boolean;
-    public cooldownDelayAll: boolean;
-    public button: GameObjects.Sprite;
-    public text: GameObjects.Text;
-    public cooldownTimer: Phaser.Tweens.Tween;
+    public cooldown!: number;
+    public name!: string;
+    public icon_name!: string;
+    public hotkey!: string;
+    public slot!: number;
+    public loop!: boolean;
+    public cooldownDelay!: boolean;
+    public cooldownDelayAll!: boolean;
+    public button!: GameObjects.Sprite;
+    public text!: GameObjects.Text;
+    public cooldownTimer!: Phaser.Tweens.Tween;
     public target: TargetType | undefined;
     // Holds whatever the (subclass-overridable) startAnimation() returns. The
     // base returns void and the value is never read back, so it stays untyped.

--- a/src/entities/UI/CombatText.ts
+++ b/src/entities/UI/CombatText.ts
@@ -16,7 +16,7 @@ interface CombatTextConfig {
 }
 
 class CombatText extends GameObjects.Text {
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
 
     constructor(
         scene: Scene,

--- a/src/entities/Weapons/AreaEffect.ts
+++ b/src/entities/Weapons/AreaEffect.ts
@@ -9,7 +9,7 @@ import type { GameSceneLike } from "@/types/scene";
 type OverlapTarget = Player | Enemy;
 
 class AreaEffect extends GameObjects.Sprite {
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
     public timestamps?: Record<string, number>;
 
     constructor(scene: Scene, x: number, y: number, lifespan: number, range: number) {

--- a/src/entities/Weapons/Trap.ts
+++ b/src/entities/Weapons/Trap.ts
@@ -4,7 +4,7 @@ import type { ArcadeCollisionObject } from "@/types/game";
 import type { GameSceneLike } from "@/types/scene";
 
 class Trap extends GameObjects.Sprite {
-    public body: Physics.Arcade.Body;
+    public body!: Physics.Arcade.Body;
     public spawned?: boolean;
     public lifespanTimer?: Time.TimerEvent;
     public enemyCollider?: Physics.Arcade.Collider;

--- a/src/scenes/GameOverScene.ts
+++ b/src/scenes/GameOverScene.ts
@@ -2,10 +2,10 @@ import { Scene, GameObjects, Display } from "phaser";
 import { fontConfig } from "../config/fonts";
 
 export default class GameOverScene extends Scene {
-    private global_game_width: number;
-    private global_game_height: number;
-    private zone: Phaser.GameObjects.Zone;
-    private game_over: Phaser.GameObjects.Container;
+    private global_game_width!: number;
+    private global_game_height!: number;
+    private zone!: Phaser.GameObjects.Zone;
+    private game_over!: Phaser.GameObjects.Container;
 
     constructor() {
         super({

--- a/src/scenes/GameScene.ts
+++ b/src/scenes/GameScene.ts
@@ -38,7 +38,7 @@ export default class GameScene extends Scene {
         TOP: 99999,
     };
     private level_complete!: Phaser.GameObjects.Container & { button?: Phaser.GameObjects.Image };
-    private config: GameSceneConfig;
+    private config!: GameSceneConfig;
     private cursors!: Phaser.Types.Input.Keyboard.CursorKeys & { esc?: Phaser.Input.Keyboard.Key };
     private next_level_timer: Phaser.Time.TimerEvent | undefined;
     private UI!: UI;

--- a/src/scenes/TownScene.ts
+++ b/src/scenes/TownScene.ts
@@ -10,7 +10,7 @@ import UI from "@entities/UI/HUD";
 
 export default class TownScene extends Scene {
     public player!: PlayerType;
-    private config: GameSceneConfig;
+    private config!: GameSceneConfig;
     private cursors!: Phaser.Types.Input.Keyboard.CursorKeys & { esc?: Input.Keyboard.Key };
     private global_game_width!: number;
     private global_game_height!: number;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "isolatedModules": true,
         "jsx": "preserve",
         "incremental": true,
-        "strictPropertyInitialization": false,
+        "strictPropertyInitialization": true,
         "paths": {
             "@store/*": ["./src/store/*"],
             "@store": ["./src/store"],


### PR DESCRIPTION
## What & why

Part of #308 — "Tighten `tsconfig`: enable `strictPropertyInitialization`, evaluate `noUncheckedIndexedAccess`."

### tsconfig change

```diff
-        "strictPropertyInitialization": false,
+        "strictPropertyInitialization": true,
```

The codebase already sets `"strict": true`, but an explicit `"strictPropertyInitialization": false` override was suppressing this one strict check. This flips it on. (`noUncheckedIndexedAccess` is intentionally **not** added — see evaluation below.)

### Field fixes

Enabling the flag surfaced **85 `tsc` errors** across **24 files**:
- 63× `TS2564` (property has no initializer / not definitely assigned in constructor)
- 22× `TS2565` (property used before being assigned)

Fixed by adding a **definite-assignment assertion (`!`) to 63 field declarations** — no direct-initializer fixes were needed, since every flagged field is assigned either in a Phaser `create()`/init helper or via `Object.assign(this, config)` in the constructor (which TS can't see through). This matches the existing house style, where many fields already use `!`. Every TS2565 "used before assigned" error resolved once its declaration gained `!` (all 22 mapped to a declaration already in the TS2564 set).

The diff is exactly **64 insertions / 64 deletions** — each change is a single `!` token, so **no runtime behavior changes** (no initializers, no logic, no reordering).

Files touched (field counts): Spell.ts (13), Enemy.ts (8), Player.ts (8), SiphonSoul.ts (5), Invocation.ts (4), GameOverScene.ts (4), Item.ts (3), EarthShield.ts (2), plus 1 field each in Monster.ts, Coin.ts, Crafting.ts, Gem.ts, Hero.ts, Consecration.ts, Enrage.ts, Faith.ts, Frostbolt.ts, PowerInfusion.ts, SnareTrap.ts, CombatText.ts, AreaEffect.ts, Trap.ts, GameScene.ts, TownScene.ts.

### Latent bug check

None found. The `TS2565` cases that looked suspicious (`Spell.cost`/`Spell.player` read at `Spell.ts:41`, `SiphonSoul.duration` read at `SiphonSoul.ts:38`) are all genuinely assigned before use at runtime via `Object.assign(this, config)` (Spell) or `super({ ...defaults, ...config })` (SiphonSoul); TS simply can't track assignment through `Object.assign`. `!` is the correct, behavior-preserving assertion here.

## noUncheckedIndexedAccess evaluation

Temporarily enabled `"noUncheckedIndexedAccess": true` and ran `npm run typecheck`:

- **29 errors across 16 files.**
- By code: 10× `TS2532` (object possibly undefined), 9× `TS2345` (`number | undefined` arg), 4× `TS18048` (possibly-undefined member), 3× `TS2322`, 2× `TS2722` (invoking possibly-undefined), 1× `TS2769`.
- Main patterns: indexed lookups into config/keymap/menu maps (`keys.esc`, `CurrentMenu`, loot multiplier tables in `Item.ts`/`Coin.ts`/`Crafting.ts`/`Gem.ts`), array element access in resource/shield arithmetic (`Resource.ts`, `Shield.ts`), and `cost[resource.name]` style lookups in `Spell.ts`/`HUD.ts`/`StatusEffects.ts`.

**Decision: defer (leave disabled).** Several of these are not mechanical — they need real runtime decisions (guard vs. fallback default vs. assertion) in loot/resource arithmetic and menu/keymap dispatch. Fixing them correctly without changing behavior would mean either `!`-spam on hot-path indexed access or introducing new guards/fallbacks, which is a behavior-adjacent change that does not belong bundled with a config-tightening PR. Per the issue, this evaluation satisfies the "evaluate" deliverable; the flag can be enabled in a dedicated follow-up that addresses each site deliberately.

## Behavior preservation

- Only `!` tokens added; no initializers, no logic, no control-flow changes.
- No `any` introduced; no `@ts-ignore`/`@ts-expect-error`.

## Test evidence (all five gates pass locally)

- `npm run typecheck` — clean (`tsc --noEmit`)
- `npm run lint` — No ESLint warnings or errors
- `npm test` — 11 files, 52 tests passed
- `npm run format:check` — all files match Prettier style
- `npm run build` — static export succeeded (4/4 pages, exported)

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_