### PR TITLE
Phase 4: unit tests for Apollo cache field policies

### DIFF
--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { gql } from "@apollo/client";
+import { cache } from "./cache";
+
+// Unit tests for the Apollo InMemoryCache field policies (Phase 4, #309).
+//
+// These exercise the real `cache` instance and its `typePolicies` end-to-end:
+// we write a normalized Item/Stat object into the cache and read back the
+// computed `color` / `adjusted` / `formatted` / `abbreviation` fields. That
+// way the test pins the actual policy wiring (which source field each read
+// function consumes and the formula/lookup it applies), not a copy of the
+// logic. No production code is changed — the read functions stay private.
+//
+// Each computed field has to be requested explicitly in the query, and the
+// underlying source field (quality / name / value / converted) has to be
+// present in the written object for `readField` to find it.
+
+const ITEM_QUERY = gql`
+    query ItemColor($id: ID!) {
+        item(id: $id) {
+            id
+            quality
+            color
+        }
+    }
+`;
+
+const STAT_QUERY = gql`
+    query StatComputed($id: ID!) {
+        stat(id: $id) {
+            id
+            name
+            value
+            converted
+            adjusted
+            formatted
+            abbreviation
+        }
+    }
+`;
+
+afterEach(() => {
+    // Isolate cases: clear the shared, exported cache between tests.
+    cache.restore({});
+    vi.restoreAllMocks();
+});
+
+function writeItem(quality: string | null) {
+    cache.writeQuery({
+        query: ITEM_QUERY,
+        variables: { id: "i1" },
+        data: {
+            item: {
+                __typename: "Item",
+                id: "i1",
+                quality,
+                color: undefined,
+            },
+        },
+    });
+}
+
+function readItemColor(): string | undefined {
+    // `returnPartialData` so an unknown quality (color resolves to `undefined`)
+    // still yields the item rather than a `null` whole-query result.
+    const result = cache.readQuery<{ item: { color?: string } }>({
+        query: ITEM_QUERY,
+        variables: { id: "i1" },
+        returnPartialData: true,
+    });
+    if (!result?.item) throw new Error("item not found in cache");
+    return result.item.color;
+}
+
+function writeStat(name: string, value: number, converted: number) {
+    cache.writeQuery({
+        query: STAT_QUERY,
+        variables: { id: "s1" },
+        data: {
+            stat: {
+                __typename: "Stat",
+                id: "s1",
+                name,
+                value,
+                converted,
+                adjusted: undefined,
+                formatted: undefined,
+                abbreviation: undefined,
+            },
+        },
+    });
+}
+
+function readStat(): {
+    adjusted?: number;
+    formatted?: string | number;
+    abbreviation?: string;
+} {
+    // `returnPartialData` so a computed field that resolves to `undefined`
+    // (an unknown stat key for `abbreviation`) doesn't make Apollo treat the
+    // whole result as incomplete and hand back `null`.
+    const result = cache.readQuery<{
+        stat: { adjusted?: number; formatted?: string | number; abbreviation?: string };
+    }>({
+        query: STAT_QUERY,
+        variables: { id: "s1" },
+        returnPartialData: true,
+    });
+    if (!result?.stat) throw new Error("stat not found in cache");
+    return result.stat;
+}
+
+describe("Item.color field policy", () => {
+    it.each([
+        ["common", "#bbbbbb"],
+        ["fine", "#00dd00"],
+        ["rare", "#0077ff"],
+        ["epic", "#9900ff"],
+        ["legendary", "#ff9900"],
+    ])("maps quality %s to %s", (quality, expected) => {
+        writeItem(quality);
+        expect(readItemColor()).toBe(expected);
+    });
+
+    it("returns undefined for an unknown quality", () => {
+        writeItem("mythic");
+        expect(readItemColor()).toBeUndefined();
+    });
+});
+
+describe("Stat.adjusted field policy", () => {
+    it.each([
+        ["attack_power", 10, 5],
+        ["attack_speed", 2000, -2],
+        ["critical_chance", 50, 5],
+        ["defence", 8, 4],
+        ["health_max", 3, 12],
+        ["health_regen_rate", 2000, -2],
+        ["health_regen_value", 50, 5],
+        ["magic_power", 10, 5],
+        ["speed", 30, 3],
+    ])("applies the %s formula", (name, value, expected) => {
+        writeStat(name, value, 0);
+        expect(readStat().adjusted).toBe(expected);
+    });
+
+    it("returns the raw value (and logs) for an unknown stat key", () => {
+        const log = vi.spyOn(console, "log").mockImplementation(() => {});
+        writeStat("unknown_stat", 42, 0);
+        expect(readStat().adjusted).toBe(42);
+        expect(log).toHaveBeenCalledWith("No adjustment for [unknown_stat] found.");
+    });
+});
+
+describe("Stat.formatted field policy", () => {
+    it.each(["attack_speed", "critical_chance", "health_regen_rate"])(
+        "formats %s as a rounded percentage with a %% suffix",
+        (name) => {
+            writeStat(name, 0, 1.234);
+            // Math.ceil((1.234 + EPSILON) * 100) / 100 = 1.24
+            expect(readStat().formatted).toBe("1.24%");
+        }
+    );
+
+    it("ceils whole-number percentages without changing them", () => {
+        writeStat("critical_chance", 0, 5);
+        expect(readStat().formatted).toBe("5%");
+    });
+
+    it("ceils non-percentage stats to an integer", () => {
+        writeStat("attack_power", 0, 4.1);
+        expect(readStat().formatted).toBe(5);
+    });
+
+    it("leaves an already-integer non-percentage stat unchanged", () => {
+        writeStat("attack_power", 0, 7);
+        expect(readStat().formatted).toBe(7);
+    });
+});
+
+describe("Stat.abbreviation field policy", () => {
+    it.each([
+        ["attack_power", "AP"],
+        ["attack_speed", "AS"],
+        ["critical_chance", "C"],
+        ["defence", "D"],
+        ["health_max", "H"],
+        ["health_regen_rate", "RR"],
+        ["health_regen_value", "RV"],
+        ["magic_power", "MP"],
+        ["speed", "S"],
+    ])("abbreviates %s as %s", (name, expected) => {
+        writeStat(name, 0, 0);
+        expect(readStat().abbreviation).toBe(expected);
+    });
+
+    it("returns undefined for an unknown stat key", () => {
+        writeStat("unknown_stat", 0, 0);
+        expect(readStat().abbreviation).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## What's tested

Adds `src/lib/cache.test.ts` covering the Apollo `InMemoryCache` field policies defined in `src/lib/cache.ts`. Tests exercise the **real exported `cache` instance** by writing a normalized `Item`/`Stat` object via `writeQuery` and reading back the computed field via `readQuery` — so they pin the actual policy wiring (which source field each read function consumes + the formula/lookup applied), not a re-implementation of the logic.

Coverage:
- **`Item.color`** — each quality (common/fine/rare/epic/legendary) maps to its exact hex; unknown quality resolves to `undefined`.
- **`Stat.adjusted`** — every distinct formula (attack_power, attack_speed, critical_chance, defence, health_max, health_regen_rate, health_regen_value, magic_power, speed) asserted to exact values; unknown key falls through to the raw value and logs the `No adjustment for [...]` message.
- **`Stat.formatted`** — percentage path (attack_speed/critical_chance/health_regen_rate → `%`-suffixed, `Math.ceil((v+EPSILON)*100)/100` rounding, incl. whole-number `5%`) vs the default integer-ceil path (`4.1 → 5`, integer unchanged).
- **`Stat.abbreviation`** — every `statShortNames` lookup; unknown key resolves to `undefined`.

Reads use `returnPartialData: true` so a computed field that legitimately resolves to `undefined` (unknown quality/key) doesn't make Apollo hand back a `null` whole-query result.

## Refactor

**None.** No production behavior change. The read functions and lookup maps in `cache.ts` stay module-private; the tests drive them through the public `cache` instance, so no export-only refactor was needed.

## Files changed

- `src/lib/cache.test.ts` (new, tests only)

## Conflict notes

This PR **only adds `src/lib/cache.test.ts`** and makes **no changes to `cache.ts`** (or any other source file). It is therefore conflict-free with the parallel Item/helpers, Resource/Spell, and component test PRs.

Part of #309

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_