### PR TITLE
Phase 4: Resource regen/adjust and Spell cooldown/resource unit tests

### DIFF
--- a/src/entities/Resources/Resource.test.ts
+++ b/src/entities/Resources/Resource.test.ts
@@ -62,3 +62,208 @@ describe("Resource.cleanup", () => {
         expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 });
+
+// Regen/adjust flow (issue #309). setValue is the clamp + redraw + emit core
+// that adjustValue/regenerate funnel through. We exercise the real prototype
+// methods against a constructor-free fake stubbing only the seams they touch:
+// this.stats, the "current" graphics bar (its scaleX is written), and emit().
+interface ResourceStatsUnderTest {
+    max: number;
+    value: number;
+    regen_rate: number;
+    regen_value: number;
+    missing?: number;
+}
+
+interface ResourceFlowUnderTest {
+    stats: ResourceStatsUnderTest;
+    graphics: { current: { scaleX: number } };
+    emit: ReturnType<typeof vi.fn>;
+    setValue(new_value: number): void;
+    adjustValue(adj: number): void;
+    getValue(): number;
+    resourcePercent(): number;
+    regenerate(): void;
+    doTick(): void;
+}
+
+function makeFlowResource(stats: Partial<ResourceStatsUnderTest> = {}): ResourceFlowUnderTest {
+    const resource = Object.create(Resource.prototype) as ResourceFlowUnderTest;
+    resource.stats = {
+        max: 100,
+        value: 50,
+        regen_rate: 1,
+        regen_value: 10,
+        ...stats,
+    };
+    resource.graphics = { current: { scaleX: 0 } };
+    resource.emit = vi.fn();
+    return resource;
+}
+
+describe("Resource.setValue", () => {
+    it("sets the value within range and ceils fractional input", () => {
+        const resource = makeFlowResource({ value: 50 });
+
+        resource.setValue(60.2);
+
+        expect(resource.stats.value).toBe(61);
+    });
+
+    it("clamps above max down to max", () => {
+        const resource = makeFlowResource({ max: 100, value: 50 });
+
+        resource.setValue(150);
+
+        expect(resource.stats.value).toBe(100);
+    });
+
+    it("clamps below zero up to zero", () => {
+        const resource = makeFlowResource({ value: 50 });
+
+        resource.setValue(-30);
+
+        expect(resource.stats.value).toBe(0);
+    });
+
+    it("updates the current bar scale to the resource percent", () => {
+        const resource = makeFlowResource({ max: 200, value: 0 });
+
+        resource.setValue(50);
+
+        expect(resource.graphics.current.scaleX).toBe(0.25);
+    });
+
+    it("recomputes the missing amount and emits change", () => {
+        const resource = makeFlowResource({ max: 100, value: 50 });
+
+        resource.setValue(80);
+
+        expect(resource.stats.missing).toBe(20);
+        expect(resource.emit).toHaveBeenCalledTimes(1);
+        expect(resource.emit).toHaveBeenCalledWith("change", resource);
+    });
+});
+
+describe("Resource.adjustValue", () => {
+    it("adds a positive delta to the current value", () => {
+        const resource = makeFlowResource({ value: 50 });
+
+        resource.adjustValue(25);
+
+        expect(resource.stats.value).toBe(75);
+    });
+
+    it("subtracts a negative delta from the current value", () => {
+        const resource = makeFlowResource({ value: 50 });
+
+        resource.adjustValue(-20);
+
+        expect(resource.stats.value).toBe(30);
+    });
+
+    it("clamps when the delta would overshoot max", () => {
+        const resource = makeFlowResource({ max: 100, value: 95 });
+
+        resource.adjustValue(20);
+
+        expect(resource.stats.value).toBe(100);
+    });
+
+    it("clamps when the delta would drop below zero", () => {
+        const resource = makeFlowResource({ value: 5 });
+
+        resource.adjustValue(-20);
+
+        expect(resource.stats.value).toBe(0);
+    });
+});
+
+describe("Resource.getValue / resourcePercent", () => {
+    it("returns the current value", () => {
+        const resource = makeFlowResource({ value: 42 });
+
+        expect(resource.getValue()).toBe(42);
+    });
+
+    it("computes value over max as a percent", () => {
+        const resource = makeFlowResource({ max: 80, value: 20 });
+
+        expect(resource.resourcePercent()).toBe(0.25);
+    });
+
+    it("returns 0 percent when the value is not above zero", () => {
+        const resource = makeFlowResource({ max: 80, value: 0 });
+
+        expect(resource.resourcePercent()).toBe(0);
+    });
+});
+
+describe("Resource.regenerate", () => {
+    it("adds regen_value when below max and regen_rate is positive", () => {
+        const resource = makeFlowResource({
+            max: 100,
+            value: 50,
+            regen_rate: 1,
+            regen_value: 10,
+        });
+
+        resource.regenerate();
+
+        expect(resource.stats.value).toBe(60);
+    });
+
+    it("does nothing when already at max", () => {
+        const resource = makeFlowResource({
+            max: 100,
+            value: 100,
+            regen_rate: 1,
+            regen_value: 10,
+        });
+
+        resource.regenerate();
+
+        expect(resource.stats.value).toBe(100);
+        expect(resource.emit).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when regen_rate is zero (non-regenerating resource)", () => {
+        const resource = makeFlowResource({
+            max: 100,
+            value: 50,
+            regen_rate: 0,
+            regen_value: 10,
+        });
+
+        resource.regenerate();
+
+        expect(resource.stats.value).toBe(50);
+        expect(resource.emit).not.toHaveBeenCalled();
+    });
+
+    it("never overshoots max on a regen tick", () => {
+        const resource = makeFlowResource({
+            max: 100,
+            value: 95,
+            regen_rate: 1,
+            regen_value: 10,
+        });
+
+        resource.regenerate();
+
+        expect(resource.stats.value).toBe(100);
+    });
+
+    it("doTick drives a regenerate cycle", () => {
+        const resource = makeFlowResource({
+            max: 100,
+            value: 50,
+            regen_rate: 1,
+            regen_value: 10,
+        });
+
+        resource.doTick();
+
+        expect(resource.stats.value).toBe(60);
+    });
+});

