### PR TITLE
Phase 4: unit tests for Item, helpers, and config factories

### DIFF
--- a/src/config/classes.test.ts
+++ b/src/config/classes.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { matchAscended, getSpellSchools, getAscendedClass, getAscendedSchools } from "./classes";
+
+// Pure config-factory logic for the class/ascended-class/school system. These
+// are deterministic table lookups and combinatorics, so they're tested directly
+// (no Phaser construction involved).
+
+describe("matchAscended", () => {
+    it("treats two arrays as equal regardless of order", () => {
+        expect(matchAscended(["warrior", "cleric"], ["cleric", "warrior"])).toBe(true);
+    });
+
+    it("returns false for differing members", () => {
+        expect(matchAscended(["warrior", "warrior"], ["warrior", "cleric"])).toBe(false);
+    });
+});
+
+describe("getSpellSchools", () => {
+    it("returns the base schools for a base class", () => {
+        expect(getSpellSchools("mage")).toEqual(["fire", "frost", "arcane", "earth"]);
+        expect(getSpellSchools("warrior")).toEqual(["arcane", "fire"]);
+    });
+
+    it("resolves ascended classes through getAscendedSchools", () => {
+        // `knight` = warrior + warrior; should equal the ascended-school resolution.
+        expect(getSpellSchools("knight")).toEqual(getAscendedSchools("knight"));
+    });
+
+    it("throws for an unknown class", () => {
+        expect(() => getSpellSchools("dragoon" as never)).toThrow(
+            "Error: Not a valid class or ascended class!"
+        );
+    });
+});
+
+describe("getAscendedClass", () => {
+    it("maps a pair of base classes to their ascended class (order-independent)", () => {
+        expect(getAscendedClass(["cleric", "warrior"])).toBe("paladin");
+        expect(getAscendedClass(["warrior", "cleric"])).toBe("paladin");
+    });
+
+    it("maps a doubled base class to its pure ascension", () => {
+        expect(getAscendedClass(["warrior", "warrior"])).toBe("knight");
+        expect(getAscendedClass(["ranger", "ranger"])).toBe("hunter");
+    });
+
+    it("returns null when no ascended class matches", () => {
+        expect(getAscendedClass(["mage", "warrior", "cleric"] as never)).toBeNull();
+    });
+});
+
+describe("getAscendedSchools", () => {
+    it("returns a sorted, de-duplicated school list", () => {
+        const schools = getAscendedSchools("knight");
+        // Sorted ascending.
+        expect([...schools].sort()).toEqual(schools);
+        // No duplicates.
+        expect(new Set(schools).size).toBe(schools.length);
+    });
+
+    it("includes the primary and secondary base schools", () => {
+        // knight = warrior + warrior; warrior's schools are arcane + fire.
+        const schools = getAscendedSchools("knight");
+        expect(schools).toContain("arcane");
+        expect(schools).toContain("fire");
+    });
+
+    it("includes ascended-school combinations for mixed parents", () => {
+        // paladin = cleric (light, fire) + warrior (arcane, fire).
+        // light+arcane => smite, fire+fire => flare, light+fire => holy.
+        const schools = getAscendedSchools("paladin");
+        expect(schools).toContain("smite");
+        expect(schools).toContain("flare");
+        expect(schools).toContain("holy");
+    });
+});

