### PR TITLE
Replace styled-jsx with CSS Modules across the UI

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,6 +84,16 @@ optimisation). Removing it eliminates framework overhead, browser-compatibility 
 hacks, and the pending Next 16 upgrade. Do this after Phase 4 so the test suite validates
 the build switch, and before Phase 6 so Vercel gets a clean Vite static deploy.
 
+Prerequisite (split out as its own PR, agreed 2026-06-17): the UI used `styled-jsx`
+(`<style jsx>`) in 30 components — a Next.js-coupled feature with no automatic transform
+under Vite + `@vitejs/plugin-react@6` (Rolldown/oxc dropped the `babel` option). Rather
+than add a Babel toolchain, `styled-jsx` was removed in favour of **CSS Modules** (Vite
+native, zero new deps): static rules in `*.module.css`, per-render values passed as CSS
+custom properties via inline `style`, shared `pixel_*` mixins ported to `themes.module.css`.
+Done on the current Next.js build first so visual parity is validated against a known-good
+stack; the Vite switch below then carries no styling risk.
+
+- [x] Remove `styled-jsx` → CSS Modules across all 30 UI components (prerequisite PR)
 - [ ] Add `vite.config.ts`: carry over path aliases from `tsconfig.json`; add `resolve.alias` stubs for Node built-ins Phaser requires (`fs`, `crypto`, `path` → `false`); set `base` from `VITE_BASE_URL` env var (empty for Vercel, `/phasercraft/` for GitHub Pages during transition)
 - [ ] Add `index.html` entry point; move page title/meta out of Next.js Metadata API into plain `<meta>` tags
 - [ ] Replace `next/font/google` (VT323) with a `<link>` tag in `index.html`

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -30,13 +30,14 @@ test.describe("Phasercraft smoke", () => {
         await expect(canvas).toBeAttached();
 
         // LoadScene.create() opens the "Pick a Game Save" overlay once the scene
-        // boots and preload completes. We key off the menu shell (.menu-container,
-        // rendered only while a menu is open) plus the save-slot headings rather
+        // boots and preload completes. We key off the menu shell
+        // ([data-testid="menu-container"], rendered only while a menu is open) plus
+        // the save-slot headings rather
         // than the menu's derived id: UI.tsx builds the id with
         // `title.toLowerCase().replace(" ", "-")`, and String.replace swaps only
         // the FIRST space, so "Pick a Game Save" yields the id "pick-a game save"
         // (a pre-existing quirk). Visible text / slot headings are the stable hook.
-        await expect(page.locator(".menu-container")).toBeVisible();
+        await expect(page.locator('[data-testid="menu-container"]')).toBeVisible();
         // Three save slots render with "Slot 1".."Slot 3" headings.
         await expect(page.getByRole("heading", { name: "Slot 1" })).toBeVisible();
     });
