### PR TITLE
Phase 6: Vercel deployment config-as-code (vercel.json + ignored build step)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,11 +111,15 @@ Static deploy to Vercel replacing GitHub Pages. Vercel auto-detects Vite project
 no adapter or framework config required. Do this after Phase 5 so the deploy is a clean
 Vite static build.
 
-- [ ] Connect the GitHub repo to Vercel (framework: Vite auto-detected; build command: `npm run build`; output directory: `dist/`)
-- [ ] Add `VITE_GRAPHQL_URL` env var in the Vercel dashboard (production + preview environments)
-- [ ] Configure Vercel's **Ignored Build Step**: add a shell script that exits `0` (skip) for preview environments unless the PR carries the `deploy-preview` label (checked via GitHub API using `VERCEL_GIT_PULL_REQUEST_ID`); exits `1` (build) for production
-- [ ] Create the `deploy-preview` label in the GitHub repo
-- [ ] Confirm production URL (`phasercraft.vercel.app`) is live and the game plays correctly
+The repo-side config is captured as code in `vercel.json` + `scripts/vercel-ignore-build.sh`
+and documented in `docs/vercel-deployment.md`; the remaining items are Vercel-dashboard
+actions only the maintainer can do (account access).
+
+- [ ] **(maintainer)** Connect the GitHub repo to Vercel. Framework (`vite`), build command (`npm run build`) and output dir (`dist`) are pinned in `vercel.json`, so no dashboard overrides are needed.
+- [ ] **(maintainer)** Add `VITE_GRAPHQL_URL` env var in the Vercel dashboard — may be left **unset in Production** until Phase 7 (no public gateway yet → graceful "merchant unavailable"); set it once a reachable gateway exists.
+- [x] Configure Vercel's **Ignored Build Step** — done as code: `vercel.json#ignoreCommand` → `scripts/vercel-ignore-build.sh`, which exits `0` (skip) for previews unless the PR carries the `deploy-preview` label (checked via the GitHub API using `VERCEL_GIT_PULL_REQUEST_ID`) and `1` (build) for production
+- [ ] **(maintainer)** Create the `deploy-preview` label in the GitHub repo (trivial; the agent has no label-creation tool / `gh` access). The Ignored Build Step gate reads this label.
+- [ ] **(maintainer)** Confirm production URL (`phasercraft.vercel.app`) is live and the game plays correctly
 - [ ] GitHub Pages workflow and `VITE_BASE_URL` transition shim stay in place during this phase; retire in the next PR once Vercel production is confirmed stable
 
 ## Phase 7 — Armory migration to Vercel (issue TBD)