--- a/src/entities/Spells/Spell.test.ts
+++ b/src/entities/Spells/Spell.test.ts
@@ -87,3 +87,134 @@ describe("Spell.cleanup", () => {
         );
     });
 });
+
+// Cooldown + resource affordability checks (issue #309). These are pure
+// predicate methods plus the enable/disable routing in onResourceChangeHandler.
+// Seam: a constructor-free fake whose player.resource.getValue() and
+// cooldownTimer.getValue() are stubbed. For onResourceChangeHandler we spy on
+// enableSpell/disableSpell to assert the routing without touching button render.
+interface CooldownTimerStub {
+    getValue: ReturnType<typeof vi.fn>;
+}
+
+interface SpellCheckUnderTest {
+    typedCost: number;
+    cooldown: number;
+    cooldownTimer?: CooldownTimerStub;
+    player: { resource: { getValue: ReturnType<typeof vi.fn> } };
+    enableSpell: ReturnType<typeof vi.fn>;
+    disableSpell: ReturnType<typeof vi.fn>;
+    checkResource(): boolean;
+    checkCooldown(): boolean;
+    checkReady(): boolean;
+    onResourceChangeHandler(): void;
+}
+
+function makeCheckSpell(
+    opts: { typedCost?: number; cooldown?: number; resourceValue?: number } = {}
+): SpellCheckUnderTest {
+    const spell = Object.create(Spell.prototype) as SpellCheckUnderTest;
+    spell.typedCost = opts.typedCost ?? 10;
+    spell.cooldown = opts.cooldown ?? 5;
+    spell.player = {
+        resource: { getValue: vi.fn(() => opts.resourceValue ?? 100) },
+    };
+    spell.enableSpell = vi.fn();
+    spell.disableSpell = vi.fn();
+    return spell;
+}
+
+describe("Spell.checkResource", () => {
+    it("is true when the resource covers the cost", () => {
+        const spell = makeCheckSpell({ typedCost: 20, resourceValue: 50 });
+
+        expect(spell.checkResource()).toBe(true);
+    });
+
+    it("is true when the resource exactly equals the cost", () => {
+        const spell = makeCheckSpell({ typedCost: 50, resourceValue: 50 });
+
+        expect(spell.checkResource()).toBe(true);
+    });
+
+    it("is false when the resource is below the cost", () => {
+        const spell = makeCheckSpell({ typedCost: 60, resourceValue: 50 });
+
+        expect(spell.checkResource()).toBe(false);
+    });
+});
+
+describe("Spell.checkCooldown", () => {
+    it("is ready when no cooldown timer has been created", () => {
+        const spell = makeCheckSpell();
+        spell.cooldownTimer = undefined;
+
+        expect(spell.checkCooldown()).toBe(true);
+    });
+
+    it("is ready when the timer value is falsy (counter at zero)", () => {
+        const spell = makeCheckSpell();
+        spell.cooldownTimer = { getValue: vi.fn(() => 0) };
+
+        expect(spell.checkCooldown()).toBe(true);
+    });
+
+    it("is ready when the counter has reached the full cooldown", () => {
+        const spell = makeCheckSpell({ cooldown: 5 });
+        spell.cooldownTimer = { getValue: vi.fn(() => 5) };
+
+        expect(spell.checkCooldown()).toBe(true);
+    });
+
+    it("is not ready while the counter is mid-cooldown", () => {
+        const spell = makeCheckSpell({ cooldown: 5 });
+        spell.cooldownTimer = { getValue: vi.fn(() => 2) };
+
+        expect(spell.checkCooldown()).toBe(false);
+    });
+});
+
+describe("Spell.checkReady", () => {
+    it("is ready only when resource and cooldown both pass", () => {
+        const spell = makeCheckSpell({ typedCost: 10, resourceValue: 50 });
+        spell.cooldownTimer = undefined;
+
+        expect(spell.checkReady()).toBe(true);
+    });
+
+    it("is not ready when the resource is insufficient even off cooldown", () => {
+        const spell = makeCheckSpell({ typedCost: 80, resourceValue: 50 });
+        spell.cooldownTimer = undefined;
+
+        expect(spell.checkReady()).toBe(false);
+    });
+
+    it("is not ready when affordable but still on cooldown", () => {
+        const spell = makeCheckSpell({ typedCost: 10, cooldown: 5, resourceValue: 50 });
+        spell.cooldownTimer = { getValue: vi.fn(() => 2) };
+
+        expect(spell.checkReady()).toBe(false);
+    });
+});
+
+describe("Spell.onResourceChangeHandler", () => {
+    it("enables the spell when it becomes ready", () => {
+        const spell = makeCheckSpell({ typedCost: 10, resourceValue: 50 });
+        spell.cooldownTimer = undefined;
+
+        spell.onResourceChangeHandler();
+
+        expect(spell.enableSpell).toHaveBeenCalledTimes(1);
+        expect(spell.disableSpell).not.toHaveBeenCalled();
+    });
+
+    it("disables the spell when it is not ready", () => {
+        const spell = makeCheckSpell({ typedCost: 80, resourceValue: 50 });
+        spell.cooldownTimer = undefined;
+
+        spell.onResourceChangeHandler();
+
+        expect(spell.disableSpell).toHaveBeenCalledWith("resource change");
+        expect(spell.enableSpell).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Extends the existing entity lifecycle tests with behavior coverage for the `Resource` regen/adjust flow and `Spell` cooldown/resource checks. Part of #309.

## Behaviors covered

### Resource (regen/adjust flow)
- `setValue`: clamps above `max` down to `max`, clamps below `0` up to `0`, `Math.ceil`s fractional input, redraws the current bar's `scaleX` to the resource percent, recomputes `stats.missing`, and emits `"change"`.
- `adjustValue`: applies positive/negative deltas through `setValue`, including clamping at both bounds.
- `getValue` / `resourcePercent`: returns the current value; computes `value / max`, and returns `0` when value is not above zero.
- `regenerate`: adds `regen_value` only when `regen_rate > 0` and `value < max`; no-ops at max and when `regen_rate === 0` (non-regenerating resources); never overshoots max. `doTick` drives one regenerate cycle.

### Spell (cooldown + resource checks)
- `checkResource`: affordability via `typedCost <= resource.getValue()` (true above and at exact cost, false below).
- `checkCooldown`: ready when there is no timer, when the counter value is falsy (zero), or when the counter has reached the full cooldown; not ready mid-cooldown.
- `checkReady`: conjunction of the two — verified that either an insufficient resource or an active cooldown blocks readiness.
- `onResourceChangeHandler`: routes to `enableSpell()` when ready and `disableSpell("resource change")` when not.

## Mocked seam
House pattern: constructor-free fakes on the real prototype (`Object.create(Resource.prototype)` / `Object.create(Spell.prototype)`), stubbing only the seams each method touches:
- Resource: `this.stats`, the `current` graphics bar (its `scaleX` is written), and `emit`.
- Spell: `player.resource.getValue()` and `cooldownTimer.getValue()`; `enableSpell`/`disableSpell` are spied to assert routing in `onResourceChangeHandler` without touching button render. The real predicate logic is exercised, not reimplemented.

## Existing lifecycle tests
The Phase 2 `cleanup()` regression `describe` blocks in both files are untouched and still pass. New tests are added in separate `describe` blocks. Full file run: 36 tests pass (20 Resource, 16 Spell).

## Five gates (all green locally)
- `npm run typecheck` — pass
- `npm run lint` — pass (No ESLint warnings or errors)
- `npm test` — pass (81 tests, 11 files)
- `npm run format:check` — pass (All matched files use Prettier code style)
- `npm run build` — pass (static export)

## Conflict notes
This PR only modifies `src/entities/Resources/Resource.test.ts` and `src/entities/Spells/Spell.test.ts` (test files only, no production code). It is therefore conflict-free with the cache, Item/helpers, and component test PRs.

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_