### PR TITLE
Phase 4: Playwright smoke pack (on PR) + nightly E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,78 @@
+# Playwright E2E (Phase 4, #309).
+#
+# Strategy (per ROADMAP decisions log): smoke E2E on every PR, full E2E nightly.
+#   - `smoke`   : fast Chromium-only pack, runs on pull_request and push to main.
+#   - `full`    : the whole suite across browsers, on a nightly schedule and on
+#                 manual dispatch.
+# This workflow is additive and does NOT touch the existing quality gates in
+# ci.yml.
+name: E2E
+
+on:
+    pull_request:
+    push:
+        branches: ["main"]
+    schedule:
+        # 03:17 UTC daily — off the top of the hour to avoid Actions congestion.
+        - cron: "17 3 * * *"
+    workflow_dispatch:
+
+concurrency:
+    group: e2e-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    # Smoke pack on every PR and push to main. Skipped on the nightly schedule
+    # (the full job covers that run).
+    smoke:
+        if: github.event_name != 'schedule'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "npm"
+            - run: npm ci
+            - name: Install Playwright browsers (Chromium)
+              run: npx playwright install --with-deps chromium
+            - name: Build static export
+              run: npm run build
+            - name: Run smoke E2E
+              run: npm run test:e2e
+            - name: Upload Playwright report
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report-smoke
+                  path: playwright-report/
+                  retention-days: 7
+
+    # Full suite across browsers, nightly and on manual dispatch only.
+    full:
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Setup Node.js environment
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: ".nvmrc"
+                  cache: "npm"
+            - run: npm ci
+            - name: Install Playwright browsers (all)
+              run: npx playwright install --with-deps
+            - name: Build static export
+              run: npm run build
+            - name: Run full E2E
+              run: npm run test:e2e:full
+            - name: Upload Playwright report
+              if: ${{ !cancelled() }}
+              uses: actions/upload-artifact@v4
+              with:
+                  name: playwright-report-full
+                  path: playwright-report/
+                  retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,12 @@
 # ci.yml.
 name: E2E
 
+# Least-privilege GITHUB_TOKEN: the jobs only checkout and upload an artifact,
+# so `contents: read` suffices. Declared at the top level so both jobs inherit
+# it (resolves the CodeQL "workflow does not contain permissions" finding).
+permissions:
+    contents: read
+
 on:
     pull_request:
     push:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@
 # testing
 /coverage
 
+# playwright e2e
+/test-results
+/playwright-report
+/playwright/.cache
+
 # next.js
 /.next/
 /out/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,10 @@
 dist
 out
 
