### PR TITLE
Fix HP/RP bars cramped on the Equipment page (match Character column width)

### DIFF
--- a/src/ui/components/templates/Equipment.module.css
+++ b/src/ui/components/templates/Equipment.module.css
@@ -2,7 +2,11 @@
     display: grid;
     gap: 0.5rem 1rem;
     height: 100%;
-    grid-template-columns: 150px 56px 1fr 66px;
+    /* Stats column is 170px to match the Character page (Character.module.css):
+       the resource block floats the player image left and each StatBar is its
+       own block formatting context, so a narrower column cramped/clipped the
+       HP/RP label + value. Equal width makes the two pages render identically. */
+    grid-template-columns: 170px 56px 1fr 66px;
     grid-template-areas: "stats eq inv com" "stats eq inv act";
     grid-template-rows: 1fr min-content;
 }


### PR DESCRIPTION
Closes #348

## Problem

The HP/RP (health & mana) `StatBar`s look slightly off on the **Equipment** page compared to the **Character** page (Character is the correct reference).

## Cause

Both pages render the same resource block — a left-floated player image followed by HP and RP `StatBar`s — with **identical markup and identical `StatBar`/`img` CSS**. The only effective difference is the grid stats-column width:

- `Character.module.css`: `grid-template-columns: 170px 1fr` → **170px**
- `Equipment.module.css`: `grid-template-columns: 150px 56px 1fr 66px` → **150px**

Each `StatBar` is `overflow: hidden` (its own block formatting context), so it sits *beside* the floated image in the remaining width. At 150px that leftover is ~20px narrower, and since the bar clips overflow, the label + value + right-floated number get cramped/clipped on Equipment but fit on Character. (The `.characterResources { clear: both }` rule that Character has and Equipment lacks is a no-op in Equipment's context — nothing floats above the resource block there — so it isn't the cause.)

Pre-existing — predates the Phase 5 Vite migration.

## Fix

Widen Equipment's stats column to **170px** to match Character. Since the resource block's content and CSS are otherwise identical, equal column width makes it render identically across the two pages. One-line CSS change.

## Verification

`typecheck` · `lint` · `format:check` · `test` (191) · `build` all pass. **Visual parity is verified by reasoning, not a screenshot** — this environment has no browser (Playwright's download is egress-blocked). The argument is deterministic: identical content + identical CSS + identical container width ⇒ identical rendering. Happy to be confirmed on the GitHub Pages build / a preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHffpDRT254bi5GiMKoAGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHffpDRT254bi5GiMKoAGU)_