--- a/docs/vercel-deployment.md
+++ b/docs/vercel-deployment.md
@@ -1,0 +1,48 @@
+# Vercel deployment (Phase 6)
+
+Phasercraft's frontend is a Vite **static build** (`npm run build` → `dist/`) deployed to
+Vercel's free hobby tier. This replaces GitHub Pages; Pages stays running in parallel until
+the Vercel production URL is confirmed stable, then it's retired (see `ROADMAP.md`).
+
+## What's config-as-code (already in the repo)
+
+- **`vercel.json`** — pins `framework: vite`, `buildCommand: npm run build`,
+  `outputDirectory: dist`, and the **Ignored Build Step** (`ignoreCommand`). Because these
+  live in the repo, the only dashboard work is connecting the repo and setting env vars.
+- **`scripts/vercel-ignore-build.sh`** — the Ignored Build Step gate. Vercel reads its exit
+  code (`1` = build, `0` = skip):
+    - **Production** (merge to the production branch) → always builds.
+    - **Preview** (a PR) → builds **only if the PR has the `deploy-preview` label**. This stops
+      the hobby tier from building a preview on every push. The script reads the PR's labels
+      from the public GitHub API (`VERCEL_GIT_PULL_REQUEST_ID` / `_REPO_OWNER` / `_REPO_SLUG`)
+      and fails closed (skips) if it can't confirm the label.
+
+### Getting a preview for a PR
+
+Add the **`deploy-preview`** label to the PR. The next push (or re-deploy) builds a preview;
+remove the label to stop further preview builds.
+
+## One-time maintainer steps (Vercel dashboard)
+
+These need the Vercel account and can't be done from the repo:
+
+1. **Create the `deploy-preview` GitHub label** (Repo → Issues → Labels → New label). The
+   Ignored Build Step gate reads it to decide whether to build a PR preview.
+2. **Import the repo** — Vercel → Add New → Project → import `chriskinch/phasercraft`.
+   Framework/build/output are picked up from `vercel.json`; no overrides needed.
+3. **Production branch** — confirm it's `main` (Project → Settings → Git).
+4. **Environment variable** `VITE_GRAPHQL_URL` (Project → Settings → Environment Variables):
+    - Until the Armory moves to Vercel (Phase 7) there is no public GraphQL gateway, so it's
+      fine to **leave this unset in Production** — the shop shows its "merchant unavailable"
+      state (decisions log). Set it for Preview/Production once a reachable gateway exists.
+5. **Confirm production** — after the first deploy, check `phasercraft.vercel.app` loads and
+   the game plays (boot → save picker → character select → run).
+
+## Notes
+
+- **Base path:** the Vercel build leaves `VITE_BASE_URL` unset, so Vite's `base` is `/`
+  (served from the domain root). The GitHub Pages workflow keeps setting
+  `VITE_BASE_URL=/phasercraft/` for its sub-path build — the two coexist during the
+  transition.
+- **No SPA rewrites** are needed: the app is a single `index.html` with no client-side
+  routing.

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Vercel "Ignored Build Step" gate (Phase 6).
+#
+# Vercel runs this before every deployment and reads its EXIT CODE:
+#   exit 1 -> continue the build
+#   exit 0 -> skip (cancel) the build
+# (see https://vercel.com/docs/project-configuration/project-settings)
+#
+# Policy (per docs/ROADMAP.md, Phase 6):
+#   - Production (merge to the production branch) always builds.
+#   - Preview builds are opt-in: a PR only builds a preview when it carries the
+#     `deploy-preview` label. This keeps the free hobby tier from building a
+#     preview for every push.
+#
+# Wired up via vercel.json -> "ignoreCommand". No dashboard setting required.
+
+set -euo pipefail
+
+# Always build Production.
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+    echo "▲ Production deployment — building."
+    exit 1
+fi
+
+PR_ID="${VERCEL_GIT_PULL_REQUEST_ID:-}"
+OWNER="${VERCEL_GIT_REPO_OWNER:-}"
+SLUG="${VERCEL_GIT_REPO_SLUG:-}"
+
+# Not a PR build (e.g. a branch push with no open PR) — nothing to preview.
+if [ -z "$PR_ID" ] || [ "$PR_ID" = "0" ]; then
+    echo "No associated pull request (VERCEL_GIT_PULL_REQUEST_ID='$PR_ID') — skipping preview build."
+    exit 0
+fi
+
+API="https://api.github.com/repos/${OWNER}/${SLUG}/issues/${PR_ID}/labels"
+echo "Checking labels for ${OWNER}/${SLUG} PR #${PR_ID}: ${API}"
+
+# Phasercraft is a public repo, so an unauthenticated read works; pass a token
+# if one is available to avoid rate limits. Fail closed (skip the build) if the
+# label can't be confirmed.
+AUTH_HEADER=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    AUTH_HEADER=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+if curl -fsS "${AUTH_HEADER[@]}" "$API" | grep -q '"name"[[:space:]]*:[[:space:]]*"deploy-preview"'; then
+    echo "✓ 'deploy-preview' label present — building preview."
+    exit 1
+fi
+
+echo "✗ 'deploy-preview' label absent (or labels unreadable) — skipping preview build."
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://openapi.vercel.sh/vercel.json",
+    "framework": "vite",
+    "buildCommand": "npm run build",
+    "outputDirectory": "dist",
+    "ignoreCommand": "bash scripts/vercel-ignore-build.sh"
+}


### PR DESCRIPTION
Closes #350

## What & why

Phase 6 — deploy the Vite static build to Vercel. This PR captures the **repo-side configuration as code** so the only remaining work is the maintainer's Vercel-dashboard steps. No Vercel project exists yet (I checked), so connecting the repo stays a maintainer action.

## Changes

- **`vercel.json`** — pins `framework: vite`, `buildCommand: npm run build`, `outputDirectory: dist`, and the **Ignored Build Step** via `ignoreCommand`. Per the Vercel docs, `ignoreCommand` in `vercel.json` overrides the dashboard setting, so the gate is config-as-code (no dashboard step for it).
- **`scripts/vercel-ignore-build.sh`** — the gate Vercel reads by **exit code (`1` = build, `0` = skip)**:
  - Production (`VERCEL_ENV=production`) → always builds.
  - Preview → builds **only if the PR carries the `deploy-preview` label** (read from the public GitHub API via `VERCEL_GIT_PULL_REQUEST_ID`/`_REPO_OWNER`/`_REPO_SLUG`), **failing closed** (skip) if the label can't be confirmed. Keeps the hobby tier from building a preview on every push.
- **`docs/vercel-deployment.md`** — how the gating works + the one-time maintainer dashboard steps.
- **ROADMAP** — config-as-code item checked off; dashboard/label items flagged `(maintainer)`.

## Maintainer steps to finish Phase 6 (can't be done from the repo)

1. Create the `deploy-preview` GitHub label (no label-creation tool available to the agent here).
2. Import `chriskinch/phasercraft` into Vercel — build settings come from `vercel.json`.
3. Add `VITE_GRAPHQL_URL` (may stay **unset in Production** until Phase 7 → graceful "merchant unavailable").
4. Confirm `phasercraft.vercel.app` is live and the game plays.

## Verification

`typecheck` · `lint` · `format:check` · `test` (191) · `build` all pass. The gate script: `bash -n` clean; exit-code logic exercised locally — `VERCEL_ENV=production` → exit 1 (build), preview with no PR → exit 0 (skip), preview + unreachable API → exit 0 (fail-closed). Base path is unaffected (Vercel build leaves `VITE_BASE_URL` unset → base `/`; Pages keeps `/phasercraft/`). No app/source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHffpDRT254bi5GiMKoAGU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHffpDRT254bi5GiMKoAGU)_