+# Playwright artifacts
+test-results
+playwright-report
+
 # Dependencies
 node_modules
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,56 @@
+import type { Page } from "@playwright/test";
+
+// Shared E2E helpers. Kept deliberately small and DOM/localStorage-only — the
+// game canvas itself is a Phaser `<canvas>` whose internals are not queryable,
+// so every assertion in the smoke pack drives the React UI overlay (DOM,
+// visible text, buttons) or `localStorage` (the save service's backing store).
+
+// The five playable classes, exactly as rendered as button labels by
+// CharacterCard (`text={type}`). See src/ui/components/templates/CharacterSelect.tsx.
+export const CHARACTERS = ["Cleric", "Mage", "Occultist", "Ranger", "Warrior"] as const;
+export type Character = (typeof CHARACTERS)[number];
+
+// localStorage save slots, mirroring SAVE_SLOTS in src/services/saveStorage.ts.
+// The on-disk shape is the Redux *root* state (`{ game: { ... } }`); the Save
+// menu reads `wave`/`coins`/`character` off `.game` to render each slot.
+export const SAVE_SLOTS = ["slot_a", "slot_b", "slot_c"] as const;
+
+// Minimal save payload matching what the Save menu reads back. We only populate
+// the fields the Load screen renders (character, wave, coins, saveSlot); the
+// rest of GameState is irrelevant to the roundtrip assertion and Redux/Phaser
+// tolerate a partial load for the purposes of the DOM check.
+export function makeSave(slot: string, character: Character, wave: number, coins: number) {
+    return {
+        game: {
+            character,
+            saveSlot: slot,
+            wave,
+            coins,
+        },
+    };
+}
+
+// Seed a save directly into localStorage before the app reads it. Playwright's
+// addInitScript runs before page scripts on the next navigation, so the Save
+// menu's `readAllSaves` sees the seeded slot on first render.
+export async function seedSave(
+    page: Page,
+    slot: string,
+    save: ReturnType<typeof makeSave>
+): Promise<void> {
+    await page.addInitScript(
+        ([key, value]) => {
+            window.localStorage.setItem(key, value);
+        },
+        [slot, JSON.stringify(save)] as const
+    );
+}
+
+// Wait for the Phaser game to mount its canvas inside the #phaser-game host.
+// This is the boot signal: PhaserGame.tsx renders `<div id="phaser-game" />`
+// and Phaser injects a `<canvas>` into it once the engine initialises.
+export async function expectGameCanvas(page: Page) {
+    const host = page.locator("#phaser-game");
+    await host.waitFor({ state: "attached" });
+    return page.locator("#phaser-game canvas");
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -30,9 +30,13 @@ test.describe("Phasercraft smoke", () => {
         await expect(canvas).toBeAttached();
 
         // LoadScene.create() opens the "Pick a Game Save" overlay once the scene
-        // boots and preload completes. The menu container id is derived from the
-        // menu title ("Pick a Game Save" -> "pick-a-game-save"); see UI.tsx.
-        await expect(page.locator("#pick-a-game-save")).toBeVisible();
+        // boots and preload completes. We key off the menu shell (.menu-container,
+        // rendered only while a menu is open) plus the save-slot headings rather
+        // than the menu's derived id: UI.tsx builds the id with
+        // `title.toLowerCase().replace(" ", "-")`, and String.replace swaps only
+        // the FIRST space, so "Pick a Game Save" yields the id "pick-a game save"
+        // (a pre-existing quirk). Visible text / slot headings are the stable hook.
+        await expect(page.locator(".menu-container")).toBeVisible();
         // Three save slots render with "Slot 1".."Slot 3" headings.
         await expect(page.getByRole("heading", { name: "Slot 1" })).toBeVisible();
     });
@@ -45,11 +49,14 @@ test.describe("Phasercraft smoke", () => {
         await expectGameCanvas(page);
 
         // From the save menu, an empty slot's "Select" button opens character select.
-        await expect(page.locator("#pick-a-game-save")).toBeVisible();
+        // (The save menu's derived id contains a space — see Flow 1 — so key off the
+        // menu shell and the Select button instead.)
+        await expect(page.locator(".menu-container")).toBeVisible();
         await page.getByRole("button", { name: "Select" }).first().click();
 
-        // The Character Select menu renders (container id from its title) with a
-        // button per playable class.
+        // The Character Select menu renders ("Character Select" has a single space,
+        // so its derived id "character-select" is well-formed); assert a button per
+        // playable class as the stable signal.
         await expect(page.locator("#character-select")).toBeVisible();
         for (const name of CHARACTERS) {
             await expect(page.getByRole("button", { name, exact: true })).toBeVisible();
@@ -95,10 +102,11 @@ test.describe("Phasercraft smoke", () => {
         await page.goto("/");
         await expectGameCanvas(page);
 
-        // The boot overlay is the save picker ("Pick a Game Save"), which lists
-        // every slot. A populated slot renders the saved character plus a "Load"
-        // button (empty slots show "Select"), so no extra navigation is needed.
-        await expect(page.locator("#pick-a-game-save")).toBeVisible();
+        // The boot overlay is the save picker, which lists every slot. A populated
+        // slot renders the saved character plus a "Load" button (empty slots show
+        // "Select"), so no extra navigation is needed. Key off the menu shell (the
+        // save menu's derived id contains a space — see Flow 1).
+        await expect(page.locator(".menu-container")).toBeVisible();
 
         // The seeded slot surfaces the persisted wave/coins straight from the
         // save service — proof the localStorage roundtrip survived a fresh load.
@@ -108,7 +116,7 @@ test.describe("Phasercraft smoke", () => {
         // Loading the save dispatches loadGame + selectCharacter, which closes the
         // overlay (showUi:false) and drops us into the restored run.
         await page.getByRole("button", { name: "Load" }).first().click();
-        await expect(page.locator("#pick-a-game-save")).toBeHidden();
+        // The overlay tears down (showUi:false) — no menu shell remains.
         await expect(page.locator(".menu-container")).toHaveCount(0);
 
         // And the underlying localStorage save is unchanged after the roundtrip.

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from "@playwright/test";
+import { CHARACTERS, makeSave, seedSave, expectGameCanvas } from "./helpers";
+
+// Smoke pack for Phasercraft (Phase 4, #309) — runs on every PR.
+//
+// The game is a Phaser `<canvas>` with a React/Redux UI overlay drawn on top.
+// Canvas internals are not queryable from the DOM, so every assertion here
+// drives the React overlay (visible text, buttons, ids) or `localStorage`
+// (the save service's backing store). Where a flow is genuinely canvas-only
+// (the wave readout), it is marked `test.fixme` with the reason inline rather
+// than shipped as a flaky/failing test.
+//
+// Boot sequence the specs rely on (see src/scenes/LoadScene.ts):
+//   LoadScene.create() dispatches toggleUi("save") and starts SelectScene, so
+//   the "Pick a Game Save" overlay is the first interactive UI. Each empty slot
+//   offers a "Select" button -> setSaveSlot + switchUi("select") -> the
+//   "Character Select" menu. Picking a character dispatches selectCharacter,
+//   which sets showUi:false (the overlay closes and the run begins).
+
+test.describe("Phasercraft smoke", () => {
+    // ── Flow 1: game boots ───────────────────────────────────────────────────
+    test("game boots: page mounts, canvas renders, initial UI appears", async ({ page }) => {
+        await page.goto("/");
+
+        // The Phaser host div is always rendered by React.
+        await expect(page.locator("#phaser-game")).toBeAttached();
+
+        // Phaser injects a <canvas> once the engine initialises — the boot signal.
+        const canvas = await expectGameCanvas(page);
+        await expect(canvas).toBeAttached();
+
+        // LoadScene.create() opens the "Pick a Game Save" overlay once the scene
+        // boots and preload completes. The menu container id is derived from the
+        // menu title ("Pick a Game Save" -> "pick-a-game-save"); see UI.tsx.
+        await expect(page.locator("#pick-a-game-save")).toBeVisible();
+        // Three save slots render with "Slot 1".."Slot 3" headings.
+        await expect(page.getByRole("heading", { name: "Slot 1" })).toBeVisible();
+    });
+
+    // ── Flow 2: character select ─────────────────────────────────────────────
+    test("character select: choosing a class closes the overlay and starts the run", async ({
+        page,
+    }) => {
+        await page.goto("/");
+        await expectGameCanvas(page);
+
+        // From the save menu, an empty slot's "Select" button opens character select.
+        await expect(page.locator("#pick-a-game-save")).toBeVisible();
+        await page.getByRole("button", { name: "Select" }).first().click();
+
+        // The Character Select menu renders (container id from its title) with a
+        // button per playable class.
+        await expect(page.locator("#character-select")).toBeVisible();
+        for (const name of CHARACTERS) {
+            await expect(page.getByRole("button", { name, exact: true })).toBeVisible();
+        }
+
+        // Picking a class dispatches selectCharacter -> showUi:false, so the whole
+        // UI overlay (header + menu container) is torn down and the run view shows.
+        await page.getByRole("button", { name: "Warrior", exact: true }).click();
+        await expect(page.locator("#character-select")).toBeHidden();
+        await expect(page.locator(".menu-container")).toHaveCount(0);
+        // The game canvas is still present underneath — we're now in the run.
+        await expect(page.locator("#phaser-game canvas")).toBeAttached();
+    });
+
+    // ── Flow 3: wave starts ──────────────────────────────────────────────────
+    //
+    // The wave readout ("Wave: N") is drawn by a Phaser GameObjects.Text on the
+    // canvas (src/entities/UI/HUD.ts), and the React HUD overlay shows only level
+    // info, not the wave. There is no DOM node carrying the wave value, and the
+    // store is not exposed on `window`, so a DOM-level assertion that the wave
+    // started/incremented is not reachable headlessly without a production hook
+    // (a synced DOM mirror or a window-exposed store) — out of scope for a
+    // test-only PR. The save/load roundtrip below exercises the wave *value*
+    // through the save service as a proxy. Deferred deliberately, not skipped for
+    // flake.
+    test.fixme("wave starts: HUD wave readout appears/increments", async () => {
+        // Needs either a data-testid mirror of state.game.wave in the React
+        // HUD, or `window.store` exposed in dev/test builds. Tracked for a
+        // follow-up that adds a minimal, flagged production hook.
+    });
+
+    // ── Flow 4: save/load roundtrip ──────────────────────────────────────────
+    test("save/load roundtrip: a seeded save is restored from localStorage", async ({ page }) => {
+        const slot = "slot_a";
+        const WAVE = 7;
+        const COINS = 1234;
+
+        // Seed a save before the app loads. The Save menu's readAllSaves() reads
+        // this slot from localStorage on first render — this is exactly the shape
+        // writeSave() persists (Redux root state under `.game`).
+        await seedSave(page, slot, makeSave(slot, "Mage", WAVE, COINS));
+
+        await page.goto("/");
+        await expectGameCanvas(page);
+
+        // The boot overlay is the save picker ("Pick a Game Save"), which lists
+        // every slot. A populated slot renders the saved character plus a "Load"
+        // button (empty slots show "Select"), so no extra navigation is needed.
+        await expect(page.locator("#pick-a-game-save")).toBeVisible();
+
+        // The seeded slot surfaces the persisted wave/coins straight from the
+        // save service — proof the localStorage roundtrip survived a fresh load.
+        await expect(page.getByText(`Wave: ${WAVE}`)).toBeVisible();
+        await expect(page.getByText(`Gold: ${COINS}`)).toBeVisible();
+
+        // Loading the save dispatches loadGame + selectCharacter, which closes the
+        // overlay (showUi:false) and drops us into the restored run.
+        await page.getByRole("button", { name: "Load" }).first().click();
+        await expect(page.locator("#pick-a-game-save")).toBeHidden();
+        await expect(page.locator(".menu-container")).toHaveCount(0);
+
+        // And the underlying localStorage save is unchanged after the roundtrip.
+        const persisted = await page.evaluate((key) => window.localStorage.getItem(key), slot);
+        expect(persisted).not.toBeNull();
+        expect(JSON.parse(persisted as string).game.wave).toBe(WAVE);
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "uuid": "^14.0.0"
             },
             "devDependencies": {
+                "@playwright/test": "^1.60.0",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.3.2",
                 "@types/lodash": "^4.17.20",
@@ -43,6 +44,7 @@
                 "postcss": "^8.5.10",
                 "prettier": "^3.8.3",
                 "react-dnd-test-backend": "^16.0.1",
+                "serve": "^14.2.6",
                 "simple-git-hooks": "^2.13.1",
                 "typescript": "^5",
                 "vitest": "^4.1.6"
@@ -1304,6 +1306,22 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+            "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.60.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@polka/url": {
@@ -2615,6 +2633,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@zeit/schemas": {
+            "version": "2.36.0",
+            "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+            "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/acorn": {
             "version": "8.16.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2652,6 +2677,61 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
+        "node_modules/ansi-align": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+            "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.1.0"
+            }
+        },
+        "node_modules/ansi-align/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-align/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/ansi-escapes": {
             "version": "7.3.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -2674,7 +2754,6 @@
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -2693,6 +2772,34 @@
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
+        },
+        "node_modules/arch": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+            "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/arg": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+            "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
@@ -2953,6 +3060,91 @@
                 "require-from-string": "^2.0.2"
             }
         },
+        "node_modules/boxen": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+            "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-align": "^3.0.1",
+                "camelcase": "^7.0.0",
+                "chalk": "^5.0.1",
+                "cli-boxes": "^3.0.0",
+                "string-width": "^5.1.2",
+                "type-fest": "^2.13.0",
+                "widest-line": "^4.0.1",
+                "wrap-ansi": "^8.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/ansi-styles": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/boxen/node_modules/chalk": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+            "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/boxen/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/boxen/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -2973,6 +3165,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/bytes": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/call-bind": {
@@ -3031,6 +3233,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/camelcase": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+            "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001799",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -3077,11 +3292,40 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/chalk-template": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+            "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chalk": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk-template?sponsor=1"
+            }
+        },
         "node_modules/classnames": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
             "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
             "license": "MIT"
+        },
+        "node_modules/cli-boxes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+            "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/cli-cursor": {
             "version": "5.0.0",
@@ -3121,6 +3365,24 @@
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
             "license": "MIT"
+        },
+        "node_modules/clipboardy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+            "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "arch": "^2.2.0",
+                "execa": "^5.1.1",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -3164,11 +3426,70 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/compressible": {
+            "version": "2.0.18",
+            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/compression": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "compressible": "~2.0.18",
+                "debug": "2.6.9",
+                "negotiator": "~0.6.4",
+                "on-headers": "~1.1.0",
+                "safe-buffer": "5.2.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/compression/node_modules/debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/compression/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
             "license": "MIT"
+        },
+        "node_modules/content-disposition": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+            "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
@@ -3314,6 +3635,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/deep-extend": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3440,6 +3771,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/email-addresses": {
             "version": "5.0.0",
@@ -4095,6 +4433,53 @@
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
         },
+        "node_modules/execa": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+            "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/execa/node_modules/onetime": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+            "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mimic-fn": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/execa/node_modules/signal-exit": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/expect-type": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4150,6 +4535,23 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.20.1",
@@ -4431,6 +4833,19 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -4697,6 +5112,16 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
+        "node_modules/human-signals": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+            "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4750,6 +5175,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -4901,6 +5333,22 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5021,6 +5469,19 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-port-reachable": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+            "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -5071,6 +5532,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-string": {
@@ -5162,6 +5636,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/isarray": {
@@ -5835,6 +6322,13 @@
             "dev": true,
             "license": "CC0-1.0"
         },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -5867,6 +6361,49 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types": {
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "~1.33.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mime-types/node_modules/mime-db": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/mimic-fn": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+            "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/mimic-function": {
@@ -5968,6 +6505,16 @@
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "license": "MIT"
         },
+        "node_modules/negotiator": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/next": {
             "version": "15.5.18",
             "resolved": "https://registry.npmjs.org/next/-/next-15.5.18.tgz",
@@ -6045,6 +6592,19 @@
             "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
+            }
+        },
+        "node_modules/npm-run-path": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+            "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "path-key": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/number-to-words": {
@@ -6180,6 +6740,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=12.20.0"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/onetime": {
@@ -6318,6 +6888,13 @@
                 "node": ">=8"
             }
         },
+        "node_modules/path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+            "dev": true,
+            "license": "(WTFPL OR MIT)"
+        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6331,6 +6908,13 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "license": "MIT"
+        },
+        "node_modules/path-to-regexp": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+            "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/path-type": {
@@ -6444,6 +7028,53 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.60.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.60.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/polished": {
@@ -6597,6 +7228,42 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/rc": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+            "dev": true,
+            "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+            "dependencies": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+            },
+            "bin": {
+                "rc": "cli.js"
+            }
+        },
+        "node_modules/rc/node_modules/strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/react": {
             "version": "19.0.0",
@@ -6790,6 +7457,30 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/registry-auth-token": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+            "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/registry-url": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+            "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "rc": "^1.0.1"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/rehackt": {
@@ -6986,6 +7677,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
@@ -7049,6 +7761,95 @@
             "engines": {
                 "node": ">=10"
             }
+        },
+        "node_modules/serve": {
+            "version": "14.2.6",
+            "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+            "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@zeit/schemas": "2.36.0",
+                "ajv": "8.18.0",
+                "arg": "5.0.2",
+                "boxen": "7.0.0",
+                "chalk": "5.0.1",
+                "chalk-template": "0.4.0",
+                "clipboardy": "3.0.0",
+                "compression": "1.8.1",
+                "is-port-reachable": "4.0.0",
+                "serve-handler": "6.1.7",
+                "update-check": "1.5.4"
+            },
+            "bin": {
+                "serve": "build/main.js"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/serve-handler": {
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+            "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.0.0",
+                "content-disposition": "0.5.2",
+                "mime-types": "2.1.18",
+                "minimatch": "3.1.5",
+                "path-is-inside": "1.0.2",
+                "path-to-regexp": "3.3.0",
+                "range-parser": "1.2.0"
+            }
+        },
+        "node_modules/serve-handler/node_modules/bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/serve/node_modules/ajv": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/serve/node_modules/chalk": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+            "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.17.0 || ^14.13 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/serve/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
@@ -7535,6 +8336,16 @@
                 "node": ">=4"
             }
         },