--- a/src/entities/Loot/Item.test.ts
+++ b/src/entities/Loot/Item.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Item generation is RNG-driven via lodash `random`/`sample`. We mock both so
+// every draw is deterministic, letting us pin the exact stat-pool maths, key
+// generation, allocation iterator, the per-stat adjust formulas/labels, and the
+// category->set mapping. `lodash/findKey` is left real (pure lookup).
+
+const randomMock = vi.fn();
+const sampleMock = vi.fn();
+
+vi.mock("lodash/random", () => ({ default: (...args: number[]) => randomMock(...args) }));
+vi.mock("lodash/sample", () => ({ default: (arr: unknown[]) => sampleMock(arr) }));
+vi.mock("uuid", () => ({ v4: () => "test-uuid" }));
+
+import Item from "./Item";
+
+const baseConfig = {
+    base: 100,
+    multiplier: 10,
+    keys: { min: 1, max: 3 },
+};
+
+beforeEach(() => {
+    randomMock.mockReset();
+    sampleMock.mockReset();
+    // Safe defaults so an unparametrised construct still completes.
+    randomMock.mockReturnValue(1);
+    sampleMock.mockReturnValue("attack_power");
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// Build an Item without running the RNG-heavy constructor logic, so individual
+// methods can be exercised in isolation (mirrors the prototype-fake seam used in
+// the lifecycle tests).
+function bareItem(): Item {
+    const item = Object.create(Item.prototype) as Item;
+    item.base = baseConfig.base;
+    item.multiplier = baseConfig.multiplier;
+    item.keys = baseConfig.keys;
+    return item;
+}
+
+describe("generateStatPool", () => {
+    it("computes Math.round(random(base+adj, base*2+adj) * random(1, 1.3))", () => {
+        const item = bareItem();
+        // wave = 1, multiplier = 10 => adjustor = 10.
+        // First random() returns the pool seed, second the multiplier factor.
+        randomMock.mockReturnValueOnce(150).mockReturnValueOnce(1.2);
+
+        expect(item.generateStatPool(100)).toBe(Math.round(150 * 1.2));
+        // First call uses the documented range bounds.
+        expect(randomMock).toHaveBeenNthCalledWith(1, 110, 210);
+        expect(randomMock).toHaveBeenNthCalledWith(2, 1, 1.3);
+    });
+
+    it("stays within the documented range when factor is 1", () => {
+        const item = bareItem();
+        // Force the seed to the lower/upper bound and factor 1.
+        randomMock.mockReturnValueOnce(110).mockReturnValueOnce(1);
+        expect(item.generateStatPool(100)).toBe(110);
+    });
+});
+
+describe("generateKeys", () => {
+    it("draws `random(min,max)` keys, each via sample(stat_names)", () => {
+        const item = bareItem();
+        randomMock.mockReturnValueOnce(3); // count
+        sampleMock
+            .mockReturnValueOnce("attack_power")
+            .mockReturnValueOnce("defence")
+            .mockReturnValueOnce("speed");
+
+        const names = ["attack_power", "defence", "speed", "magic_power"];
+        const keys = item.generateKeys({ min: 1, max: 3 }, names);
+
+        expect(randomMock).toHaveBeenCalledWith(1, 3);
+        expect(keys).toEqual(["attack_power", "defence", "speed"]);
+        expect(sampleMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("returns a count within [min, max] across many draws (invariant)", () => {
+        const item = bareItem();
+        const names = ["attack_power", "defence"];
+        for (let n = 2; n <= 5; n++) {
+            randomMock.mockReturnValueOnce(n);
+            sampleMock.mockReturnValue("attack_power");
+            expect(item.generateKeys({ min: 2, max: 5 }, names)).toHaveLength(n);
+        }
+    });
+});
+
+describe("allocateStatIterator", () => {
+    it("deducts a share per call and gives the remainder to the final stat", () => {
+        const item = bareItem();
+        // length 2 => range = 1/4. Force random to return the low bound `range`.
+        randomMock.mockReturnValue(0.25);
+        const it = item.allocateStatIterator(1000, 2);
+
+        const first = it.next("attack_power");
+        // deduction = round(1000 * 0.25) = 250
+        expect(first).toEqual({ value: 250, done: false, key: "attack_power" });
+
+        const second = it.next("defence");
+        // remainder = 1000 - 250 = 750, flagged done.
+        expect(second).toEqual({ value: 750, done: true, key: "defence" });
+    });
+
+    it("conserves the pool: allocations sum to the original pool", () => {
+        const item = bareItem();
+        randomMock.mockReturnValue(0.1);
+        const pool = 900;
+        const length = 4;
+        const it = item.allocateStatIterator(pool, length);
+
+        let sum = 0;
+        for (let i = 0; i < length; i++) {
+            sum += it.next(`k${i}`).value;
+        }
+        expect(sum).toBe(pool);
+    });
+});
+
+describe("adjustStats", () => {
+    const cases: Array<
+        [string, number, Partial<{ adjusted: number; format: string; abr: string }>]
+    > = [
+        ["attack_power", 10, { adjusted: 5, format: "basic", abr: "AP" }],
+        ["attack_speed", 1000, { adjusted: -1, format: "percent", abr: "AS" }],
+        ["critical_chance", 100, { adjusted: 10, format: "percent", abr: "C" }],
+        ["defence", 10, { adjusted: 5, format: "basic", abr: "D" }],
+        ["health_max", 3, { adjusted: 12, format: "basic", abr: "H" }],
+        ["health_regen_rate", 1000, { adjusted: -1, format: "percent", abr: "RR" }],
+        ["health_regen_value", 100, { adjusted: 10, format: "basic", abr: "RV" }],
+        ["magic_power", 10, { adjusted: 5, format: "basic", abr: "MP" }],
+        ["speed", 100, { adjusted: 10, format: "basic", abr: "S" }],
+    ];
+
+    it.each(cases)("maps %s to its formula/format/abr", (key, value, expected) => {
+        const item = bareItem();
+        const result = item.adjustStats({ value, done: false, key });
+        expect(result).toMatchObject(expected);
+        // The original stat fields are spread through.
+        expect(result.key).toBe(key);
+    });
+
+    it("falls back to the `default` shape for an unknown key", () => {
+        const item = bareItem();
+        const result = item.adjustStats({ value: 42, done: false, key: "nonsense" });
+        expect(result).toMatchObject({
+            adjusted: 42,
+            format: "basic",
+            label: "Default",
+            abr: "Default",
+        });
+    });
+});
+
+describe("round", () => {
+    it("ceils basic stats to a whole number", () => {
+        const item = bareItem();
+        const out = item.round({
+            adjusted: 5.2,
+            format: "basic",
+            label: "x",
+            short: "x",
+            abr: "x",
+        });
+        expect((out as unknown as { rounded: number }).rounded).toBe(6);
+    });
+
+    it("ceils percent stats to two decimals", () => {
+        const item = bareItem();
+        const out = item.round({
+            adjusted: 0.121,
+            format: "percent",
+            label: "x",
+            short: "x",
+            abr: "x",
+        });
+        expect((out as unknown as { rounded: number }).rounded).toBe(0.13);
+    });
+});
+
+describe("getCategory / getIcon / getSet", () => {
+    it("getCategory returns a sampled category", () => {
+        const item = bareItem();
+        sampleMock.mockReturnValueOnce("sword");
+        expect(item.getCategory()).toBe("sword");
+    });
+
+    it("getIcon picks `category_n` within the category's max", () => {
+        const item = bareItem();
+        randomMock.mockReturnValueOnce(7);
+        expect(item.getIcon("sword")).toBe("sword_7");
+        expect(randomMock).toHaveBeenCalledWith(1, 24);
+    });
+
+    it.each([
+        ["amulet", "amulet"],
+        ["gem", "amulet"],
+        ["misc", "amulet"],
+        ["armor", "body"],
+        ["helmet", "helm"],
+        ["axe", "weapon"],
+        ["bow", "weapon"],
+        ["staff", "weapon"],
+        ["sword", "weapon"],
+    ])("getSet maps %s -> %s", (category, set) => {
+        const item = bareItem();
+        expect(item.getSet(category)).toBe(set);
+    });
+});
+
+describe("constructor assembly", () => {
+    it("assembles stats, category, icon, set and uuid from the RNG draws", () => {
+        // stat_pool: seed*factor
+        randomMock
+            .mockReturnValueOnce(200) // generateStatPool seed
+            .mockReturnValueOnce(1) // generateStatPool factor => pool 200
+            .mockReturnValueOnce(2); // generateKeys count = 2
+        // two distinct keys so the Set keeps both
+        sampleMock.mockReturnValueOnce("attack_power").mockReturnValueOnce("defence");
+        // Remaining random draws (allocation share + icon index) default to 3.
+        randomMock.mockReturnValue(3);
+        sampleMock.mockReturnValueOnce("sword"); // category
+
+        const item = new Item({ ...baseConfig });
+
+        expect(item.stat_pool).toBe(200);
+        expect(Object.keys(item.stats).sort()).toEqual(["attack_power", "defence"]);
+        expect(item.category).toBe("sword");
+        // icon is `${category}_${random(1,max)}`; max=24 for sword, draw forced to 3.
+        expect(item.icon).toBe("sword_3");
+        expect(item.set).toBe("weapon");
+        expect(item.uuid).toBe("test-uuid");
+        // Allocations conserve the pool.
+        const allocated = (item.stats.attack_power.value ?? 0) + (item.stats.defence.value ?? 0);
+        expect(allocated).toBe(item.stat_pool);
+    });
+
+    it("dedupes repeated sampled keys via the Set", () => {
+        randomMock.mockReturnValueOnce(200).mockReturnValueOnce(1).mockReturnValueOnce(3); // ask for 3 keys
+        sampleMock
+            .mockReturnValueOnce("speed")
+            .mockReturnValueOnce("speed")
+            .mockReturnValueOnce("speed");
+        randomMock.mockReturnValue(0.5); // share draws + icon
+        sampleMock.mockReturnValueOnce("gem"); // category
+
+        const item = new Item({ ...baseConfig });
+        expect(Object.keys(item.stats)).toEqual(["speed"]);
+        expect(item.set).toBe("amulet");
+    });
+});

--- a/src/ui/operations/helpers.test.ts
+++ b/src/ui/operations/helpers.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+    sortAscending,
+    sortDescending,
+    sortBy,
+    statsArrayToObject,
+    addStats,
+    removeStats,
+} from "./helpers";
+
+// Pure sort/shape helpers used by the inventory/loot UI. These pin the
+// comparator semantics (the `>`/`<` based ordering), the non-mutating
+// `sortBy`, and the array->object reduction.
+
+describe("sortAscending", () => {
+    it("returns 1/-1/0 mirroring `>`/`<` on the keyed value", () => {
+        const cmp = sortAscending("v");
+        expect(cmp({ v: 2 }, { v: 1 })).toBe(1);
+        expect(cmp({ v: 1 }, { v: 2 })).toBe(-1);
+        expect(cmp({ v: 1 }, { v: 1 })).toBe(0);
+    });
+
+    it("orders an array ascending when used with Array.sort", () => {
+        const arr = [{ v: 3 }, { v: 1 }, { v: 2 }];
+        expect(arr.sort(sortAscending("v"))).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
+    });
+
+    it("compares string-valued keys lexicographically", () => {
+        const cmp = sortAscending("name");
+        expect(cmp({ name: "b" }, { name: "a" })).toBe(1);
+        expect(cmp({ name: "a" }, { name: "b" })).toBe(-1);
+    });
+});
+
+describe("sortDescending", () => {
+    it("returns 1/-1/0 as the inverse of ascending", () => {
+        const cmp = sortDescending("v");
+        expect(cmp({ v: 1 }, { v: 2 })).toBe(1);
+        expect(cmp({ v: 2 }, { v: 1 })).toBe(-1);
+        expect(cmp({ v: 1 }, { v: 1 })).toBe(0);
+    });
+
+    it("orders an array descending when used with Array.sort", () => {
+        const arr = [{ v: 1 }, { v: 3 }, { v: 2 }];
+        expect(arr.sort(sortDescending("v"))).toEqual([{ v: 3 }, { v: 2 }, { v: 1 }]);
+    });
+});
+
+describe("sortBy", () => {
+    it("sorts ascending by default", () => {
+        const arr = [{ v: 3 }, { v: 1 }, { v: 2 }];
+        expect(sortBy(arr, { key: "v" })).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
+    });
+
+    it("sorts descending when order is 'desc'", () => {
+        const arr = [{ v: 3 }, { v: 1 }, { v: 2 }];
+        expect(sortBy(arr, { key: "v", order: "desc" })).toEqual([{ v: 3 }, { v: 2 }, { v: 1 }]);
+    });
+
+    it("does not mutate the input array", () => {
+        const arr = [{ v: 3 }, { v: 1 }, { v: 2 }];
+        const before = [...arr];
+        sortBy(arr, { key: "v" });
+        expect(arr).toEqual(before);
+    });
+
+    it("returns a new array reference", () => {
+        const arr = [{ v: 1 }];
+        expect(sortBy(arr, { key: "v" })).not.toBe(arr);
+    });
+});
+
+describe("statsArrayToObject", () => {
+    it("builds an object keyed by name with the value", () => {
+        expect(
+            statsArrayToObject([
+                { name: "attack_power", value: 5 },
+                { name: "defence", value: 3 },
+            ])
+        ).toEqual({ attack_power: 5, defence: 3 });
+    });
+
+    it("returns an empty object for an empty array", () => {
+        expect(statsArrayToObject([])).toEqual({});
+    });
+
+    it("keeps the last value when a name repeats", () => {
+        expect(
+            statsArrayToObject([
+                { name: "speed", value: 1 },
+                { name: "speed", value: 9 },
+            ])
+        ).toEqual({ speed: 9 });
+    });
+});
+
+describe("addStats / removeStats", () => {
+    it("addStats sums overlapping keys and keeps the base for the rest", () => {
+        expect(addStats({ attack_power: 5, defence: 2 }, { attack_power: 3 })).toEqual({
+            attack_power: 8,
+            defence: 2,
+        });
+    });
+
+    it("removeStats subtracts overlapping keys", () => {
+        expect(removeStats({ attack_power: 5, defence: 2 }, { attack_power: 3 })).toEqual({
+            attack_power: 2,
+            defence: 2,
+        });
+    });
+});


### PR DESCRIPTION
Part of #309 — "Unit: `Item.ts` stat allocation/generation; `ui/operations/helpers.ts`; config factories."

Tests only; no production behavior change.

## What's tested

**`src/entities/Loot/Item.ts`** (`src/entities/Loot/Item.test.ts`)
- `generateStatPool` — exact `Math.round(random(base+adj, base*2+adj) * random(1,1.3))` maths and that it calls `random` with the documented range bounds.
- `generateKeys` — draws `random(min,max)` names via `sample`, plus a count-within-`[min,max]` invariant across draws.
- `allocateStatIterator` — per-call deduction, remainder on the final stat (`done: true`), and a pool-conservation invariant (allocations sum to the original pool).
- `adjustStats` — table-driven check of every stat's `adjusted` formula, `format`, and `abr`, plus the `default` fallback for unknown keys.
- `round` — basic stats ceil to whole numbers, percent stats ceil to two decimals.
- `getCategory` / `getIcon` / `getSet` — sampled category, `${category}_${n}` icon within the category max, and the full category→set mapping.
- Constructor assembly — stats/category/icon/set/uuid wired from the RNG draws, and the `Set` de-dupe of repeated sampled keys.

**`src/ui/operations/helpers.ts`** (`src/ui/operations/helpers.test.ts`)
- `sortAscending` / `sortDescending` — comparator `1/-1/0` semantics (numeric + string keys) and use with `Array.sort`.
- `sortBy` — asc default, desc, non-mutating, new array reference.
- `statsArrayToObject` — object build, empty input, last-wins on repeated names.
- `addStats` / `removeStats` — overlapping-key merge maths (bonus pure helpers in the same file).

**Config factory** (`src/config/classes.test.ts`)
- `matchAscended`, `getSpellSchools` (base + ascended + throw), `getAscendedClass` (order-independent, doubled class, no-match → null), `getAscendedSchools` (sorted/de-duped, includes parent + combination schools).

## How RNG was handled
`Item` is driven by lodash `random`/`sample`. The Item test file `vi.mock`s `lodash/random`, `lodash/sample`, and `uuid` (scoped to that file only) so every draw is deterministic — exact assertions where the call order is pinnable, and conservation/range invariants elsewhere. The helpers and config tests are pure and need no mocking.

## Deferred config factory
The `Assign*` factories (`AssignClass`, `AssignType`, `AssignResource`, `AssignSpell`) are thin dispatchers that `new` Phaser-dependent entity classes (scenes/game objects), so their happy path is entangled with Phaser construction and not cleanly unit-testable at this seam. `src/config/classes.ts` is the tractable, fully-pure config-factory logic and is tested instead. The `AssignClass` validation/throw branch could be tested in isolation but its success path still constructs Phaser entities; left out to keep this PR pure-logic-only. Noted here rather than forced.

## Conflict notes
New files only (no edits to existing files):
- `src/entities/Loot/Item.test.ts`
- `src/ui/operations/helpers.test.ts`
- `src/config/classes.test.ts`

These are new `*.test.ts` files sitting next to their targets and touch no production code, so they are conflict-free with the cache, Resource/Spell, and component test PRs.

## Five-gate results (local)
- `npm run typecheck` — pass
- `npm run lint` — pass (no ESLint warnings or errors)
- `npm test` — pass (14 files, 108 tests)
- `npm run format:check` — pass (all files Prettier-clean)
- `npm run build` — pass (static export OK)

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_