@@ -51,7 +52,7 @@ test.describe("Phasercraft smoke", () => {
         // From the save menu, an empty slot's "Select" button opens character select.
         // (The save menu's derived id contains a space — see Flow 1 — so key off the
         // menu shell and the Select button instead.)
-        await expect(page.locator(".menu-container")).toBeVisible();
+        await expect(page.locator('[data-testid="menu-container"]')).toBeVisible();
         await page.getByRole("button", { name: "Select" }).first().click();
 
         // The Character Select menu renders ("Character Select" has a single space,
@@ -66,7 +67,7 @@ test.describe("Phasercraft smoke", () => {
         // UI overlay (header + menu container) is torn down and the run view shows.
         await page.getByRole("button", { name: "Warrior", exact: true }).click();
         await expect(page.locator("#character-select")).toBeHidden();
-        await expect(page.locator(".menu-container")).toHaveCount(0);
+        await expect(page.locator('[data-testid="menu-container"]')).toHaveCount(0);
         // The game canvas is still present underneath — we're now in the run.
         await expect(page.locator("#phaser-game canvas")).toBeAttached();
     });
@@ -106,7 +107,7 @@ test.describe("Phasercraft smoke", () => {
         // slot renders the saved character plus a "Load" button (empty slots show
         // "Select"), so no extra navigation is needed. Key off the menu shell (the
         // save menu's derived id contains a space — see Flow 1).
-        await expect(page.locator(".menu-container")).toBeVisible();
+        await expect(page.locator('[data-testid="menu-container"]')).toBeVisible();
 
         // The seeded slot surfaces the persisted wave/coins straight from the
         // save service — proof the localStorage roundtrip survived a fresh load.
@@ -117,7 +118,7 @@ test.describe("Phasercraft smoke", () => {
         // overlay (showUi:false) and drops us into the restored run.
         await page.getByRole("button", { name: "Load" }).first().click();
         // The overlay tears down (showUi:false) — no menu shell remains.
-        await expect(page.locator(".menu-container")).toHaveCount(0);
+        await expect(page.locator('[data-testid="menu-container"]')).toHaveCount(0);
 
         // And the underlying localStorage save is unchanged after the roundtrip.
         const persisted = await page.evaluate((key) => window.localStorage.getItem(key), slot);

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -28,43 +28,16 @@ const PhaserGameWithoutSSR = dynamic(() => import("../PhaserGame"), { ssr: false
 // prerendered on the server during the initial page load.
 export default function Home() {
     return (
-        <>
-            <ApolloProvider client={client}>
-                <Provider store={store}>
-                    <DndProvider
-                        backend={TouchBackend}
-                        options={{ enableMouseEvents: true, preview: true }}
-                    >
-                        <UI />
-                        <PhaserGameWithoutSSR />
-                    </DndProvider>
-                </Provider>
-            </ApolloProvider>
-
-            <style jsx global>{`
-                @import url("https://fonts.googleapis.com/css?family=VT323&display=swap");
-
-                body {
-                    margin: 0;
-                    font-size: 14px;
-                    font-family: "VT323", monospace;
-                }
-
-                button {
-                    font-family: "VT323", monospace;
-                    font-weight: bold;
-                }
-
-                h1,
-                h2,
-                h3,
-                h4,
-                h5,
-                h6 {
-                    margin-bottom: 0.5em;
-                    margin-top: 0;
-                }
-            `}</style>
-        </>
+        <ApolloProvider client={client}>
+            <Provider store={store}>
+                <DndProvider
+                    backend={TouchBackend}
+                    options={{ enableMouseEvents: true, preview: true }}
+                >
+                    <UI />
+                    <PhaserGameWithoutSSR />
+                </DndProvider>
+            </Provider>
+        </ApolloProvider>
     );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { VT323 } from "next/font/google";
+import "../styles/globals.css";
 
 const vt323 = VT323({ weight: "400", subsets: ["latin"] });
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,14 +1,19 @@
+/*
+ * Global app styles. These used to live in a `<style jsx global>` block in
+ * src/app/home.tsx; they are imported from src/app/layout.tsx now. The VT323
+ * @import is retained from that block so plain elements (e.g. <button>) keep the
+ * font — next/font applies VT323 via a className that only reaches <body>.
+ */
+@import url("https://fonts.googleapis.com/css?family=VT323&display=swap");
+
 body {
     margin: 0;
     font-size: 14px;
-}
-
-body,
-button {
     font-family: "VT323", monospace;
 }
 
 button {
+    font-family: "VT323", monospace;
     font-weight: bold;
 }
 

--- a/src/ui/UI.module.css
+++ b/src/ui/UI.module.css
@@ -1,0 +1,21 @@
+.uiContainer {
+    position: absolute;
+    width: 100vw;
+    height: 100vh;
+    pointer-events: none;
+}
+
+.uiMain {
+    box-sizing: border-box;
+    height: 100%;
+    padding: 1em;
+    width: 100%;
+    pointer-events: all;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+}
+
+.headerContainer {
+    margin-bottom: 14px;
+}

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -1,6 +1,8 @@
 import React, { createContext } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { pixel_background } from "@ui/themes";
+import { pixelBackgroundVars } from "@ui/themes";
+import theme from "@ui/themes.module.css";
+import styles from "./UI.module.css";
 import { toggleUi } from "@store/gameReducer";
 import Arcanum from "@components/Arcanum";
 import Armory from "@components/Armory";
@@ -89,18 +91,25 @@ const UI: React.FC = () => {
 
     // Use specified menu other use equipment as default
     const CurrentMenu = menu ? config[menu] : config.equipment;
+    const isSystem = menu === "system";
 
     return (
-        <div className="ui-container">
+        <div className={styles.uiContainer}>
             {showHUD && <HUD />}
             {showUi && (
-                <div className="ui-main">
-                    <div className="header-container">
+                <div className={styles.uiMain}>
+                    <div className={styles.headerContainer}>
                         <Header config={CurrentMenu} toggleUi={handleToggleUi} />
                     </div>
                     <div
                         id={CurrentMenu.title.toLowerCase().replace(" ", "-")}
-                        className="menu-container"
+                        className={isSystem ? undefined : theme.pixelBackground}
+                        style={{
+                            ...(isSystem ? {} : pixelBackgroundVars()),
+                            margin: "0 auto",
+                            padding: "calc(1em + 6px) 1em 1em",
+                            width: isSystem ? "200px" : "100%",
+                        }}
                     >
                         <CustomDragLayer />
                         <MenuContext.Provider value={menu || "equipment"}>
@@ -109,36 +118,6 @@ const UI: React.FC = () => {
                     </div>
                 </div>
             )}
-            <style jsx>{`
-                .ui-container {
-                    position: absolute;
-                    width: 100vw;
-                    height: 100vh;
-                    pointer-events: none;
-                }
-
-                .ui-main {
-                    box-sizing: border-box;
-                    height: 100%;
-                    padding: 1em;
-                    width: 100%;
-                    pointer-events: all;
-                    background: rgba(0, 0, 0, 0.5);
-                    display: flex;
-                    flex-direction: column;
-                }
-
-                .header-container {
-                    margin-bottom: 14px;
-                }
-
-                .menu-container {
-                    ${menu === "system" ? "" : pixel_background()}
-                    margin: 0 auto;
-                    padding: calc(1em + 6px) 1em 1em;
-                    width: ${menu === "system" ? "200px" : "100%"};
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -103,6 +103,7 @@ const UI: React.FC = () => {
                     </div>
                     <div
                         id={CurrentMenu.title.toLowerCase().replace(" ", "-")}
+                        data-testid="menu-container"
                         className={isSystem ? undefined : theme.pixelBackground}
                         style={{
                             ...(isSystem ? {} : pixelBackgroundVars()),

--- a/src/ui/components/atoms/Attribute.module.css
+++ b/src/ui/components/atoms/Attribute.module.css
@@ -1,0 +1,15 @@
+.label {
+    clear: left;
+    float: left;
+    margin-right: 0.5rem;
+    text-align: left;
+    text-transform: capitalize;
+    white-space: nowrap;
+}
+
+.value {
+    overflow: hidden;
+    text-align: right;
+    margin-left: 0;
+    color: var(--attribute-color);
+}

--- a/src/ui/components/atoms/Attribute.tsx
+++ b/src/ui/components/atoms/Attribute.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import round from "lodash/round";
+import styles from "./Attribute.module.css";
 
 interface AttributeProps {
     delimeter?: string;
@@ -16,29 +17,16 @@ const Attribute: React.FC<AttributeProps> = ({ delimeter = ":", label, value, po
 
     return (
         <>
-            <dt className="attribute-label">
+            <dt className={styles.label}>
                 {label}
                 {delimeter}
             </dt>
-            <dd className="attribute-value">{round(value, 2)}</dd>
-
-            <style jsx>{`
-                .attribute-label {
-                    clear: left;
-                    float: left;
-                    margin-right: 0.5rem;
-                    text-align: left;
-                    text-transform: capitalize;
-                    white-space: nowrap;
-                }
-
-                .attribute-value {
-                    overflow: hidden;
-                    text-align: right;
-                    margin-left: 0;
-                    color: ${getColor()};
-                }
-            `}</style>
+            <dd
+                className={styles.value}
+                style={{ "--attribute-color": getColor() } as React.CSSProperties}
+            >
+                {round(value, 2)}
+            </dd>
         </>
     );
 };

--- a/src/ui/components/atoms/Button.module.css
+++ b/src/ui/components/atoms/Button.module.css
@@ -1,0 +1,28 @@
+.button {
+    display: inline-block;
+    padding: 0 0.75rem;
+    height: 1.5em;
+    border: none;
+    outline: none;
+    font-weight: bold;
+    border-radius: 3px;
+    margin-bottom: 0.5rem;
+    width: 100%;
+    background-color: var(--btn-bg);
+    border-bottom: 2px solid var(--btn-bg-dark);
+    color: var(--btn-fg);
+    font-size: var(--btn-size);
+    box-shadow: var(--btn-shadow);
+    text-shadow: 0 1px var(--btn-text-shadow);
+}
+
+.button:active {
+    transform: translateY(0.125rem);
+    box-shadow: none;
+}
+
+.button:disabled {
+    color: var(--btn-disabled-color);
+    background-color: grey;
+    border-color: var(--btn-disabled-color);
+}

--- a/src/ui/components/atoms/Button.tsx
+++ b/src/ui/components/atoms/Button.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { darken, grayscale } from "polished";
+import styles from "./Button.module.css";
 
 interface ButtonProps {
     disabled?: boolean;
@@ -25,43 +26,22 @@ const Button: React.FC<ButtonProps> = (props) => {
     } = props;
 
     const state_color = on ? "lime" : bg_color;
+    const dark = darken(0.3, state_color);
+    const grayDark = grayscale(dark);
+
+    const style = {
+        "--btn-bg": state_color,
+        "--btn-bg-dark": dark,
+        "--btn-fg": color,
+        "--btn-size": `${size}em`,
+        "--btn-shadow": disabled ? `0 3px 0px ${grayDark}` : `0 3px 0px ${dark}`,
+        "--btn-text-shadow": text_shadow_color,
+        "--btn-disabled-color": grayDark,
+    } as React.CSSProperties;
 
     return (
-        <button disabled={disabled} onClick={onClick}>
+        <button className={styles.button} style={style} disabled={disabled} onClick={onClick}>
             {text}
-
-            <style jsx>{`
-                button {
-                    display: inline-block;
-                    padding: 0 0.75rem;
-                    height: 1.5em;
-                    border: none;
-                    outline: none;
-                    font-weight: bold;
-                    border-radius: 3px;
-                    margin-bottom: 0.5rem;
-                    width: 100%;
-                    background-color: ${state_color};
-                    border-bottom: 2px solid ${darken(0.3, state_color)};
-                    color: ${color};
-                    font-size: ${size}em;
-                    box-shadow: ${disabled
-                        ? `0 3px 0px ${grayscale(darken(0.3, state_color))}`
-                        : `0 3px 0px ${darken(0.3, state_color)}`};
-                    text-shadow: 0 1px ${text_shadow_color};
-                }
-
-                button:active {
-                    transform: translateY(0.125rem);
-                    box-shadow: none;
-                }
-
-                button:disabled {
-                    color: ${grayscale(darken(0.3, state_color))};
-                    background-color: grey;
-                    border-color: ${grayscale(darken(0.3, state_color))};
-                }
-            `}</style>
         </button>
     );
 };

--- a/src/ui/components/atoms/DroppableSlot.module.css
+++ b/src/ui/components/atoms/DroppableSlot.module.css
@@ -1,0 +1,3 @@
+.droppableSlot {
+    text-transform: capitalize;
+}

--- a/src/ui/components/atoms/DroppableSlot.test.tsx
+++ b/src/ui/components/atoms/DroppableSlot.test.tsx
@@ -20,15 +20,15 @@ const helm: LootItem = {
 describe("DroppableSlot", () => {
     it("registers as a react-dnd drop target without an equipped item", () => {
         const { container } = renderWithProviders(<DroppableSlot slot="helm" loot={null} />);
-        const slot = container.querySelector(".droppable-slot");
+        const slot = container.querySelector(`[data-testid="droppable-slot"]`);
         expect(slot).toBeInTheDocument();
         // Empty slot renders no loot icon.
-        expect(container.querySelector(".styled-loot-icon")).not.toBeInTheDocument();
+        expect(container.querySelector(`img[alt="Loot!"]`)).not.toBeInTheDocument();
     });
 
     it("renders the equipped item's icon when a loot item is provided", () => {
         const { container } = renderWithProviders(<DroppableSlot slot="helm" loot={helm} />);
-        const icon = container.querySelector(".styled-loot-icon");
+        const icon = container.querySelector(`img[alt="Loot!"]`);
         expect(icon).toBeInTheDocument();
         expect(icon).toHaveAttribute("src", "graphics/images/loot/helmet/iron-helm.png");
     });
@@ -44,7 +44,7 @@ describe("DroppableSlot", () => {
             }
         );
 
-        const slot = container.querySelector(".droppable-slot") as HTMLElement;
+        const slot = container.querySelector(`[data-testid="droppable-slot"]`) as HTMLElement;
         fireEvent.click(slot);
 
         const state = store.getState().game;
@@ -56,7 +56,7 @@ describe("DroppableSlot", () => {
     it("does nothing when an empty slot is clicked", () => {
         const { store, container } = renderWithProviders(<DroppableSlot slot="helm" loot={null} />);
         const before = store.getState().game;
-        const slot = container.querySelector(".droppable-slot") as HTMLElement;
+        const slot = container.querySelector(`[data-testid="droppable-slot"]`) as HTMLElement;
         fireEvent.click(slot);
         expect(store.getState().game).toEqual(before);
         // Sanity: an unrelated query confirms nothing rendered/changed.

--- a/src/ui/components/atoms/DroppableSlot.tsx
+++ b/src/ui/components/atoms/DroppableSlot.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 
 import Loot from "@components/Loot";
-import { pixel_emboss } from "@ui/themes";
+import { pixelEmbossVars } from "@ui/themes";
+import theme from "@ui/themes.module.css";
 import { useDrop } from "react-dnd";
 import { connect } from "react-redux";
 import { unequipLoot } from "@store/gameReducer";
 import type { LootItem } from "@/types/game";
+import styles from "./DroppableSlot.module.css";
 
 interface DroppableSlotProps {
     loot?: LootItem | null;
@@ -32,17 +34,12 @@ const DroppableSlot: React.FC<DroppableSlotProps> = ({ loot, slot, unequipLoot }
             ref={(node) => {
                 drop(node);
             }}
-            className={"droppable-slot"}
+            className={`${theme.pixelEmboss} ${styles.droppableSlot}`}
+            style={pixelEmbossVars({ rgb, a })}
+            data-testid="droppable-slot"
             onClick={() => loot && unequipLoot(loot)}
         >
             {loot && <Loot loot={loot} />}
-
-            <style jsx>{`
-                .droppable-slot {
-                    ${pixel_emboss({ rgb: rgb, a: a })}
-                    text-transform: capitalize;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/atoms/LootIcon.module.css
+++ b/src/ui/components/atoms/LootIcon.module.css
@@ -1,0 +1,6 @@
+.styledLootIcon {
+    border: 2px solid var(--loot-border);
+    border-radius: 0.25rem;
+    padding: 0.25rem;
+    background-color: white;
+}

--- a/src/ui/components/atoms/LootIcon.tsx
+++ b/src/ui/components/atoms/LootIcon.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import iconStyles from "./LootIcon.module.css";
 
 interface LootIconStyles {
     width?: number;
@@ -14,29 +15,30 @@ interface LootIconProps {
 }
 
 const LootIcon: React.FC<LootIconProps> = ({ category, color, icon, selected, styles = {} }) => {
-    // Parse the override style if provided
-    const overrideProperty = styles.override?.split(":")[0];
-    const overrideValue = styles.override?.split(":")[1];
+    // The optional `override` is a raw "property: value" CSS declaration with a
+    // dynamic property *name*, so it can't be a CSS variable — parse it into an
+    // inline style entry (camel-casing the property for React).
+    const overrideStyle: React.CSSProperties = {};
+    if (styles.override) {
+        const [prop, ...rest] = styles.override.split(":");
+        const value = rest.join(":").replace(/;/g, "").trim();
+        const camel = prop.trim().replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+        (overrideStyle as Record<string, string>)[camel] = value;
+    }
 
     return (
-        <>
-            <img
-                className="styled-loot-icon"
-                src={`graphics/images/loot/${category}/${icon}.png`}
-                alt="Loot!"
-            />
-
-            <style jsx>{`
-                .styled-loot-icon {
-                    border: 2px solid ${selected ? "red" : color};
-                    border-radius: 0.25rem;
-                    padding: 0.25rem;
-                    background-color: white;
-                    width: ${styles.width || 24}px;
-                    ${overrideProperty ? `${overrideProperty}: ${overrideValue};` : ""}
-                }
-            `}</style>
-        </>
+        <img
+            className={iconStyles.styledLootIcon}
+            src={`graphics/images/loot/${category}/${icon}.png`}
+            alt="Loot!"
+            style={
+                {
+                    "--loot-border": selected ? "red" : color,
+                    width: `${styles.width || 24}px`,
+                    ...overrideStyle,
+                } as React.CSSProperties
+            }
+        />
     );
 };
 

--- a/src/ui/components/atoms/Price.module.css
+++ b/src/ui/components/atoms/Price.module.css
@@ -1,0 +1,13 @@
+.priceContainer {
+    background-color: rgba(255, 255, 255, 0.95);
+    border: 4px solid var(--price-color);
+    border-radius: 0.125rem;
+    font-size: 1.125rem;
+    padding: 0.25rem 0.5rem;
+    white-space: nowrap;
+}
+
+.priceIcon {
+    width: 0.5rem;
+    display: inline-block;
+}

--- a/src/ui/components/atoms/Price.tsx
+++ b/src/ui/components/atoms/Price.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { MenuContext } from "@ui/UI";
+import styles from "./Price.module.css";
 
 interface PriceProps {
     cost: number;
@@ -22,23 +23,12 @@ const Price: React.FC<PriceProps> = ({ cost }) => {
               };
 
     return (
-        <div className="price-container">
-            <img className="price-icon" src={`./UI/icons/${icon}.gif`} alt="Item cost:" /> {value}
-            <style jsx>{`
-                .price-container {
-                    background-color: rgba(255, 255, 255, 0.95);
-                    border: 4px solid ${color};
-                    border-radius: 0.125rem;
-                    font-size: 1.125rem;
-                    padding: 0.25rem 0.5rem;
-                    white-space: nowrap;
-                }
-
-                .price-icon {
-                    width: 0.5rem;
-                    display: inline-block;
-                }
-            `}</style>
+        <div
+            className={styles.priceContainer}
+            style={{ "--price-color": color } as React.CSSProperties}
+        >
+            <img className={styles.priceIcon} src={`./UI/icons/${icon}.gif`} alt="Item cost:" />{" "}
+            {value}
         </div>
     );
 };

--- a/src/ui/components/atoms/Slot.module.css
+++ b/src/ui/components/atoms/Slot.module.css
@@ -1,0 +1,12 @@
+.capitalize {
+    text-transform: capitalize;
+}
+
+.pixelEmboss {
+    background: rgba(0, 0, 0, 0.1);
+    border-top: 6px solid rgba(0, 0, 0, 0.1);
+    box-shadow: 0 -6px 0 rgba(0, 0, 0, 0.3);
+    margin: 6px;
+    text-align: center;
+    position: relative;
+}

--- a/src/ui/components/atoms/Slot.tsx
+++ b/src/ui/components/atoms/Slot.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import type { LootItem } from "@/types/game";
+import styles from "./Slot.module.css";
 
 interface SlotComponentProps {
     loot: LootItem;
@@ -18,26 +19,9 @@ const Slot: React.FC<SlotProps> = ({ loot, component, background, compare }) => 
     const Component = component;
 
     return (
-        <>
-            <div className={`capitalize ${background ? "pixel-emboss" : ""}`}>
-                {loot && <Component loot={loot} compare={compare} />}
-            </div>
-
-            <style jsx>{`
-                .capitalize {
-                    text-transform: capitalize;
-                }
-
-                .pixel-emboss {
-                    background: rgba(0, 0, 0, 0.1);
-                    border-top: 6px solid rgba(0, 0, 0, 0.1);
-                    box-shadow: 0 -6px 0 rgba(0, 0, 0, 0.3);
-                    margin: 6px;
-                    text-align: center;
-                    position: relative;
-                }
-            `}</style>
-        </>
+        <div className={`${styles.capitalize} ${background ? styles.pixelEmboss : ""}`}>
+            {loot && <Component loot={loot} compare={compare} />}
+        </div>
     );
 };
 

--- a/src/ui/components/atoms/Stat.module.css
+++ b/src/ui/components/atoms/Stat.module.css
@@ -1,0 +1,15 @@
+.label {
+    clear: left;
+    float: left;
+    margin-right: 0.5rem;
+    text-align: left;
+    text-transform: capitalize;
+    white-space: nowrap;
+}
+
+.value {
+    overflow: hidden;
+    text-align: right;
+    margin-left: 0;
+    color: var(--stat-color);
+}

--- a/src/ui/components/atoms/Stat.tsx
+++ b/src/ui/components/atoms/Stat.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import round from "lodash/round";
+import styles from "./Stat.module.css";
 
 interface StatProps {
     delimeter?: string;
@@ -24,29 +25,16 @@ const Stat: React.FC<StatProps> = ({ delimeter = ":", label, value, polarity }) 
 
     return (
         <>
-            <dt className="stat-label">
+            <dt className={styles.label}>
                 {label}
                 {delimeter}
             </dt>
-            <dd className="stat-value">{formatValue()}</dd>
-
-            <style jsx>{`
-                .stat-label {
-                    clear: left;
-                    float: left;
-                    margin-right: 0.5rem;
-                    text-align: left;
-                    text-transform: capitalize;
-                    white-space: nowrap;
-                }
-
-                .stat-value {
-                    overflow: hidden;
-                    text-align: right;
-                    margin-left: 0;
-                    color: ${getColor()};
-                }
-            `}</style>
+            <dd
+                className={styles.value}
+                style={{ "--stat-color": getColor() } as React.CSSProperties}
+            >
+                {formatValue()}
+            </dd>
         </>
     );
 };

--- a/src/ui/components/atoms/Title.tsx
+++ b/src/ui/components/atoms/Title.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { pixel_background } from "../../themes";
+import { pixelBackgroundVars } from "@ui/themes";
+import theme from "@ui/themes.module.css";
 
 interface TitleProps {
     text: string;
@@ -7,17 +8,16 @@ interface TitleProps {
 
 const Title: React.FC<TitleProps> = ({ text }) => {
     return (
-        <h1 className="title">
+        <h1
+            className={theme.pixelBackground}
+            style={{
+                ...pixelBackgroundVars({ bg_color: "#44bff7" }),
+                color: "white",
+                float: "left",
+                marginRight: "1em",
+            }}
+        >
             {text}
-
-            <style jsx>{`
-                .title {
-                    ${pixel_background({ bg_color: "#44bff7" })}
-                    color: white;
-                    float: left;
-                    margin-right: 1em;
-                }
-            `}</style>
         </h1>
     );
 };

--- a/src/ui/components/molecules/Attributes.module.css
+++ b/src/ui/components/molecules/Attributes.module.css
@@ -1,0 +1,6 @@
+.attributesList {
+    clear: both;
+    overflow: hidden;
+    margin: 0;
+    width: var(--attributes-width, auto);
+}

--- a/src/ui/components/molecules/Attributes.tsx
+++ b/src/ui/components/molecules/Attributes.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Attribute from "@components/Attribute";
 
 import { v4 as uuid } from "uuid";
+import listStyles from "./Attributes.module.css";
 
 interface AttributesStyles {
     width?: string;
@@ -14,21 +15,15 @@ interface AttributesProps {
 
 const Attributes: React.FC<AttributesProps> = ({ children: stats, styles = {} }) => {
     return (
-        <dl className="attributes-list">
+        <dl
+            className={listStyles.attributesList}
+            style={{ "--attributes-width": styles.width || "auto" } as React.CSSProperties}
+        >
             {Object.entries(stats).map((stat, i) => {
                 return (
                     <Attribute key={uuid()} value={stat[1]} label={stat[0].split("_").join(" ")} />
                 );
             })}
-
-            <style jsx>{`
-                .attributes-list {
-                    clear: both;
-                    overflow: hidden;
-                    margin: 0;
-                    width: ${styles.width || "auto"};
-                }
-            `}</style>
         </dl>
     );
 };

--- a/src/ui/components/molecules/CharacterCard.module.css
+++ b/src/ui/components/molecules/CharacterCard.module.css
@@ -1,0 +1,16 @@
+.characterListItem {
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.characterListItem:first-child {
+    padding-left: 0;
+}
+
+.characterListItem:last-child {
+    padding-right: 0;
+}
+
+.characterImage {
+    padding-bottom: 0.5rem;
+}

--- a/src/ui/components/molecules/CharacterCard.tsx
+++ b/src/ui/components/molecules/CharacterCard.tsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import type { PlayerName } from "@entities/Player/AssignClass";
 
 import Button from "../atoms/Button";
+import styles from "./CharacterCard.module.css";
 
 interface CharacterCardProps {
     // Injected by `connect`'s mapDispatchToProps; dispatches the selectCharacter action.
@@ -13,32 +14,13 @@ interface CharacterCardProps {
 
 const CharacterCard: React.FC<CharacterCardProps> = ({ selectCharacter, type }) => {
     return (
-        <li className="character-list-item">
+        <li className={styles.characterListItem}>
             <img
-                className="character-image"
+                className={styles.characterImage}
                 src={`UI/player/${type.toLowerCase()}.gif`}
                 alt={`Choose the ${type} class.`}
             />
             <Button text={type} onClick={() => selectCharacter(type)} />
-
-            <style jsx>{`
-                .character-list-item {
-                    padding: 0.5rem;
-                    text-align: center;
-                }
-
-                .character-list-item:first-child {
-                    padding-left: 0;
-                }
-
-                .character-list-item:last-child {
-                    padding-right: 0;
-                }
-
-                .character-image {
-                    padding-bottom: 0.5rem;
-                }
-            `}</style>
         </li>
     );
 };

--- a/src/ui/components/molecules/DetailedLoot.module.css
+++ b/src/ui/components/molecules/DetailedLoot.module.css
@@ -1,0 +1,8 @@
+.detailedLootContainer {
+    display: flex;
+    align-items: flex-start;
+    background-color: white;
+    padding: 0.25rem;
+    border: 2px solid #1f2937;
+    border-radius: 0.25rem;
+}

--- a/src/ui/components/molecules/DetailedLoot.tsx
+++ b/src/ui/components/molecules/DetailedLoot.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import LootIcon from "@components/LootIcon";
 import Stats from "@components/Stats";
 import type { LootItem } from "@/types/game";
+import styles from "./DetailedLoot.module.css";
 
 interface DetailedLootProps {
     id: string;
@@ -12,7 +13,7 @@ interface DetailedLootProps {
 
 const DetailedLoot: React.FC<DetailedLootProps> = ({ id, loot, compare }) => {
     return (
-        <div className="detailed-loot-container">
+        <div className={styles.detailedLootContainer}>
             <LootIcon
                 category={loot.category || "default"}
                 color={loot.color || "#000"}
@@ -20,17 +21,6 @@ const DetailedLoot: React.FC<DetailedLootProps> = ({ id, loot, compare }) => {
                 styles={{ width: 16, override: "margin-right:0.5em;" }}
             />
             <Stats styles={{ width: "100%" }}>{loot.stats}</Stats>
-
-            <style jsx>{`
-                .detailed-loot-container {
-                    display: flex;
-                    align-items: flex-start;
-                    background-color: white;
-                    padding: 0.25rem;
-                    border: 2px solid #1f2937;
-                    border-radius: 0.25rem;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/molecules/Health.module.css
+++ b/src/ui/components/molecules/Health.module.css
@@ -1,0 +1,24 @@
+.healthBar {
+    border: 4px solid black;
+    background-color: red;
+    margin-bottom: 0;
+    overflow: hidden;
+    padding: 0.25em;
+    position: relative;
+}
+
+.healthBar::after {
+    position: absolute;
+    border-bottom: 2px solid rgba(0, 0, 0, 0.2);
+    border-right: 2px solid rgba(0, 0, 0, 0.2);
+    bottom: 0;
+    content: "";
+    left: 0;
+    right: 0;
+    top: 0;
+}
+
+.healthRegen {
+    float: left;
+    margin-top: 0;
+}

--- a/src/ui/components/molecules/Health.tsx
+++ b/src/ui/components/molecules/Health.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Stat from "@components/Stat";
+import styles from "./Health.module.css";
 
 interface HealthStats {
     health_max: number;
@@ -17,36 +18,12 @@ const Health: React.FC<HealthProps> = ({ stats }) => {
 
     return (
         <>
-            <dl className="health-bar">
+            <dl className={styles.healthBar}>
                 <Stat label={"HP"} value={health_max} />
             </dl>
-            <dl className="health-regen">
+            <dl className={styles.healthRegen}>
                 <Stat label="Regen" delimeter={" "} value={regen} />
             </dl>
-            <style jsx>{`
-                .health-bar {
-                    border: 4px solid black;
-                    background-color: red;
-                    margin-bottom: 0;
-                    overflow: hidden;
-                    padding: 0.25em;
-                    position: relative;
-                }
-                .health-bar:after {
-                    position: absolute;
-                    border-bottom: 2px solid rgba(0, 0, 0, 0.2);
-                    border-right: 2px solid rgba(0, 0, 0, 0.2);
-                    bottom: 0;
-                    content: "";
-                    left: 0;
-                    right: 0;
-                    top: 0;
-                }
-                .health-regen {
-                    float: left;
-                    margin-top: 0;
-                }
-            `}</style>
         </>
     );
 };

--- a/src/ui/components/molecules/ItemTooltip.module.css
+++ b/src/ui/components/molecules/ItemTooltip.module.css
@@ -1,0 +1,35 @@
+.tooltip {
+    font-size: 1em;
+    background-color: transparent !important;
+    padding: 0;
+    text-align: left;
+}
+
+.tooltipContent {
+    display: grid;
+    grid-template-columns: 1fr min-content;
+    align-items: end;
+    grid-gap: 0.5em;
+}
+
+.tooltipMain {
+    border-style: solid;
+    border-width: 5px;
+    background: white;
+    padding: 0.5em 1em;
+    border-radius: 3px;
+    border-color: var(--tooltip-border);
+}
+
+.tooltipTitle {
+    margin: 0;
+}
+
+.tooltipCompare {
+    border-style: solid;
+    border-width: 5px;
+    background: white;
+    padding: 0.5em 1em;
+    border-radius: 3px;
+    border-color: grey;
+}

--- a/src/ui/components/molecules/ItemTooltip.tsx
+++ b/src/ui/components/molecules/ItemTooltip.tsx
@@ -8,6 +8,7 @@ import { connect } from "react-redux";
 import type { LootItem, Equipment } from "@/types/game";
 import type { LootStat } from "@/types/game";
 import type { RootState } from "@store";
+import styles from "./ItemTooltip.module.css";
 
 interface ItemTooltipProps {
     id: string;
@@ -75,59 +76,29 @@ const ItemTooltip: React.FC<ItemTooltipProps> = ({ id, loot, equipment }) => {
 
     return (
         <Tooltip
-            className="tooltip"
+            className={styles.tooltip}
             id={id}
             variant="light"
             globalCloseEvents={{ clickOutsideAnchor: true }}
             afterShow={afterShowHandler}
         >
-            <div className="tooltip-content">
-                <div className="tooltip-main">
-                    <h3 className="tooltip-title">{name}</h3>
+            <div className={styles.tooltipContent}>
+                <div
+                    className={styles.tooltipMain}
+                    style={{ "--tooltip-border": color } as React.CSSProperties}
+                >
+                    <h3 className={styles.tooltipTitle}>{name}</h3>
                     <label>Type: </label> <span>{set}</span>
                     {stats.length > 0 && <Stats>{convertStatsToArray(stats)}</Stats>}
                 </div>
                 <Price cost={cost} />
                 {compare && (
-                    <div className="tooltip-compare">
+                    <div className={styles.tooltipCompare}>
                         <h4>Stat comparison</h4>
                         <Stats>{convertStatsToArray(compare, true)}</Stats>
                     </div>
                 )}
             </div>
-            <style jsx>{`
-                .tooltip {
-                    font-size: 1em;
-                    background-color: transparent !important;
-                    padding: 0;
-                    text-align: left;
-                }
-                .tooltip-content {
-                    display: grid;
-                    grid-template-columns: 1fr min-content;
-                    align-items: end;
-                    grid-gap: 0.5em;
-                }
-                .tooltip-main {
-                    border-style: solid;
-                    border-width: 5px;
-                    background: white;
-                    padding: 0.5em 1em;
-                    border-radius: 3px;
-                    border-color: ${color};
-                }
-                .tooltip-title {
-                    margin: 0;
-                }
-                .tooltip-compare {
-                    border-style: solid;
-                    border-width: 5px;
-                    background: white;
-                    padding: 0.5em 1em;
-                    border-radius: 3px;
-                    border-color: grey;
-                }
-            `}</style>
         </Tooltip>
     );
 };

--- a/src/ui/components/molecules/LootList.module.css
+++ b/src/ui/components/molecules/LootList.module.css
@@ -1,0 +1,7 @@
+.lootList {
+    display: grid;
+    gap: 0.5rem;
+    overflow-y: scroll;
+    grid-template-columns: repeat(var(--cols), 1fr);
+    height: calc(100vh - 158px);
+}

--- a/src/ui/components/molecules/LootList.tsx
+++ b/src/ui/components/molecules/LootList.tsx
@@ -5,6 +5,7 @@ import { selectLoot } from "@store/gameReducer";
 import { useSelector, useDispatch } from "react-redux";
 import type { LootItem } from "@/types/game";
 import type { RootState } from "@store";
+import styles from "./LootList.module.css";
 
 interface LootListProps {
     name: string;
@@ -35,17 +36,8 @@ const LootList: React.FC<LootListProps> = ({ cols = 4, list }) => {
     }
 
     return (
-        <div className="loot-list">
+        <div className={styles.lootList} style={{ "--cols": cols } as React.CSSProperties}>
             {list && items}
-            <style jsx>{`
-                .loot-list {
-                    display: grid;
-                    gap: 0.5rem;
-                    overflow-y: scroll;
-                    grid-template-columns: repeat(${cols}, 1fr);
-                    height: calc(100vh - 158px);
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/molecules/LootListDrag.module.css
+++ b/src/ui/components/molecules/LootListDrag.module.css
@@ -1,0 +1,11 @@
+.dragging {
+    opacity: 0.1;
+    filter: grayscale(100%);
+}
+
+.lootGrid {
+    display: grid;
+    gap: 1rem;
+    overflow-y: scroll;
+    grid-template-columns: repeat(var(--cols), 1fr);
+}

--- a/src/ui/components/molecules/LootListDrag.test.tsx
+++ b/src/ui/components/molecules/LootListDrag.test.tsx
@@ -29,16 +29,16 @@ describe("LootListDrag (Inventory grid)", () => {
         ];
         const { container } = renderWithProviders(<LootListDrag list={list} name="inventory" />);
 
-        const grid = container.querySelector(".loot-grid");
+        const grid = container.querySelector(`[data-testid="loot-grid"]`);
         expect(grid).toBeInTheDocument();
         // Each item renders a LootIcon image; the grid wraps the draggable nodes.
-        expect(container.querySelectorAll(".styled-loot-icon")).toHaveLength(3);
+        expect(container.querySelectorAll(`img[alt="Loot!"]`)).toHaveLength(3);
     });
 
     it("renders nothing for an empty list but still mounts the drop grid", () => {
         const { container } = renderWithProviders(<LootListDrag list={[]} name="inventory" />);
-        expect(container.querySelector(".loot-grid")).toBeInTheDocument();
-        expect(container.querySelectorAll(".styled-loot-icon")).toHaveLength(0);
+        expect(container.querySelector(`[data-testid="loot-grid"]`)).toBeInTheDocument();
+        expect(container.querySelectorAll(`img[alt="Loot!"]`)).toHaveLength(0);
     });
 
     it("dispatches selectLoot with the clicked item", () => {
@@ -61,7 +61,7 @@ describe("LootListDrag (Inventory grid)", () => {
             preloadedGame: { selected: item },
         });
         // A selected icon renders with a red border (see LootIcon styling).
-        const icon = container.querySelector(".styled-loot-icon");
+        const icon = container.querySelector(`img[alt="Loot!"]`);
         expect(icon).toBeInTheDocument();
     });
 });

--- a/src/ui/components/molecules/LootListDrag.tsx
+++ b/src/ui/components/molecules/LootListDrag.tsx
@@ -7,6 +7,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { equipLoot, selectLoot, unequipLoot } from "@store/gameReducer";
 import type { LootItem } from "@/types/game";
 import type { RootState } from "@store";
+import styles from "./LootListDrag.module.css";
 
 interface LootListDragProps {
     cols?: number;
@@ -68,19 +69,13 @@ const LootListDrag: React.FC<LootListDragProps> = ({ cols = 6, list, name }) => 
                 ref={(node) => {
                     drag(node);
                 }}
-                className={isDragging ? "dragging" : ""}
+                className={isDragging ? styles.dragging : ""}
             >
                 <Loot
                     loot={props.loot}
                     isSelected={props.isSelected}
                     setSelected={props.setSelected}
                 />
-                <style jsx>{`
-                    .dragging {
-                        opacity: 0.1;
-                        filter: grayscale(100%);
-                    }
-                `}</style>
             </div>
         );
     };
@@ -95,7 +90,9 @@ const LootListDrag: React.FC<LootListDragProps> = ({ cols = 6, list, name }) => 
             ref={(node) => {
                 drop(node);
             }}
-            className="loot-grid"
+            className={styles.lootGrid}
+            style={{ "--cols": cols } as React.CSSProperties}
+            data-testid="loot-grid"
         >
             {list &&
                 list.map((loot, i) => {
@@ -113,14 +110,6 @@ const LootListDrag: React.FC<LootListDragProps> = ({ cols = 6, list, name }) => 
                         />
                     );
                 })}
-            <style jsx>{`
-                .loot-grid {
-                    display: grid;
-                    gap: 1rem;
-                    overflow-y: scroll;
-                    grid-template-columns: repeat(${cols}, 1fr);
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/molecules/Navigation.tsx
+++ b/src/ui/components/molecules/Navigation.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { switchUi } from "@store/gameReducer";
-import { pixel_background } from "../../themes";
+import { pixelBackgroundVars } from "../../themes";
+import theme from "../../themes.module.css";
 import type { RootState } from "@store";
 
 const Navigation = () => {
@@ -11,29 +12,29 @@ const Navigation = () => {
     const items = ["Character", "Equipment", "Armory", "Arcanum"];
 
     return (
-        <nav className="nav-container">
+        <nav>
             {items &&
-                items.map((item, i) => (
-                    <React.Fragment key={i}>
+                items.map((item, i) => {
+                    const active = menu === item.toLowerCase();
+                    return (
                         <button
-                            className={`nav-button ${menu === item.toLowerCase() ? "active" : ""}`}
+                            key={i}
+                            className={theme.pixelBackground}
+                            style={{
+                                ...pixelBackgroundVars({
+                                    bg_color: active ? "#44bff7" : "#ffa53d",
+                                }),
+                                color: "white",
+                                float: "left",
+                                fontSize: "2em",
+                                marginRight: "0.5em",
+                            }}
                             onClick={() => dispatch(switchUi(item.toLowerCase()))}
                         >
                             {item}
                         </button>
-                        <style jsx>{`
-                            .nav-button {
-                                ${pixel_background({
-                                    bg_color: menu === item.toLowerCase() ? "#44bff7" : "#ffa53d",
-                                })}
-                                color: white;
-                                float: left;
-                                font-size: 2em;
-                                margin-right: 0.5em;
-                            }
-                        `}</style>
-                    </React.Fragment>
-                ))}
+                    );
+                })}
         </nav>
     );
 };

--- a/src/ui/components/molecules/StatBar.module.css
+++ b/src/ui/components/molecules/StatBar.module.css
@@ -1,0 +1,42 @@
+.statBarContainer {
+    position: relative;
+    overflow: hidden;
+    margin-bottom: 0.125rem;
+    padding: 0.125rem 0.25rem;
+    border: var(--bar-border-w) solid black;
+    background-color: var(--bar-bg-dark);
+}
+
+.progressFill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: var(--bar-fill);
+    transform-origin: left;
+    transform: scaleX(var(--bar-pct));
+}
+
+.innerShadow {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-right: 1px solid rgba(0, 0, 0, 0.2);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.label {
+    position: relative;
+}
+
+.value {
+    position: relative;
+}
+
+.maxValue {
+    position: relative;
+    float: right;
+}

--- a/src/ui/components/molecules/StatBar.tsx
+++ b/src/ui/components/molecules/StatBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { darken } from "polished";
 import { getResourceColour } from "@helpers/getResourceColour";
+import styles from "./StatBar.module.css";
 
 interface StatBarProps {
     type: string;
@@ -16,62 +17,26 @@ const StatBar: React.FC<StatBarProps> = ({ type, colour, label, value, max }) =>
     const percentage = value / maxValue;
     const borderWidth = label ? 3 : 2;
 
+    // Custom properties are set on the container; the fill inherits them.
+    const style = {
+        "--bar-border-w": `${borderWidth}px`,
+        "--bar-bg-dark": darken(0.3, finalColour),
+        "--bar-fill": finalColour,
+        "--bar-pct": percentage,
+    } as React.CSSProperties;
+
     return (
-        <div className="stat-bar-container">
-            <div className="progress-fill" />
-            <div className="inner-shadow" />
+        <div className={styles.statBarContainer} style={style}>
+            <div className={styles.progressFill} />
+            <div className={styles.innerShadow} />
 
             {label && (
                 <>
-                    <label className="label">{label}</label>:<span className="value">{value}</span>
-                    <span className="max-value">{maxValue}</span>
+                    <label className={styles.label}>{label}</label>:
+                    <span className={styles.value}>{value}</span>
+                    <span className={styles.maxValue}>{maxValue}</span>
                 </>
             )}
-
-            <style jsx>{`
-                .stat-bar-container {
-                    position: relative;
-                    overflow: hidden;
-                    margin-bottom: 0.125rem;
-                    padding: 0.125rem 0.25rem;
-                    border: ${borderWidth}px solid black;
-                    background-color: ${darken(0.3, finalColour)};
-                }
-
-                .progress-fill {
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                    right: 0;
-                    bottom: 0;
-                    background-color: ${finalColour};
-                    transform-origin: left;
-                    transform: scaleX(${percentage});
-                }
-
-                .inner-shadow {
-                    position: absolute;
-                    top: 0;
-                    left: 0;
-                    right: 0;
-                    bottom: 0;
-                    border-right: 1px solid rgba(0, 0, 0, 0.2);
-                    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
-                }
-
-                .label {
-                    position: relative;
-                }
-
-                .value {
-                    position: relative;
-                }
-
-                .max-value {
-                    position: relative;
-                    float: right;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/molecules/Stats.module.css
+++ b/src/ui/components/molecules/Stats.module.css
@@ -1,0 +1,6 @@
+.statsList {
+    clear: both;
+    overflow: hidden;
+    margin: 0;
+    width: var(--stats-width, auto);
+}

--- a/src/ui/components/molecules/Stats.tsx
+++ b/src/ui/components/molecules/Stats.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Stat from "@components/Stat";
+import listStyles from "./Stats.module.css";
 
 interface StatItem {
     id: string;
@@ -19,7 +20,10 @@ interface StatsProps {
 
 const Stats: React.FC<StatsProps> = ({ children: stats, styles = {} }) => {
     return (
-        <dl className="stats-list">
+        <dl
+            className={listStyles.statsList}
+            style={{ "--stats-width": styles.width || "auto" } as React.CSSProperties}
+        >
             {stats.map((stat) => {
                 return (
                     <Stat
@@ -30,14 +34,6 @@ const Stats: React.FC<StatsProps> = ({ children: stats, styles = {} }) => {
                     />
                 );
             })}
-            <style jsx>{`
-                .stats-list {
-                    clear: both;
-                    overflow: hidden;
-                    margin: 0;
-                    width: ${styles.width || "auto"};
-                }
-            `}</style>
         </dl>
     );
 };

--- a/src/ui/components/organisms/Header.module.css
+++ b/src/ui/components/organisms/Header.module.css
@@ -1,0 +1,3 @@
+.closeButton {
+    float: right;
+}

--- a/src/ui/components/organisms/Header.tsx
+++ b/src/ui/components/organisms/Header.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Button from "@components/Button";
 import Navigation from "@components/Navigation";
 import Title from "@components/Title";
+import styles from "./Header.module.css";
 
 interface HeaderConfig {
     navigation?: boolean;
@@ -21,28 +22,18 @@ const Header: React.FC<HeaderProps> = ({ config, toggleUi }) => {
         return (
             <>
                 <Navigation />
-                <div className="close-button">
+                <div className={styles.closeButton}>
                     <Button text="X" onClick={() => toggleUi()} />
                 </div>
-                <style jsx>{`
-                    .close-button {
-                        float: right;
-                    }
-                `}</style>
             </>
         );
     } else {
         return (
             <>
                 <Title text={title || ""} />
-                <div className="close-button">
+                <div className={styles.closeButton}>
                     {close && <Button text="X" onClick={() => toggleUi()} />}
                 </div>
-                <style jsx>{`
-                    .close-button {
-                        float: right;
-                    }
-                `}</style>
             </>
         );
     }

--- a/src/ui/components/protons/CustomDragLayer.module.css
+++ b/src/ui/components/protons/CustomDragLayer.module.css
@@ -1,0 +1,9 @@
+.dragLayer {
+    position: fixed;
+    pointer-events: none;
+    z-index: 100;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/src/ui/components/protons/CustomDragLayer.tsx
+++ b/src/ui/components/protons/CustomDragLayer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { useDragLayer } from "react-dnd";
 import LootIcon from "@components/LootIcon";
+import styles from "./CustomDragLayer.module.css";
 
 interface Offset {
     x: number;
@@ -44,19 +45,8 @@ const CustomDragLayer: React.FC = () => {
     }
 
     return (
-        <div className="drag-layer">
+        <div className={styles.dragLayer}>
             <div style={getItemStyles(initialOffset, currentOffset)}>{renderItem()}</div>
-            <style jsx>{`
-                .drag-layer {
-                    position: fixed;
-                    pointer-events: none;
-                    z-index: 100;
-                    left: 0;
-                    top: 0;
-                    width: 100%;
-                    height: 100%;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/templates/Arcanum.module.css
+++ b/src/ui/components/templates/Arcanum.module.css
@@ -1,0 +1,3 @@
+.container {
+    display: flex;
+}

--- a/src/ui/components/templates/Arcanum.tsx
+++ b/src/ui/components/templates/Arcanum.tsx
@@ -1,16 +1,12 @@
 import React from "react";
+import styles from "./Arcanum.module.css";
 
 const Arcanum: React.FC = () => {
     return (
-        <div>
+        <div className={styles.container}>
             <section>
                 <h2>Arcanum</h2>
             </section>
-            <style jsx>{`
-                div {
-                    display: flex;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/templates/Armory.module.css
+++ b/src/ui/components/templates/Armory.module.css
@@ -1,0 +1,23 @@
+.armoryContainer {
+    display: grid;
+    grid-template-columns: 90px 90px 1fr;
+    grid-gap: 1em;
+    height: 100%;
+}
+
+.filterGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    column-gap: 0.5em;
+}
+
+/*
+ * NOTE: preserves a pre-existing bug. The original styled-jsx interpolated
+ * `${pixel_emboss}` — the function reference, not a call — so it emitted the
+ * function's source as invalid CSS which the browser dropped. The emboss never
+ * applied; only `padding` ever took effect. Behaviour is kept identical here
+ * (no emboss) rather than silently "fixing" it; see PR notes.
+ */
+.stockSection {
+    padding: 0.5em;
+}

--- a/src/ui/components/templates/Armory.tsx
+++ b/src/ui/components/templates/Armory.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
 
-import { pixel_emboss } from "@ui/themes";
 import Button from "@components/Button";
 import Stock from "@components/Stock";
 import { buyLoot, toggleFilter } from "@store/gameReducer";
@@ -12,6 +11,7 @@ import { RESTOCK_STORE, REMOVE_ITEM } from "@mutations";
 import { sortBy } from "@ui/operations/helpers";
 import type { LootItem } from "@/types/game";
 import type { RootState } from "@store";
+import styles from "./Armory.module.css";
 
 interface ArmoryProps {}
 
@@ -46,7 +46,7 @@ const Armory: React.FC<ArmoryProps> = () => {
     };
 
     return (
-        <div className="armory-container">
+        <div className={styles.armoryContainer}>
             <section>
                 <h3>Sort</h3>
                 <Button
@@ -103,7 +103,7 @@ const Armory: React.FC<ArmoryProps> = () => {
             </section>
             <section>
                 <h3>Filter</h3>
-                <div className="filter-grid">
+                <div className={styles.filterGrid}>
                     <Button
                         text="AP"
                         on={filterOn("attack_power")}
@@ -151,26 +151,9 @@ const Armory: React.FC<ArmoryProps> = () => {
                     />
                 </div>
             </section>
-            <section className="stock-section">
+            <section className={styles.stockSection}>
                 <Stock items={data.items} />
             </section>
-            <style jsx>{`
-                .armory-container {
-                    display: grid;
-                    grid-template-columns: 90px 90px 1fr;
-                    grid-gap: 1em;
-                    height: 100%;
-                }
-                .filter-grid {
-                    display: grid;
-                    grid-template-columns: 1fr 1fr;
-                    column-gap: 0.5em;
-                }
-                .stock-section {
-                    ${pixel_emboss}
-                    padding: 0.5em;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/templates/Character.module.css
+++ b/src/ui/components/templates/Character.module.css
@@ -1,0 +1,34 @@
+.characterContainer {
+    display: grid;
+    gap: 1rem;
+    height: 100%;
+    grid-template-columns: 170px 1fr;
+}
+
+.characterLevel {
+    margin-bottom: 0.5rem;
+}
+
+.characterLevel h2 {
+    float: left;
+    margin-right: 0.5rem;
+}
+
+.characterResources {
+    clear: both;
+}
+
+.characterResources img {
+    float: left;
+    height: 3rem;
+    margin-right: 1rem;
+    margin-bottom: 1rem;
+}
+
+.equipmentDisplay {
+    padding: 0.5em;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: min-content min-content;
+    grid-gap: 1em;
+}

--- a/src/ui/components/templates/Character.tsx
+++ b/src/ui/components/templates/Character.tsx
@@ -4,8 +4,9 @@ import Slot from "@components/Slot";
 import DetailedLoot from "@components/DetailedLoot";
 import GroupedAttributes from "@components/GroupedAttributes";
 import StatBar from "@components/StatBar";
-import { pixel_emboss } from "@ui/themes";
+import theme from "@ui/themes.module.css";
 import type { RootState } from "@store";
+import styles from "./Character.module.css";
 
 const Character: React.FC = () => {
     const {
@@ -17,9 +18,9 @@ const Character: React.FC = () => {
     } = useSelector((state: RootState) => state.game);
 
     return (
-        <div className="character-container">
-            <section className="character-data">
-                <div className="character-level">
+        <div className={styles.characterContainer}>
+            <section>
+                <div className={styles.characterLevel}>
                     <h2>Level {level.currentLevel}</h2>
                     <StatBar
                         type="experience"
@@ -29,7 +30,7 @@ const Character: React.FC = () => {
                         max={level.toNextLevel}
                     />
                 </div>
-                <div className="character-resources">
+                <div className={styles.characterResources}>
                     <img src={`ui/player/${character}.gif`} alt="This is you!" />
                     <StatBar type={"health"} label={"HP"} value={stats.health_max || 0} />
                     <StatBar
@@ -40,7 +41,7 @@ const Character: React.FC = () => {
                 </div>
                 <GroupedAttributes stats={stats} />
             </section>
-            <section className="equipment-display">
+            <section className={`${theme.pixelEmboss} ${styles.equipmentDisplay}`}>
                 <Slot
                     loot={helm}
                     component={({ loot, compare }) => (
@@ -66,43 +67,6 @@ const Character: React.FC = () => {
                     )}
                 />
             </section>
-            <style jsx>{`
-                .character-container {
-                    display: grid;
-                    gap: 1rem;
-                    height: 100%;
-                    grid-template-columns: 170px 1fr;
-                }
-
-                .character-level {
-                    margin-bottom: 0.5rem;
-                }
-
-                .character-level h2 {
-                    float: left;
-                    margin-right: 0.5rem;
-                }
-
-                .character-resources {
-                    clear: both;
-                }
-
-                .character-resources img {
-                    float: left;
-                    height: 3rem;
-                    margin-right: 1rem;
-                    margin-bottom: 1rem;
-                }
-
-                .equipment-display {
-                    ${pixel_emboss()}
-                    padding: 0.5em;
-                    display: grid;
-                    grid-template-columns: 1fr 1fr;
-                    grid-template-rows: min-content min-content;
-                    grid-gap: 1em;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/templates/CharacterSelect.module.css
+++ b/src/ui/components/templates/CharacterSelect.module.css
@@ -1,0 +1,6 @@
+.characterList {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}

--- a/src/ui/components/templates/CharacterSelect.tsx
+++ b/src/ui/components/templates/CharacterSelect.tsx
@@ -1,25 +1,16 @@
 import React from "react";
 import CharacterCard from "@components/CharacterCard";
+import styles from "./CharacterSelect.module.css";
 
 const CharacterSelect: React.FC = () => {
     return (
-        <>
-            <ol className="character-list">
-                <CharacterCard type="Cleric" />
-                <CharacterCard type="Mage" />
-                <CharacterCard type="Occultist" />
-                <CharacterCard type="Ranger" />
-                <CharacterCard type="Warrior" />
-            </ol>
-            <style jsx>{`
-                .character-list {
-                    display: flex;
-                    list-style: none;
-                    margin: 0;
-                    padding: 0;
-                }
-            `}</style>
-        </>
+        <ol className={styles.characterList}>
+            <CharacterCard type="Cleric" />
+            <CharacterCard type="Mage" />
+            <CharacterCard type="Occultist" />
+            <CharacterCard type="Ranger" />
+            <CharacterCard type="Warrior" />
+        </ol>
     );
 };
 

--- a/src/ui/components/templates/Equipment.module.css
+++ b/src/ui/components/templates/Equipment.module.css
@@ -1,0 +1,38 @@
+.equipmentContainer {
+    display: grid;
+    gap: 0.5rem 1rem;
+    height: 100%;
+    grid-template-columns: 150px 56px 1fr 66px;
+    grid-template-areas: "stats eq inv com" "stats eq inv act";
+    grid-template-rows: 1fr min-content;
+}
+
+.characterData {
+    grid-area: stats;
+}
+
+.characterData h2 {
+    margin-bottom: 0.5rem;
+}
+
+.characterResources img {
+    float: left;
+    height: 3rem;
+    margin-right: 1rem;
+    margin-bottom: 1rem;
+}
+
+.equipmentSection {
+    grid-area: eq;
+    display: grid;
+    grid-template-rows: repeat(4, 1fr);
+}
+
+.inventorySection {
+    grid-area: inv;
+    padding: 0.5em;
+}
+
+.actionsSection {
+    grid-area: act;
+}

--- a/src/ui/components/templates/Equipment.test.tsx
+++ b/src/ui/components/templates/Equipment.test.tsx
@@ -42,8 +42,8 @@ describe("Equipment template", () => {
         seed({ character: "Warrior", inventory: [], stats: { health_max: 100 } as never });
         const { container } = renderWithProviders(<Equipment />, { store });
 
-        expect(container.querySelectorAll(".droppable-slot")).toHaveLength(4);
-        expect(container.querySelector(".loot-grid")).toBeInTheDocument();
+        expect(container.querySelectorAll(`[data-testid="droppable-slot"]`)).toHaveLength(4);
+        expect(container.querySelector(`[data-testid="loot-grid"]`)).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Sell" })).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Scrap" })).toBeInTheDocument();
     });
@@ -64,7 +64,7 @@ describe("Equipment template", () => {
         });
         const { container } = renderWithProviders(<Equipment />, { store });
 
-        const icons = Array.from(container.querySelectorAll(".styled-loot-icon")).map((n) =>
+        const icons = Array.from(container.querySelectorAll(`img[alt="Loot!"]`)).map((n) =>
             n.getAttribute("src")
         );
         expect(icons).toContain("graphics/images/loot/helmet/worn-helm.png");

--- a/src/ui/components/templates/Equipment.tsx
+++ b/src/ui/components/templates/Equipment.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { pixel_emboss } from "@ui/themes";
 import { sellLoot } from "@store/gameReducer";
 import Button from "@components/Button";
 import Inventory from "@components/Inventory";
@@ -8,6 +7,8 @@ import DroppableSlot from "@components/DroppableSlot";
 import GroupedAttributes from "@components/GroupedAttributes";
 import StatBar from "@components/StatBar";
 import type { RootState } from "@store";
+import theme from "@ui/themes.module.css";
+import styles from "./Equipment.module.css";
 
 const Equipment: React.FC = () => {
     const dispatch = useDispatch();
@@ -23,10 +24,10 @@ const Equipment: React.FC = () => {
     } = useSelector((state: RootState) => state.game);
 
     return (
-        <div className="equipment-container">
-            <section className="character-data">
+        <div className={styles.equipmentContainer}>
+            <section className={styles.characterData}>
                 <h2>Level {level.currentLevel}</h2>
-                <div className="character-resources">
+                <div className={styles.characterResources}>
                     <img src={`ui/player/${character}.gif`} alt="This is you!" />
                     <StatBar type={"health"} label={"HP"} value={stats.health_max || 0} />
                     <StatBar
@@ -37,16 +38,16 @@ const Equipment: React.FC = () => {
                 </div>
                 <GroupedAttributes stats={stats} />
             </section>
-            <section className="equipment-section">
+            <section className={styles.equipmentSection}>
                 <DroppableSlot slot="helm" loot={helm} />
                 <DroppableSlot slot="body" loot={body} />
                 <DroppableSlot slot="weapon" loot={weapon} />
                 <DroppableSlot slot="amulet" loot={amulet} />
             </section>
-            <section className="inventory-section">
+            <section className={`${theme.pixelEmboss} ${styles.inventorySection}`}>
                 <Inventory />
             </section>
-            <section className="actions-section">
+            <section className={styles.actionsSection}>
                 <Button
                     text="Sell"
                     onClick={() => {
@@ -62,47 +63,6 @@ const Equipment: React.FC = () => {
                     }}
                 />
             </section>
-            <style jsx>{`
-                .equipment-container {
-                    display: grid;
-                    gap: 0.5rem 1rem;
-                    height: 100%;
-                    grid-template-columns: 150px 56px 1fr 66px;
-                    grid-template-areas: "stats eq inv com" "stats eq inv act";
-                    grid-template-rows: 1fr min-content;
-                }
-
-                .character-data {
-                    grid-area: stats;
-                }
-
-                .character-data h2 {
-                    margin-bottom: 0.5rem;
-                }
-
-                .character-resources img {
-                    float: left;
-                    height: 3rem;
-                    margin-right: 1rem;
-                    margin-bottom: 1rem;
-                }
-
-                .equipment-section {
-                    grid-area: eq;
-                    display: grid;
-                    grid-template-rows: repeat(4, 1fr);
-                }
-
-                .inventory-section {
-                    grid-area: inv;
-                    ${pixel_emboss()}
-                    padding: 0.5em;
-                }
-
-                .actions-section {
-                    grid-area: act;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/templates/HUD.module.css
+++ b/src/ui/components/templates/HUD.module.css
@@ -1,0 +1,7 @@
+.hudContainer {
+    padding: 0.5em 1em;
+}
+
+.levelInfo {
+    width: 100px;
+}

--- a/src/ui/components/templates/HUD.tsx
+++ b/src/ui/components/templates/HUD.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useSelector } from "react-redux";
 import StatBar from "@components/StatBar";
 import type { RootState } from "@store";
+import styles from "./HUD.module.css";
 
 interface Level {
     currentLevel: number;
@@ -13,8 +14,8 @@ const HUD: React.FC = () => {
     const level = useSelector((state: RootState) => state.game.level);
 
     return (
-        <div className="hud-container">
-            <div className="level-info">
+        <div className={styles.hudContainer}>
+            <div className={styles.levelInfo}>
                 <label>LV {level?.currentLevel}</label>
                 <StatBar
                     type="experience"
@@ -23,15 +24,6 @@ const HUD: React.FC = () => {
                     max={level.toNextLevel}
                 />
             </div>
-            <style jsx>{`
-                .hud-container {
-                    padding: 0.5em 1em;
-                }
-
-                .level-info {
-                    width: 100px;
-                }
-            `}</style>
         </div>
     );
 };

--- a/src/ui/components/templates/Save.module.css
+++ b/src/ui/components/templates/Save.module.css
@@ -1,0 +1,55 @@
+.slots {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.slots li {
+    flex: 1;
+    padding: 0.5rem;
+    text-align: center;
+}
+
+.slots li:first-child {
+    padding-left: 0;
+}
+
+.slots li:last-child {
+    padding-right: 0;
+}
+
+.slots h2 {
+    text-transform: capitalize;
+}
+
+.slots img {
+    padding-bottom: 0.5rem;
+}
+
+.slots p {
+    margin: 0;
+}
+
+.slots p:last-of-type {
+    margin-bottom: 0.5rem;
+}
+
+.slots li > div {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.5rem;
+}
+
+.dialog {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: rgba(0, 0, 0, 0.9);
+    padding: 10% 35%;
+    color: white;
+    font-size: 1.25rem;
+    font-weight: bold;
+}

--- a/src/ui/components/templates/Save.tsx
+++ b/src/ui/components/templates/Save.tsx
@@ -5,6 +5,7 @@ import Button from "@components/Button";
 import Dialog from "@components/Dialog";
 import { readAllSaves, removeSave, SAVE_SLOTS } from "@services/saveStorage";
 import type { RootState } from "@store";
+import styles from "./Save.module.css";
 
 interface SaveProps {
     load?: boolean;
@@ -20,7 +21,7 @@ const Save: React.FC<SaveProps> = ({ load = false }) => {
 
     const delete_dialog = showDialog ? (
         <Dialog>
-            <div>
+            <div className={styles.dialog}>
                 <p>Are you sure you want to delete this save game?</p>
                 <Button
                     text="Confirm"
@@ -33,27 +34,13 @@ const Save: React.FC<SaveProps> = ({ load = false }) => {
                     }}
                 />
                 <Button text="Cancel" onClick={() => setShowDialog(false)} />
-                <style jsx>{`
-                    div {
-                        position: absolute;
-                        top: 0;
-                        right: 0;
-                        bottom: 0;
-                        left: 0;
-                        background-color: rgba(0, 0, 0, 0.9);
-                        padding: 10% 35%;
-                        color: white;
-                        font-size: 1.25rem;
-                        font-weight: bold;
-                    }
-                `}</style>
             </div>
         </Dialog>
     ) : null;
 
     return (
         <>
-            <ol>
+            <ol className={styles.slots}>
                 {otherGames.map((save, i) => {
                     const { game: { saveSlot, character, coins, wave } = {} } = save || {};
                     return (
@@ -102,50 +89,6 @@ const Save: React.FC<SaveProps> = ({ load = false }) => {
                     );
                 })}
             </ol>
-            <style jsx>{`
-                ol {
-                    display: flex;
-                    list-style: none;
-                    margin: 0;
-                    padding: 0;
-                }
-
-                li {
-                    flex: 1;
-                    padding: 0.5rem;
-                    text-align: center;
-                }
-
-                li:first-child {
-                    padding-left: 0;
-                }
-
-                li:last-child {
-                    padding-right: 0;
-                }
-
-                h2 {
-                    text-transform: capitalize;
-                }
-
-                img {
-                    padding-bottom: 0.5rem;
-                }
-
-                p {
-                    margin: 0;
-                }
-
-                p:last-of-type {
-                    margin-bottom: 0.5rem;
-                }
-
-                li > div {
-                    display: grid;
-                    grid-template-columns: repeat(2, 1fr);
-                    gap: 0.5rem;
-                }
-            `}</style>
             {delete_dialog}
         </>
     );

--- a/src/ui/components/templates/System.tsx
+++ b/src/ui/components/templates/System.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { switchUi, toggleUi } from "@store/gameReducer";
 import Button from "@components/Button";
 import Dialog from "@components/Dialog";
-import { dialog_overlay } from "@ui/themes";
+import theme from "@ui/themes.module.css";
 import { writeSave } from "@services/saveStorage";
 import type { RootState } from "@store";
 
@@ -18,7 +18,7 @@ const System: React.FC<SystemProps> = ({ state }) => {
 
     const save_dialog = showDialog ? (
         <Dialog>
-            <div className="dialog-overlay">
+            <div className={theme.dialogOverlay}>
                 <p>Overwrite your existing save game?</p>
                 <Button
                     text="Yes"
@@ -31,11 +31,6 @@ const System: React.FC<SystemProps> = ({ state }) => {
                     }}
                 />
                 <Button text="Cancel" onClick={() => setShowDialog(false)} />
-                <style jsx>{`
-                    .dialog-overlay {
-                        ${dialog_overlay()}
-                    }
-                `}</style>
             </div>
         </Dialog>
     ) : null;

--- a/src/ui/themes.module.css
+++ b/src/ui/themes.module.css
@@ -1,0 +1,104 @@
+/*
+ * Shared "pixel" styling mixins, ported from the JS string helpers that used to
+ * live in themes.ts and were interpolated into styled-jsx blocks. They are now
+ * plain CSS Module classes; the values that used to be computed per-render
+ * (background colour + its darkened shadow, emboss fill/shadow) are read from
+ * CSS custom properties set inline by the consumer (see themes.ts helpers).
+ */
+
+.pixelBackground {
+    background: var(--pb-bg);
+    border: none;
+    box-shadow:
+        0 6px 0 var(--pb-bg-dark),
+        0 10px 0 rgba(0, 0, 0, 0.25);
+    box-sizing: border-box;
+    display: inline-block;
+    outline: 0;
+    padding: 0.25em;
+    position: relative;
+    height: 100%;
+    margin: 0 6px;
+}
+
+.pixelBackground::before {
+    background: var(--pb-bg);
+    width: 6px;
+    content: "";
+    display: block;
+    top: 6px;
+    position: absolute;
+    bottom: 6px;
+    left: -6px;
+    box-shadow:
+        0 6px 0 var(--pb-bg-dark),
+        0 10px 0 rgba(0, 0, 0, 0.25);
+}
+
+.pixelBackground::after {
+    background: var(--pb-bg);
+    width: 6px;
+    content: "";
+    display: block;
+    top: 6px;
+    position: absolute;
+    bottom: 6px;
+    right: -6px;
+    box-shadow:
+        0 6px 0 var(--pb-bg-dark),
+        0 10px 0 rgba(0, 0, 0, 0.3);
+}
+
+/*
+ * Emboss defaults match the old pixel_emboss() call with no arguments
+ * (rgb = 0,0,0, a = 0.1 → fill rgba(0,0,0,0.1), shadow rgba(0,0,0,0.3)). Call
+ * sites that need other values (DroppableSlot) override --pe-fill / --pe-shadow.
+ */
+.pixelEmboss {
+    background: var(--pe-fill, rgba(0, 0, 0, 0.1));
+    border-top: 6px solid var(--pe-fill, rgba(0, 0, 0, 0.1));
+    box-shadow: 0 -6px 0 var(--pe-shadow, rgba(0, 0, 0, 0.3));
+    box-sizing: border-box;
+    position: relative;
+    margin: 6px;
+    text-align: center;
+}
+
+.pixelEmboss::before {
+    background: var(--pe-fill, rgba(0, 0, 0, 0.1));
+    border-top: 6px solid var(--pe-fill, rgba(0, 0, 0, 0.1));
+    bottom: 6px;
+    box-shadow: 0 -6px 0 var(--pe-shadow, rgba(0, 0, 0, 0.3));
+    content: "";
+    display: block;
+    left: -6px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+}
+
+.pixelEmboss::after {
+    background: var(--pe-fill, rgba(0, 0, 0, 0.1));
+    border-top: 6px solid var(--pe-fill, rgba(0, 0, 0, 0.1));
+    bottom: 6px;
+    box-shadow: 0 -6px 0 var(--pe-shadow, rgba(0, 0, 0, 0.3));
+    content: "";
+    display: block;
+    right: -6px;
+    position: absolute;
+    top: 0;
+    width: 6px;
+}
+
+.dialogOverlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.9);
+    padding: 10% 35%;
+    color: white;
+    font-size: 1.5em;
+    font-weight: bold;
+}

--- a/src/ui/themes.ts
+++ b/src/ui/themes.ts
@@ -1,103 +1,39 @@
 import { darken } from "polished";
+import type { CSSProperties } from "react";
+
+/*
+ * These helpers used to return CSS strings that were interpolated into
+ * styled-jsx blocks. The styling itself now lives in themes.module.css; what
+ * remains here is the *dynamic* part — the per-render colour values — which we
+ * hand to CSS as custom properties via an inline `style` object. Colour maths
+ * (polished's darken) still runs in JS; only its result travels through a var.
+ */
 
 interface PixelBackgroundOptions {
     bg_color?: string;
 }
 
-export const pixel_background = ({ bg_color = "#e4f6f7" }: PixelBackgroundOptions = {}): string => {
-    return `
-    background: ${bg_color};
-    border: none;
-    box-shadow: 0 6px 0 ${darken(0.3, bg_color)}, 0 10px 0 rgba(0,0,0,0.25);
-    box-sizing: border-box;
-    display: inline-block;
-    outline: 0;
-    padding: 0.25em;
-    position: relative;
-    height: 100%;
-    margin: 0 6px;
-    &:before {
-      background: ${bg_color};
-      width: 6px;
-      content: '';
-      display: block;
-      top: 6px;
-      position: absolute;
-      bottom: 6px;
-      left: -6px;
-      box-shadow: 0 6px 0 ${darken(0.3, bg_color)}, 0 10px 0 rgba(0,0,0,0.25);
-    }
-    &:after {
-      background: ${bg_color};
-      width: 6px;
-      content: '';
-      display: block;
-      top: 6px;
-      position: absolute;
-      bottom: 6px;
-      right: -6px;
-      box-shadow: 0 6px 0 ${darken(0.3, bg_color)}, 0 10px 0 rgba(0,0,0,0.3);
-    }
-  `;
-};
+export const pixelBackgroundVars = ({
+    bg_color = "#e4f6f7",
+}: PixelBackgroundOptions = {}): CSSProperties =>
+    ({
+        "--pb-bg": bg_color,
+        "--pb-bg-dark": darken(0.3, bg_color),
+    }) as CSSProperties;
 
 interface PixelEmbossOptions {
     rgb?: string;
     a?: number;
 }
 
-export const pixel_emboss = ({ rgb = "0,0,0", a = 0.1 }: PixelEmbossOptions = {}): string => {
-    const depth = "6px";
-    return `
-    background: rgba(${rgb},${a});
-    border-top: ${depth} solid rgba(${rgb},${a});
-    box-shadow: 0 -${depth} 0 rgba(${rgb},${a * 3});
-    box-sizing: border-box;
-    position: relative;
-    margin: ${depth};
-    text-align: center;
-    &:before {
-      background: rgba(${rgb},${a});
-      border-top: ${depth} solid rgba(${rgb},${a});
-      bottom: ${depth};
-      box-shadow: 0 -${depth} 0 rgba(${rgb},${a * 3});
-      content: '';
-      display: block;
-      left: -${depth};
-      position: absolute;
-      top: 0;
-      width: ${depth};
-    }
-    &:after {
-      background: rgba(${rgb},${a});
-      border-top: ${depth} solid rgba(${rgb},${a});
-      bottom: ${depth};
-      box-shadow: 0 -${depth} 0 rgba(${rgb},${a * 3});
-      content: '';
-      display: block;
-      right: -${depth};
-      position: absolute;
-      top: 0;
-      width: ${depth};
-    }
-  `;
-};
-
-interface DialogOverlayOptions {
-    bg_color?: string;
-}
-
-export const dialog_overlay = ({ bg_color = "#e4f6f7" }: DialogOverlayOptions = {}): string => {
-    return `
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0,0,0,0.9);
-    padding: 10% 35%;
-    color: white;
-    font-size: 1.5em;
-    font-weight: bold;
-  `;
+export const pixelEmbossVars = ({ rgb, a }: PixelEmbossOptions = {}): CSSProperties => {
+    // Omitting both leaves the CSS Module's defaults (rgba(0,0,0,0.1) /
+    // rgba(0,0,0,0.3)) in place, matching the old pixel_emboss() call.
+    if (rgb === undefined && a === undefined) return {};
+    const r = rgb ?? "0,0,0";
+    const alpha = a ?? 0.1;
+    return {
+        "--pe-fill": `rgba(${r},${alpha})`,
+        "--pe-shadow": `rgba(${r},${alpha * 3})`,
+    } as CSSProperties;
 };


### PR DESCRIPTION
Closes #344

## What & why

Prerequisite for **Phase 5 (Vite migration)**, split out as its own PR per the maintainer decision (2026-06-17).

The UI used Next's `styled-jsx` (`<style jsx>`) in **30 components**. It's a Next.js-coupled feature with **no automatic transform under Vite** — and the installed modern stack (`vite@8` + `@vitejs/plugin-react@6`, Rolldown/oxc) **dropped the `babel` option**, so the usual `babel: { plugins: ['styled-jsx/babel'] }` one-liner isn't available. Rather than add a whole Babel toolchain, we remove `styled-jsx` in favour of **CSS Modules** — Vite-native, **zero new dependencies**.

Doing this **on the current Next.js build first** means visual parity is validated against a known-good stack; the subsequent Next→Vite switch then carries no styling risk.

## Approach

- Every `<style jsx>` block → a colocated `*.module.css`.
- **Per-render dynamic values** (colours, `scaleX(percentage)`, widths, conditional borders) are passed as **CSS custom properties via inline `style`** and read with `var(--x)` in the module. Colour maths (`polished`) still runs in JS; only its result travels through a variable.
- **Variant/discrete state** (e.g. nav active colour) toggles which inline vars are set.
- Shared `pixel_background` / `pixel_emboss` / `dialog_overlay` string mixins moved from `themes.ts` into `themes.module.css` classes; `themes.ts` now exports `pixelBackgroundVars` / `pixelEmbossVars` helpers returning the inline-var objects.
- Global `<style jsx global>` moved from `home.tsx` into `globals.css` (imported by `layout.tsx`); kept the VT323 `@import` so plain `<button>`s keep the font (next/font only reaches `<body>` via a className).
- Tests that queried now-hashed class names (`.styled-loot-icon`, `.loot-grid`, `.droppable-slot`) switched to `data-testid` / semantic (`alt`-text) queries.

## Behaviour notes (please review)

- **Armory `.stock-section` — pre-existing bug preserved.** The original interpolated `${pixel_emboss}` (the function reference, *uncalled*), emitting the function source as invalid CSS that the browser dropped — so the emboss never rendered. Kept identical (no emboss) and flagged in a comment rather than silently "fixing" it.
- **Save dialog scoping.** `styled-jsx` scopes per *component*, so Save's two blocks leaked across all its elements. The delete-dialog rules are now scoped to their own element (the intended design) instead of reproducing the leak.

No game balance, save-format, or public-API changes.

## Test evidence

`typecheck` · `lint` · `format:check` · `test` (191 passing) · `build` all pass locally. Bundle for `/` dropped ~126 kB → ~122 kB (styled-jsx runtime gone). E2E smoke left to CI — the Playwright browser download is blocked by this environment's network egress policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHffpDRT254bi5GiMKoAGU