+        "node_modules/strip-final-newline": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+            "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/strip-indent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -7834,6 +8645,19 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/type-fest": {
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+            "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=12.20"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -8003,6 +8827,17 @@
                 "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
             }
         },
+        "node_modules/update-check": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+            "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "registry-auth-token": "3.3.2",
+                "registry-url": "3.1.0"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8032,6 +8867,16 @@
             "license": "MIT",
             "bin": {
                 "uuid": "dist-node/bin/uuid"
+            }
+        },
+        "node_modules/vary": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
             }
         },
         "node_modules/vite": {
@@ -8365,6 +9210,40 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/widest-line": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+            "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "string-width": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/widest-line/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
         "test": "vitest run",
         "test:watch": "vitest",
         "test:ui": "vitest --ui",
+        "test:e2e": "playwright test --project=smoke",
+        "test:e2e:full": "playwright test",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "prepare": "simple-git-hooks",
@@ -55,6 +57,7 @@
         "uuid": "^14.0.0"
     },
     "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/lodash": "^4.17.20",
@@ -71,6 +74,7 @@
         "postcss": "^8.5.10",
         "prettier": "^3.8.3",
         "react-dnd-test-backend": "^16.0.1",
+        "serve": "^14.2.6",
         "simple-git-hooks": "^2.13.1",
         "typescript": "^5",
         "vitest": "^4.1.6"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,61 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Phasercraft E2E configuration (Phase 4, #309).
+//
+// The app is a Next 15 *static export* — `npm run build` emits the site to
+// `dist/`. We serve that built output with a plain static server and point
+// Playwright at it; there is no runtime Next server in production, so testing
+// the static export is the closest thing to "production" we can drive.
+//
+// Two test layers share this config, split by Playwright *project*:
+//   - `smoke`   : the fast pack that runs on every PR (Chromium only).
+//   - `firefox` / `webkit` : extra browser coverage for the nightly full run.
+// CI selects a project with `--project=<name>` (see .github/workflows/e2e.yml).
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? 3000);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${PORT}`;
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+    testDir: "./e2e",
+    // Fail the build on a stray `test.only` left in source on CI.
+    forbidOnly: isCI,
+    // The game boots a Phaser canvas and loads assets, so give specs headroom.
+    timeout: 60_000,
+    expect: { timeout: 15_000 },
+    // Flake guard on CI; locally a failure should fail fast for the author.
+    retries: isCI ? 2 : 0,
+    workers: isCI ? 1 : undefined,
+    reporter: isCI ? [["github"], ["html", { open: "never" }]] : [["list"]],
+    use: {
+        baseURL,
+        trace: "on-first-retry",
+        screenshot: "only-on-failure",
+        video: "retain-on-failure",
+    },
+    projects: [
+        {
+            name: "smoke",
+            use: { ...devices["Desktop Chrome"] },
+        },
+        // Nightly-only extra browser coverage. The smoke job runs `--project=smoke`
+        // so these never execute on PRs; the nightly job runs all projects.
+        {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"] },
+        },
+        {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"] },
+        },
+    ],
+    // Serve the static export. `serve` is a devDependency so CI is deterministic
+    // (no `npx` network fetch). `-s` enables SPA fallback; `-L` disables the
+    // request logger. Reuse an already-running server locally for fast reruns.
+    webServer: {
+        command: `npx serve dist -s -L -l ${PORT}`,
+        url: baseURL,
+        reuseExistingServer: !isCI,
+        timeout: 120_000,
+    },
+});


### PR DESCRIPTION
Part of #309. Implements the bullet: "Playwright: smoke pack on PR (game boots, character select, wave starts, save/load roundtrip); full suite nightly via scheduled workflow." Per the ROADMAP decisions log: **smoke E2E on every PR; full E2E nightly.**

## What this adds

- `@playwright/test` and `serve` as devDependencies.
- `playwright.config.ts` at repo root — test dir `e2e/`, a `webServer` that serves the static export (`npx serve dist -s -l 3000`) with `baseURL` pointed at it (reuses an existing local server). Projects: `smoke` (Chromium), `firefox`, `webkit`. CI-aware retries (2), single worker, `github` + `html` reporters, trace/screenshot/video on failure.
- `e2e/smoke.spec.ts` + `e2e/helpers.ts` — the smoke pack, driving the **React UI overlay (DOM)** and `localStorage` only (see below).
- `.github/workflows/e2e.yml` — smoke on PR/push, full nightly + dispatch.
- `package.json` scripts: `test:e2e` (smoke), `test:e2e:full` (all browsers).
- gitignore/prettierignore entries for Playwright artifacts.

## Smoke flows: implemented vs deferred

The game is a Phaser `<canvas>` with a React/Redux overlay on top. Canvas internals are not queryable from the DOM, so every assertion drives the overlay (visible text, buttons, container ids) or `localStorage` (the save service's backing store, `src/services/saveStorage.ts`).

- **game boots** — implemented. Asserts `#phaser-game` mounts, Phaser injects a `<canvas>`, and the initial "Pick a Game Save" overlay renders (`#pick-a-game-save`, "Slot 1" heading). The overlay appears because `LoadScene.create()` dispatches `toggleUi("save")` once the scene boots.
- **character select** — implemented. From the save menu, clicks "Select" on an empty slot → asserts the "Character Select" menu (`#character-select`) and a button per class (Cleric/Mage/Occultist/Ranger/Warrior) → clicks "Warrior" → asserts the overlay tears down (`selectCharacter` sets `showUi:false`) and the canvas remains (the run begins).
- **save/load roundtrip** — implemented. Seeds a save into `localStorage` (exact shape `writeSave` persists: Redux root state under `.game`) before load, reloads, asserts the slot surfaces the persisted "Wave: N"/"Gold: N", clicks "Load" (dispatches `loadGame` + `selectCharacter`, overlay closes), and asserts the stored save is intact after the roundtrip.
- **wave starts** — **deferred with `test.fixme` + inline rationale.** The wave readout ("Wave: N") is drawn by a Phaser `GameObjects.Text` on the canvas (`src/entities/UI/HUD.ts`); the React HUD overlay shows only level info, not the wave, and the Redux store is not exposed on `window`. So there is no DOM node carrying the wave value to assert against headlessly. Reaching it would require a production hook (a DOM mirror of `state.game.wave`, or a window-exposed store), which is out of scope for a test-only PR — the save/load roundtrip exercises the wave *value* through the save service as a proxy in the meantime.

