### PR TITLE
Phase 3: check off completed roadmap items

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -55,16 +55,16 @@ Each bullet is one small PR unless trivially related.
 - [x] `PhaserGame.tsx` — remove the `setTimeout(createGame, 100)` boot race (arcade `debug` kept on per maintainer decision)
 - [x] Document the resulting lifecycle conventions in `CLAUDE.md` (every entity cleans up on `SHUTDOWN`)
 
-## Phase 3 — TypeScript completion
+## Phase 3 — TypeScript completion (done)
 
-- [ ] Convert trivial JS loot classes: `Fine.js`, `Rare.js`, `Legendary.js`, `Gem.js`
-- [ ] Convert UI entities: `HUD.js` (after Phase 2 fixes), `CombatText.js`, `StatusEffects.js`, `Banes.js`, `Boons.js`
-- [ ] Convert `Weapons/AreaEffect.js`, `Weapons/Trap.js`, `helpers/spawnStyle.js`
-- [ ] Convert `lib/cache.js` (typed field policies)
-- [ ] Replace scene-augmentation casts (`this.scene as Scene & {...}`) with explicit typed scene interfaces
-- [ ] Eliminate `any` across entities/spells/UI (notably `Spell.ts#player`, `CharacterCard.tsx`, TownScene handlers, react-dnd refs); add `@typescript-eslint` with `no-explicit-any`
-- [ ] Tighten `tsconfig`: enable `strictPropertyInitialization`, evaluate `noUncheckedIndexedAccess`
-- [ ] Gate: 0 JS files in `src/`, `any` count ≤ 5 (documented exceptions only)
+- [x] Convert trivial JS loot classes: `Fine.js`, `Rare.js`, `Legendary.js`, `Gem.js` (#324; re-enabled gem loot)
+- [x] Convert UI entities: `HUD.js`, `CombatText.js`, `StatusEffects.js`, `Banes.js`, `Boons.js` (#327)
+- [x] Convert `Weapons/AreaEffect.js`, `Weapons/Trap.js`, `helpers/spawnStyle.js` (#326)
+- [x] Convert `lib/cache.js` (typed field policies) (#325)
+- [x] Replace scene-augmentation casts with an explicit typed scene interface (`GameSceneLike`, `src/types/scene.ts`) (#330)
+- [x] Eliminate `any` across entities/spells/UI; add `@typescript-eslint` `no-explicit-any` (#331)
+- [x] Tighten `tsconfig`: enable `strictPropertyInitialization` (#332). `noUncheckedIndexedAccess` evaluated and deferred — see backlog (#333)
+- [x] Gate: 0 JS files in `src/`, `any` count = 0 (≤ 5 target met)
 
 ## Phase 4 — Test buildout
 
@@ -117,3 +117,5 @@ Frontend integration:
 - Gateway production hosting decision (Lambda merge, PaaS, or other)
 - AWS CDK migration (replaces Serverless v3; unlocks newest Lambda runtimes)
 - Coverage ratchet toward 80%+ on non-Phaser code
+- Enable `noUncheckedIndexedAccess` (deferred from Phase 3; 29 sites needing deliberate guard/fallback decisions) (#333)
+- Lifecycle cleanup for `AreaEffect` overlap colliders and `StatusEffects`/`Banes` timers (pre-existing leaks surfaced during Phase 3) (#328)


### PR DESCRIPTION
## Summary

Docs-only. Checks off the **Phase 3 (TypeScript completion)** bullets in `docs/ROADMAP.md` now that all of them have landed, each annotated with its PR:

- Loot classes → #324 · UI entities → #327 · Weapons + spawnStyle → #326 · `lib/cache` → #325
- Scene-cast interface (`GameSceneLike`) → #330 · eliminate `any` + `no-explicit-any` → #331 · `strictPropertyInitialization` → #332

Records the **#308 gate as met**: 0 JS files in `src/`, 0 explicit `any` (rule-enforced).

Adds the two Phase 3 deferrals to the backlog:
- `noUncheckedIndexedAccess` — evaluated in #332, deferred (29 sites) → tracked in #333
- `AreaEffect` / `StatusEffects` lifecycle leaks (pre-existing, surfaced during conversion) → tracked in #328

## Risk

None — Markdown only.

## Test evidence

`format:check` passes locally; CI gate jobs run on the PR. No code paths touched.

Addresses #308 (bookkeeping for the completed phase).

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F