## CI workflow design (`e2e.yml`)

- **smoke** job — `if: github.event_name != 'schedule'`, runs on `pull_request` and push to `main`: checkout → setup Node from `.nvmrc` → `npm ci` → `npx playwright install --with-deps chromium` → `npm run build` → `npm run test:e2e` (Chromium smoke project) → upload report artifact.
- **full** job — `if: schedule || workflow_dispatch`, daily cron (`17 3 * * *`) + manual: same setup, installs all browsers, runs `npm run test:e2e:full` across Chromium/Firefox/WebKit → upload report.
- The existing `ci.yml` (the five quality gates) is **not modified**.

## Production files touched

**None.** This PR is test-only — no `data-testid` hooks were needed because existing roles/visible text/container ids (`#phaser-game`, `#pick-a-game-save`, `#character-select`, real `<button>` labels) gave stable selectors. The deferred wave test documents the one place a production hook *would* be required (and is intentionally not added here).

## Could I run the browser locally?

**No** — the sandbox blocks the Playwright browser download (`cdn.playwright.dev` returns 403, "Host not in allowlist"). I validated everything reachable without a browser:
- `npx playwright test --list` resolves the config and all specs (4 smoke entries: 3 active + 1 fixme).
- The smoke run reaches `browserType.launch` and fails *only* with "Executable doesn't exist" — i.e. the `webServer` starts, the config loads, and the specs compile; only the browser binary is missing. The `e2e.yml` workflow installs it via `npx playwright install --with-deps chromium`, so CI will exercise the real flows.

If any selector turns out to be flaky against the actual boot timing in CI, I'll tune waits in a follow-up — the config already grants generous timeouts (60s test, 15s expect, 120s webServer) and 2 retries on CI.

## Test evidence (five gates, run locally after `npm ci`)

- `npm run typecheck` — pass
- `npm run lint` — pass ("No ESLint warnings or errors")
- `npm test` (Vitest) — pass, **20 files / 191 tests, unchanged** (e2e specs are under `e2e/` and not collected by Vitest, whose `include` is `src/**`)
- `npm run format:check` — pass ("All matched files use Prettier code style")
- `npm run build` — pass (static export to `dist/`)

## Notes for the reviewer

This PR changes CI/process. It is additive (new `e2e.yml`, untouched `ci.yml`). The one judgment call worth a look is the deferred **wave** test: I chose `test.fixme` + a documented rationale over shipping a flaky/failing test or adding an unflagged production hook. Happy to follow up with a minimal, clearly-flagged hook if you'd prefer the wave flow covered now.

https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLay8FkYhiRJGhNjVa7r4F)_