### PR TITLE
feat: Vercel armory API (/api/armory) on Vercel KV (Phase 7 PR2)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,7 @@
+# Keep test files out of the Vercel deployment. Vercel turns every non-underscore
+# file under api/ into a serverless function; a co-located *.test.ts would become
+# a broken function (it imports vitest, a dev-only dep). These files are not
+# needed at runtime or for the Vite build.
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts

--- a/api/armory/README.md
+++ b/api/armory/README.md
@@ -1,0 +1,43 @@
+# Armory API (`/api/armory`)
+
+The armory item service, running as Vercel Functions backed by Vercel KV. This is
+the Phase 7 replacement for the legacy AWS Lambda + DynamoDB service in
+`services/armory/` — it produces **structurally identical** responses (see the
+shared contract in `test/contract/armoryContract.ts`). Nothing here is wired to
+the frontend yet; that happens in Phase 8 (PR3).
+
+## Endpoints
+
+| Method   | Path                       | Description                                               | Legacy equivalent    |
+| -------- | -------------------------- | --------------------------------------------------------- | -------------------- |
+| `GET`    | `/api/armory/items`        | List all items                                            | `GET /items`         |
+| `POST`   | `/api/armory/items`        | Generate + store one item (optional body overrides)       | `POST /items`        |
+| `GET`    | `/api/armory/items/:id`    | Get one item                                              | `GET /items/{id}`    |
+| `DELETE` | `/api/armory/items/:id`    | Remove + return one item                                  | `DELETE /items/{id}` |
+| `POST`   | `/api/armory/store/create` | Batch-generate N items (`{ amount }`, default 1, max 200) | `POST /createStore`  |
+| `POST`   | `/api/armory/store/clear`  | Empty the store (plain-text body)                         | `POST /clearStore`   |
+
+## Storage
+
+Items live in a single Redis hash (`armory:items`, field = item id, value = the
+item). The handlers depend only on the `ItemStore` interface (`_lib/itemStore.ts`):
+
+- **MemoryItemStore** — a `Map`, used by tests, the smoke harness, and local dev.
+- **KvItemStore** — Vercel KV (Upstash Redis).
+
+The factory uses Vercel KV when a binding is present (`KV_REST_API_URL` env var),
+otherwise falls back to the in-memory store, so nothing breaks before the store
+is provisioned.
+
+## Verifying it standalone (no infra)
+
+```bash
+npm run armory:smoke   # watch generate → store → list → retrieve → delete
+npm test               # api/armory/handlers.test.ts asserts the full flow + contract parity
+```
+
+## Production (maintainer)
+
+1. Create a Vercel KV store and connect it to the project — Vercel injects
+   `KV_REST_API_URL` / `KV_REST_API_TOKEN` automatically.
+2. Deploy. The functions are picked up from `api/` with no extra config.

--- a/api/armory/README.md
+++ b/api/armory/README.md
@@ -23,11 +23,11 @@ Items live in a single Redis hash (`armory:items`, field = item id, value = the
 item). The handlers depend only on the `ItemStore` interface (`_lib/itemStore.ts`):
 
 - **MemoryItemStore** — a `Map`, used by tests, the smoke harness, and local dev.
-- **KvItemStore** — Vercel KV (Upstash Redis).
+- **RedisItemStore** — a Redis client (`ioredis`) over the `REDIS_URL` connection
+  string injected by the Vercel KV / Upstash store.
 
-The factory uses Vercel KV when a binding is present (`KV_REST_API_URL` env var),
-otherwise falls back to the in-memory store, so nothing breaks before the store
-is provisioned.
+The factory uses Redis when `REDIS_URL` is present, otherwise falls back to the
+in-memory store, so nothing breaks before the store is provisioned.
 
 ## Verifying it standalone (no infra)
 
@@ -38,6 +38,6 @@ npm test               # api/armory/handlers.test.ts asserts the full flow + con
 
 ## Production (maintainer)
 
-1. Create a Vercel KV store and connect it to the project — Vercel injects
-   `KV_REST_API_URL` / `KV_REST_API_TOKEN` automatically.
+1. Create a Vercel KV / Upstash Redis store and connect it to the project —
+   Vercel injects `REDIS_URL` automatically.
 2. Deploy. The functions are picked up from `api/` with no extra config.

--- a/api/armory/_lib/constants.ts
+++ b/api/armory/_lib/constants.ts
@@ -1,0 +1,60 @@
+// Item generation constants — ported verbatim from
+// `services/armory/src/common/constants.ts` (the legacy AWS armory) so the new
+// Vercel armory generates structurally identical items. Do not "improve" these;
+// parity with the legacy generator is the whole point of Phase 7.
+
+export const statNames = Object.freeze({
+    ATTACK_POWER: "attack_power",
+    ATTACK_SPEED: "attack_speed",
+    MAGIC_POWER: "magic_power",
+    CRITICAL_CHANCE: "critical_chance",
+    SPEED: "speed",
+    DEFENCE: "defence",
+    HEALTH_MAX: "health_max",
+    HEALTH_REGEN_RATE: "health_regen_rate",
+    HEALTH_REGEN_VALUE: "health_regen_value",
+});
+
+export const itemCategories = Object.freeze({
+    AMULET: "amulet",
+    ARMOR: "armor",
+    AXE: "axe",
+    BOW: "bow",
+    GEM: "gem",
+    HELMET: "helmet",
+    MISC: "misc",
+    STAFF: "staff",
+    SWORD: "sword",
+});
+
+export enum Stats {
+    attack_power = "attack_power",
+    attack_speed = "attack_speed",
+    magic_power = "magic_power",
+    critical_chance = "critical_chance",
+    speed = "speed",
+    defence = "defence",
+    health_max = "health_max",
+    health_regen_rate = "health_regen_rate",
+    health_regen_value = "health_regen_value",
+}
+
+export enum Categories {
+    Amulet = "amulet",
+    Armor = "armor",
+    Axe = "axe",
+    Bow = "bow",
+    Gem = "gem",
+    Helmet = "helmet",
+    Misc = "misc",
+    Staff = "staff",
+    Sword = "sword",
+}
+
+export enum Qualities {
+    "common",
+    "fine",
+    "rare",
+    "epic",
+    "legendary",
+}

--- a/api/armory/_lib/generateItem.test.ts
+++ b/api/armory/_lib/generateItem.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { generateItem } from "./generateItem";
+import { createStoredItem } from "./item";
+import { Categories, Stats } from "./constants";
+import { validate, itemContract } from "../../../test/contract/armoryContract";
+
+const categories = Object.values(Categories) as string[];
+const statNames = Object.values(Stats) as string[];
+const qualities = ["common", "fine", "rare", "epic", "legendary"];
+
+describe("generateItem", () => {
+    it("produces a structurally valid item over many random rolls", () => {
+        for (let i = 0; i < 250; i++) {
+            const stored = createStoredItem();
+            // The stored shape must satisfy the legacy contract exactly.
+            expect(validate(itemContract, stored)).toEqual([]);
+            expect(categories).toContain(stored.category);
+            expect(qualities).toContain(stored.quality);
+            expect(stored.qualitySort).toBeGreaterThanOrEqual(1);
+            expect(stored.qualitySort).toBeLessThanOrEqual(5);
+            expect(stored.icon.startsWith(`${stored.category}_`)).toBe(true);
+            expect(stored.stats.length).toBeGreaterThan(0);
+            for (const stat of stored.stats) {
+                expect(statNames).toContain(stat.name);
+                expect(typeof stat.value).toBe("number");
+            }
+        }
+    });
+
+    it("honours explicit overrides", () => {
+        const item = generateItem({
+            name: "Test Blade",
+            category: "sword",
+            quality: "legendary",
+        });
+        expect(item.name).toBe("Test Blade");
+        expect(item.category).toBe("sword");
+        expect(item.quality).toBe("legendary");
+        expect(item.qualitySort).toBe(5);
+        expect(item.cost).toBe(200);
+    });
+
+    it("converts a stats override into id'd stat entries", () => {
+        const item = generateItem({ stats: { attack_power: 12, defence: 7 } });
+        const byName = Object.fromEntries(item.stats.map((s) => [s.name, s]));
+        expect(item.stats).toHaveLength(2);
+        expect(byName.attack_power?.value).toBe(12);
+        expect(byName.defence?.value).toBe(7);
+        for (const stat of item.stats) expect(typeof stat.id).toBe("string");
+    });
+});
+
+describe("createStoredItem", () => {
+    it("adds a unique id and a createdAt timestamp", () => {
+        const a = createStoredItem();
+        const b = createStoredItem();
+        expect(a.id).not.toBe(b.id);
+        expect(typeof a.id).toBe("string");
+        expect(typeof a.createdAt).toBe("number");
+    });
+});

--- a/api/armory/_lib/generateItem.ts
+++ b/api/armory/_lib/generateItem.ts
@@ -1,0 +1,155 @@
+// Item generator — ported from `services/armory/src/common/generateItem.ts`
+// (the legacy AWS armory) with NO algorithm changes, so the new Vercel armory
+// produces structurally identical items. Only the seams changed: the input type
+// is the hand-written `ItemInput` (instead of `json-schema-to-ts`), constants
+// are imported locally, and the stray debug `console.log` was dropped.
+
+import { v4 as uuidv4 } from "uuid";
+import { findKey, random, sample, sampleSize } from "lodash";
+import * as FCG from "fantasy-content-generator";
+
+import { Categories, Stats } from "./constants";
+import type { Category, GeneratedItem, ItemInput, Stat, StatGroup } from "./types";
+
+type StatKey = keyof typeof Stats;
+
+interface QualityLevel {
+    keys: StatKey[];
+    pool: number;
+    qualitySort: number;
+    cost: number;
+}
+
+interface QualityMap {
+    [key: string]: QualityLevel;
+}
+
+const getRandomStatNames = (number = 1): StatKey[] =>
+    sampleSize(Object.values(Stats), number) as StatKey[];
+
+const getQualityMap = (): QualityMap => ({
+    common: {
+        keys: getRandomStatNames(random(1, 2)),
+        pool: random(15, 30),
+        qualitySort: 1,
+        cost: 5,
+    },
+    fine: {
+        keys: getRandomStatNames(random(1, 3)),
+        pool: random(25, 50),
+        qualitySort: 2,
+        cost: 15,
+    },
+    rare: {
+        keys: getRandomStatNames(random(2, 3)),
+        pool: random(40, 80),
+        qualitySort: 3,
+        cost: 40,
+    },
+    epic: {
+        keys: getRandomStatNames(random(2, 3)),
+        pool: random(65, 130),
+        qualitySort: 4,
+        cost: 90,
+    },
+    legendary: {
+        keys: getRandomStatNames(random(3, 4)),
+        pool: random(110, 220),
+        qualitySort: 5,
+        cost: 200,
+    },
+});
+
+const thing: Record<Category, number> = {
+    amulet: 3,
+    armor: 30,
+    axe: 40,
+    bow: 6,
+    gem: 10,
+    helmet: 50,
+    misc: 12,
+    staff: 3,
+    sword: 24,
+};
+
+const getRandomCategory = (): Category => sample(Object.values(Categories)) as Category;
+const getIcon = (category: string, max: number) => `${category}_${random(1, max, false)}`;
+const getQuality = (roll = Math.random()) =>
+    roll < 0.01
+        ? "legendary"
+        : roll < 0.1
+          ? "epic"
+          : roll < 0.3
+            ? "rare"
+            : roll < 0.6
+              ? "fine"
+              : "common";
+const getSet = (category: string) =>
+    findKey(
+        {
+            amulet: ["amulet", "gem", "misc"],
+            body: ["armor"],
+            helm: ["helmet"],
+            weapon: ["axe", "bow", "staff", "sword"],
+        },
+        (c) => c.includes(category)
+    );
+
+const allocateStatIterator = (pool: number, length: number) => {
+    let count = 0;
+    const statIterator = {
+        next: (key: StatKey) => {
+            const range = 1 / (length * 2); // E.g 2 stats = 50% mid way so range is from 25% to 75%.
+            const deduction = Math.round(pool * random(range, range * 3)); // Percentage of lower to upper range.
+            if (count < length - 1) {
+                pool -= deduction;
+                count++;
+                return { value: deduction, done: false, key };
+            }
+            return { value: pool, done: true, key };
+        },
+    };
+    return statIterator;
+};
+
+const getStats = (qualityType: QualityLevel): Stat[] => {
+    const keys = qualityType.keys;
+    const pool = qualityType.pool;
+    const it = allocateStatIterator(pool, keys.length);
+    return keys.map((key) => ({
+        id: uuidv4(),
+        name: key,
+        value: it.next(key).value,
+    }));
+};
+
+const addStatIds = (stats: StatGroup): Stat[] => {
+    const keys = Object.keys(stats) as StatKey[];
+    return keys.map((key) => ({
+        id: uuidv4(),
+        name: key,
+        value: stats[key]!,
+    }));
+};
+
+interface MagicItemResult {
+    formattedData: { title: string };
+}
+
+export const generateItem = (data?: ItemInput): GeneratedItem => {
+    const qualityMap: QualityMap = getQualityMap();
+    const generated: MagicItemResult = FCG.MagicItems.generate();
+    const name = data?.name || generated.formattedData.title;
+    const category = data?.category || getRandomCategory();
+    const set = data?.set || getSet(category);
+    const quality = data?.quality || getQuality();
+    const qualityLevel = qualityMap[quality];
+    const qualitySort = data?.qualitySort || qualityLevel.qualitySort;
+    const cost = data?.cost || qualityLevel.cost;
+    const pool = data?.pool || qualityLevel.pool;
+    const categoryMax: number = thing[category];
+    const icon = data?.icon || getIcon(category, categoryMax);
+    const stats = data?.stats ? addStatIds(data.stats) : getStats(qualityLevel);
+
+    return { ...data, name, category, set, quality, qualitySort, cost, pool, icon, stats };
+};

--- a/api/armory/_lib/generateItem.ts
+++ b/api/armory/_lib/generateItem.ts
@@ -4,7 +4,7 @@
 // is the hand-written `ItemInput` (instead of `json-schema-to-ts`), constants
 // are imported locally, and the stray debug `console.log` was dropped.
 
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { findKey, random, sample, sampleSize } from "lodash";
 import * as FCG from "fantasy-content-generator";
 
@@ -117,7 +117,7 @@ const getStats = (qualityType: QualityLevel): Stat[] => {
     const pool = qualityType.pool;
     const it = allocateStatIterator(pool, keys.length);
     return keys.map((key) => ({
-        id: uuidv4(),
+        id: randomUUID(),
         name: key,
         value: it.next(key).value,
     }));
@@ -126,7 +126,7 @@ const getStats = (qualityType: QualityLevel): Stat[] => {
 const addStatIds = (stats: StatGroup): Stat[] => {
     const keys = Object.keys(stats) as StatKey[];
     return keys.map((key) => ({
-        id: uuidv4(),
+        id: randomUUID(),
         name: key,
         value: stats[key]!,
     }));

--- a/api/armory/_lib/http.ts
+++ b/api/armory/_lib/http.ts
@@ -1,0 +1,68 @@
+// Minimal request/response shapes for Vercel Node functions. Typed structurally
+// (rather than depending on `@vercel/node`, which pulls a whole build toolchain
+// and its audit advisories) — these cover exactly what the handlers use, and
+// match the Vercel `(req, res)` runtime contract.
+
+export interface ApiRequest {
+    method?: string;
+    query?: Record<string, string | string[] | undefined>;
+    body?: unknown;
+}
+
+export interface ApiResponse {
+    setHeader(name: string, value: string): void;
+    status(code: number): ApiResponse;
+    json(body: unknown): void;
+    send(body: string): void;
+    end(): void;
+}
+
+const applyCors = (res: ApiResponse): void => {
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+};
+
+/** Returns true if the request was a CORS preflight and has been answered. */
+export const handlePreflight = (req: ApiRequest, res: ApiResponse): boolean => {
+    if (req.method === "OPTIONS") {
+        applyCors(res);
+        res.status(204).end();
+        return true;
+    }
+    return false;
+};
+
+export const sendJson = (res: ApiResponse, status: number, data: unknown): void => {
+    applyCors(res);
+    res.status(status).json(data);
+};
+
+export const sendText = (res: ApiResponse, status: number, text: string): void => {
+    applyCors(res);
+    res.setHeader("Content-Type", "text/plain");
+    res.status(status).send(text);
+};
+
+export const methodNotAllowed = (res: ApiResponse, allow: string): void => {
+    applyCors(res);
+    res.setHeader("Allow", allow);
+    res.status(405).json({ error: "Method not allowed." });
+};
+
+/** Vercel parses JSON bodies into `req.body`; tolerate a raw string too. */
+export const parseBody = (req: ApiRequest): unknown => {
+    if (typeof req.body === "string") {
+        if (req.body.trim() === "") return undefined;
+        try {
+            return JSON.parse(req.body);
+        } catch {
+            return undefined;
+        }
+    }
+    return req.body;
+};
+
+/** Reads a single path-param value (`req.query.id` may be string | string[]). */
+export const firstQueryValue = (value: string | string[] | undefined): string | undefined =>
+    Array.isArray(value) ? value[0] : value;

--- a/api/armory/_lib/http.ts
+++ b/api/armory/_lib/http.ts
@@ -66,3 +66,22 @@ export const parseBody = (req: ApiRequest): unknown => {
 /** Reads a single path-param value (`req.query.id` may be string | string[]). */
 export const firstQueryValue = (value: string | string[] | undefined): string | undefined =>
     Array.isArray(value) ? value[0] : value;
+
+/**
+ * Wraps a handler so any thrown error becomes a JSON 500 (and a server log)
+ * instead of an opaque FUNCTION_INVOCATION_FAILED. `detail` surfaces the message
+ * to make misconfiguration (e.g. a missing KV binding) diagnosable.
+ */
+export const withErrors =
+    (handler: (req: ApiRequest, res: ApiResponse) => Promise<void>) =>
+    async (req: ApiRequest, res: ApiResponse): Promise<void> => {
+        try {
+            await handler(req, res);
+        } catch (err) {
+            console.error("[armory] handler error", err);
+            sendJson(res, 500, {
+                error: "Internal server error.",
+                detail: err instanceof Error ? err.message : String(err),
+            });
+        }
+    };

--- a/api/armory/_lib/item.ts
+++ b/api/armory/_lib/item.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import { generateItem } from "./generateItem";
 import type { ItemInput, StoredItem } from "./types";
 
@@ -6,7 +6,7 @@ import type { ItemInput, StoredItem } from "./types";
 // the legacy create/createStore handlers added before persisting. Centralised so
 // the single-create and batch-create paths stay identical.
 export const createStoredItem = (data?: ItemInput): StoredItem => ({
-    id: uuidv4(),
+    id: randomUUID(),
     createdAt: Date.now(),
     ...generateItem(data),
 });

--- a/api/armory/_lib/item.ts
+++ b/api/armory/_lib/item.ts
@@ -1,0 +1,12 @@
+import { v4 as uuidv4 } from "uuid";
+import { generateItem } from "./generateItem";
+import type { ItemInput, StoredItem } from "./types";
+
+// Wraps a freshly generated item with the storage fields (`id`, `createdAt`)
+// the legacy create/createStore handlers added before persisting. Centralised so
+// the single-create and batch-create paths stay identical.
+export const createStoredItem = (data?: ItemInput): StoredItem => ({
+    id: uuidv4(),
+    createdAt: Date.now(),
+    ...generateItem(data),
+});

--- a/api/armory/_lib/itemStore.test.ts
+++ b/api/armory/_lib/itemStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MemoryItemStore } from "./itemStore";
+import { createStoredItem } from "./item";
+import type { StoredItem } from "./types";
+
+describe("MemoryItemStore", () => {
+    let store: MemoryItemStore;
+    let item: StoredItem;
+
+    beforeEach(() => {
+        store = new MemoryItemStore();
+        item = createStoredItem();
+    });
+
+    it("starts empty", async () => {
+        expect(await store.list()).toEqual([]);
+    });
+
+    it("puts and gets an item by id", async () => {
+        await store.put(item);
+        expect(await store.get(item.id)).toEqual(item);
+        expect(await store.list()).toHaveLength(1);
+    });
+
+    it("returns null for a missing id", async () => {
+        expect(await store.get("nope")).toBeNull();
+    });
+
+    it("putMany stores a batch", async () => {
+        const batch = [createStoredItem(), createStoredItem(), createStoredItem()];
+        await store.putMany(batch);
+        expect(await store.list()).toHaveLength(3);
+    });
+
+    it("remove deletes and returns the item; second remove is null", async () => {
+        await store.put(item);
+        expect(await store.remove(item.id)).toEqual(item);
+        expect(await store.get(item.id)).toBeNull();
+        expect(await store.remove(item.id)).toBeNull();
+    });
+
+    it("clear empties the store", async () => {
+        await store.putMany([createStoredItem(), createStoredItem()]);
+        await store.clear();
+        expect(await store.list()).toEqual([]);
+    });
+
+    it("stores copies, not references (mutating a returned item can't corrupt the store)", async () => {
+        await store.put(item);
+        const fetched = await store.get(item.id);
+        fetched!.cost = -999;
+        expect((await store.get(item.id))!.cost).toBe(item.cost);
+    });
+});

--- a/api/armory/_lib/itemStore.ts
+++ b/api/armory/_lib/itemStore.ts
@@ -7,7 +7,7 @@
 // The factory picks Redis when `REDIS_URL` is present, otherwise falls back to
 // memory — so nothing breaks before the store is provisioned.
 
-import Redis from "ioredis";
+import type Redis from "ioredis";
 import type { StoredItem } from "./types";
 
 /** Redis hash key holding the whole shop, field = item id, value = item JSON. */
@@ -57,44 +57,56 @@ export class MemoryItemStore implements ItemStore {
     }
 }
 
-// One client per warm function instance. ioredis lazily connects on first
-// command, so constructing it at module scope is cheap and connection-safe.
+// One client per warm function instance. ioredis is loaded via dynamic import
+// (so a load/connection failure surfaces inside the request — catchable by
+// withErrors — rather than as an opaque module-load crash) and configured to
+// fail fast instead of retry-looping until the function times out.
 let redis: Redis | null = null;
-const client = (): Redis => (redis ??= new Redis(process.env.REDIS_URL as string));
+const client = async (): Promise<Redis> => {
+    if (redis) return redis;
+    const { default: RedisCtor } = await import("ioredis");
+    redis = new RedisCtor(process.env.REDIS_URL as string, {
+        connectTimeout: 5000,
+        maxRetriesPerRequest: 1,
+        enableOfflineQueue: false,
+        retryStrategy: () => null,
+    });
+    return redis;
+};
 
 const parse = (value: string | null): StoredItem | null =>
     value ? (JSON.parse(value) as StoredItem) : null;
 
 export class RedisItemStore implements ItemStore {
     async list(): Promise<StoredItem[]> {
-        const all = await client().hgetall(ITEMS_KEY);
+        const all = await (await client()).hgetall(ITEMS_KEY);
         return Object.values(all).map((v) => JSON.parse(v) as StoredItem);
     }
 
     async get(id: string): Promise<StoredItem | null> {
-        return parse(await client().hget(ITEMS_KEY, id));
+        return parse(await (await client()).hget(ITEMS_KEY, id));
     }
 
     async put(item: StoredItem): Promise<void> {
-        await client().hset(ITEMS_KEY, item.id, JSON.stringify(item));
+        await (await client()).hset(ITEMS_KEY, item.id, JSON.stringify(item));
     }
 
     async putMany(items: StoredItem[]): Promise<void> {
         if (items.length === 0) return;
         const pairs: Record<string, string> = {};
         for (const item of items) pairs[item.id] = JSON.stringify(item);
-        await client().hset(ITEMS_KEY, pairs);
+        await (await client()).hset(ITEMS_KEY, pairs);
     }
 
     async remove(id: string): Promise<StoredItem | null> {
         const existing = await this.get(id);
         if (!existing) return null;
-        await client().hdel(ITEMS_KEY, id);
+        await (await client()).hdel(ITEMS_KEY, id);
         return existing;
     }
 
     async clear(): Promise<void> {
-        await client().del(ITEMS_KEY);
+        await (await client()).del(ITEMS_KEY);
     }
 }
 

--- a/api/armory/_lib/itemStore.ts
+++ b/api/armory/_lib/itemStore.ts
@@ -65,11 +65,13 @@ let redis: Redis | null = null;
 const client = async (): Promise<Redis> => {
     if (redis) return redis;
     const { default: RedisCtor } = await import("ioredis");
+    // Serverless-friendly: the first command waits for the connection (offline
+    // queue left on), with a generous connect timeout and a bounded reconnect so
+    // a transient blip retries a few times but a real failure still surfaces.
     redis = new RedisCtor(process.env.REDIS_URL as string, {
-        connectTimeout: 5000,
-        maxRetriesPerRequest: 1,
-        enableOfflineQueue: false,
-        retryStrategy: () => null,
+        connectTimeout: 10000,
+        maxRetriesPerRequest: 5,
+        retryStrategy: (times: number) => (times > 5 ? null : Math.min(times * 200, 2000)),
     });
     return redis;
 };

--- a/api/armory/_lib/itemStore.ts
+++ b/api/armory/_lib/itemStore.ts
@@ -1,0 +1,105 @@
+// Storage seam for the armory. The handlers depend only on the `ItemStore`
+// interface; the implementation is chosen at runtime:
+//   - MemoryItemStore: a plain Map, used by tests, the standalone harness, and
+//     local dev (zero infra).
+//   - KvItemStore: Vercel KV (an Upstash Redis hash, field = item id, value =
+//     the item) for production.
+// The factory picks KV when a Vercel KV binding is present (`KV_REST_API_URL`),
+// otherwise falls back to memory — so nothing breaks before the maintainer
+// provisions the store.
+
+import { kv } from "@vercel/kv";
+import type { StoredItem } from "./types";
+
+/** Redis hash key holding the whole shop, field = item id, value = item JSON. */
+export const ITEMS_KEY = "armory:items";
+
+export interface ItemStore {
+    list(): Promise<StoredItem[]>;
+    get(id: string): Promise<StoredItem | null>;
+    put(item: StoredItem): Promise<void>;
+    putMany(items: StoredItem[]): Promise<void>;
+    /** Removes and returns the item (legacy DELETE returns the deleted item), or null if absent. */
+    remove(id: string): Promise<StoredItem | null>;
+    clear(): Promise<void>;
+}
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+export class MemoryItemStore implements ItemStore {
+    private items = new Map<string, StoredItem>();
+
+    async list(): Promise<StoredItem[]> {
+        return [...this.items.values()].map(clone);
+    }
+
+    async get(id: string): Promise<StoredItem | null> {
+        const item = this.items.get(id);
+        return item ? clone(item) : null;
+    }
+
+    async put(item: StoredItem): Promise<void> {
+        this.items.set(item.id, clone(item));
+    }
+
+    async putMany(items: StoredItem[]): Promise<void> {
+        for (const item of items) this.items.set(item.id, clone(item));
+    }
+
+    async remove(id: string): Promise<StoredItem | null> {
+        const item = this.items.get(id);
+        if (!item) return null;
+        this.items.delete(id);
+        return clone(item);
+    }
+
+    async clear(): Promise<void> {
+        this.items.clear();
+    }
+}
+
+export class KvItemStore implements ItemStore {
+    async list(): Promise<StoredItem[]> {
+        const all = await kv.hgetall<Record<string, StoredItem>>(ITEMS_KEY);
+        return all ? Object.values(all) : [];
+    }
+
+    async get(id: string): Promise<StoredItem | null> {
+        return (await kv.hget<StoredItem>(ITEMS_KEY, id)) ?? null;
+    }
+
+    async put(item: StoredItem): Promise<void> {
+        await kv.hset(ITEMS_KEY, { [item.id]: item });
+    }
+
+    async putMany(items: StoredItem[]): Promise<void> {
+        if (items.length === 0) return;
+        const entries: Record<string, StoredItem> = {};
+        for (const item of items) entries[item.id] = item;
+        await kv.hset(ITEMS_KEY, entries);
+    }
+
+    async remove(id: string): Promise<StoredItem | null> {
+        const existing = await this.get(id);
+        if (!existing) return null;
+        await kv.hdel(ITEMS_KEY, id);
+        return existing;
+    }
+
+    async clear(): Promise<void> {
+        await kv.del(ITEMS_KEY);
+    }
+}
+
+let instance: ItemStore | null = null;
+
+/** Returns the process-wide store, creating it from the environment on first use. */
+export const getItemStore = (): ItemStore => (instance ??= createItemStore());
+
+/** Test/harness hook to inject a store (and reset between tests). */
+export const setItemStore = (store: ItemStore | null): void => {
+    instance = store;
+};
+
+const createItemStore = (): ItemStore =>
+    process.env.KV_REST_API_URL ? new KvItemStore() : new MemoryItemStore();

--- a/api/armory/_lib/itemStore.ts
+++ b/api/armory/_lib/itemStore.ts
@@ -2,13 +2,12 @@
 // interface; the implementation is chosen at runtime:
 //   - MemoryItemStore: a plain Map, used by tests, the standalone harness, and
 //     local dev (zero infra).
-//   - KvItemStore: Vercel KV (an Upstash Redis hash, field = item id, value =
-//     the item) for production.
-// The factory picks KV when a Vercel KV binding is present (`KV_REST_API_URL`),
-// otherwise falls back to memory — so nothing breaks before the maintainer
-// provisions the store.
+//   - RedisItemStore: a Redis hash (field = item id, value = JSON), backed by the
+//     `REDIS_URL` connection string that the Vercel KV / Upstash store injects.
+// The factory picks Redis when `REDIS_URL` is present, otherwise falls back to
+// memory — so nothing breaks before the store is provisioned.
 
-import { kv } from "@vercel/kv";
+import Redis from "ioredis";
 import type { StoredItem } from "./types";
 
 /** Redis hash key holding the whole shop, field = item id, value = item JSON. */
@@ -58,36 +57,44 @@ export class MemoryItemStore implements ItemStore {
     }
 }
 
-export class KvItemStore implements ItemStore {
+// One client per warm function instance. ioredis lazily connects on first
+// command, so constructing it at module scope is cheap and connection-safe.
+let redis: Redis | null = null;
+const client = (): Redis => (redis ??= new Redis(process.env.REDIS_URL as string));
+
+const parse = (value: string | null): StoredItem | null =>
+    value ? (JSON.parse(value) as StoredItem) : null;
+
+export class RedisItemStore implements ItemStore {
     async list(): Promise<StoredItem[]> {
-        const all = await kv.hgetall<Record<string, StoredItem>>(ITEMS_KEY);
-        return all ? Object.values(all) : [];
+        const all = await client().hgetall(ITEMS_KEY);
+        return Object.values(all).map((v) => JSON.parse(v) as StoredItem);
     }
 
     async get(id: string): Promise<StoredItem | null> {
-        return (await kv.hget<StoredItem>(ITEMS_KEY, id)) ?? null;
+        return parse(await client().hget(ITEMS_KEY, id));
     }
 
     async put(item: StoredItem): Promise<void> {
-        await kv.hset(ITEMS_KEY, { [item.id]: item });
+        await client().hset(ITEMS_KEY, item.id, JSON.stringify(item));
     }
 
     async putMany(items: StoredItem[]): Promise<void> {
         if (items.length === 0) return;
-        const entries: Record<string, StoredItem> = {};
-        for (const item of items) entries[item.id] = item;
-        await kv.hset(ITEMS_KEY, entries);
+        const pairs: Record<string, string> = {};
+        for (const item of items) pairs[item.id] = JSON.stringify(item);
+        await client().hset(ITEMS_KEY, pairs);
     }
 
     async remove(id: string): Promise<StoredItem | null> {
         const existing = await this.get(id);
         if (!existing) return null;
-        await kv.hdel(ITEMS_KEY, id);
+        await client().hdel(ITEMS_KEY, id);
         return existing;
     }
 
     async clear(): Promise<void> {
-        await kv.del(ITEMS_KEY);
+        await client().del(ITEMS_KEY);
     }
 }
 
@@ -102,4 +109,4 @@ export const setItemStore = (store: ItemStore | null): void => {
 };
 
 const createItemStore = (): ItemStore =>
-    process.env.KV_REST_API_URL ? new KvItemStore() : new MemoryItemStore();
+    process.env.REDIS_URL ? new RedisItemStore() : new MemoryItemStore();

--- a/api/armory/_lib/types.ts
+++ b/api/armory/_lib/types.ts
@@ -1,0 +1,54 @@
+// Shared types for the Armory API. These describe the same shape pinned by the
+// structural contract in `test/contract/armoryContract.ts`.
+
+import type { Categories, Stats } from "./constants";
+
+/** A category string, e.g. "sword" | "amulet" | … (the enum's values). */
+export type Category = `${Categories}`;
+
+/** A stat name string, e.g. "attack_power" | "health_max" | … */
+export type StatName = `${Stats}`;
+
+export type Quality = "common" | "fine" | "rare" | "epic" | "legendary";
+
+/** A single allocated stat on an item. */
+export interface Stat {
+    id: string;
+    name: string;
+    value: number;
+}
+
+/** Stats passed in as overrides on create: `{ attack_power: 12, … }`. */
+export type StatGroup = Partial<Record<StatName, number>>;
+
+/** Optional overrides accepted by `POST /items` — any omitted field is generated. */
+export interface ItemInput {
+    name?: string;
+    category?: Category;
+    set?: string;
+    icon?: string;
+    quality?: Quality;
+    qualitySort?: number;
+    cost?: number;
+    pool?: number;
+    stats?: StatGroup;
+}
+
+/** A fully generated item, before it is given an id and a timestamp. */
+export interface GeneratedItem {
+    name: string;
+    category: string;
+    set: string | undefined;
+    quality: string;
+    qualitySort: number;
+    cost: number;
+    pool: number;
+    icon: string;
+    stats: Stat[];
+}
+
+/** A generated item as stored and returned by the API. */
+export interface StoredItem extends GeneratedItem {
+    id: string;
+    createdAt: number;
+}

--- a/api/armory/handlers.test.ts
+++ b/api/armory/handlers.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import itemsHandler from "./items/index";
+import itemByIdHandler from "./items/[id]";
+import storeCreateHandler from "./store/create";
+import storeClearHandler from "./store/clear";
+
+import { MemoryItemStore, setItemStore } from "./_lib/itemStore";
+import type { ApiRequest, ApiResponse } from "./_lib/http";
+import type { StoredItem } from "./_lib/types";
+import { validate, itemContract, itemListContract } from "../../test/contract/armoryContract";
+
+interface Captured {
+    statusCode: number;
+    json: unknown;
+    text: string | undefined;
+    headers: Record<string, string>;
+    ended: boolean;
+}
+
+const mockRes = (): { res: ApiResponse; captured: Captured } => {
+    const captured: Captured = {
+        statusCode: 0,
+        json: undefined,
+        text: undefined,
+        headers: {},
+        ended: false,
+    };
+    const res: ApiResponse = {
+        setHeader(name, value) {
+            captured.headers[name] = value;
+        },
+        status(code) {
+            captured.statusCode = code;
+            return res;
+        },
+        json(body) {
+            captured.json = body;
+        },
+        send(body) {
+            captured.text = body;
+        },
+        end() {
+            captured.ended = true;
+        },
+    };
+    return { res, captured };
+};
+
+const mockReq = (
+    method: string,
+    opts: { query?: ApiRequest["query"]; body?: unknown } = {}
+): ApiRequest => ({ method, query: opts.query, body: opts.body });
+
+type Handler = (req: ApiRequest, res: ApiResponse) => Promise<void>;
+
+const run = async (
+    handler: Handler,
+    method: string,
+    opts: { query?: ApiRequest["query"]; body?: unknown } = {}
+): Promise<Captured> => {
+    const { res, captured } = mockRes();
+    await handler(mockReq(method, opts), res);
+    return captured;
+};
+
+beforeEach(() => {
+    setItemStore(new MemoryItemStore());
+});
+
+describe("POST/GET /api/armory/items", () => {
+    it("creates an item (contract-valid) and lists it", async () => {
+        const created = await run(itemsHandler, "POST", { body: {} });
+        expect(created.statusCode).toBe(200);
+        expect(validate(itemContract, created.json)).toEqual([]);
+
+        const listed = await run(itemsHandler, "GET");
+        expect(listed.statusCode).toBe(200);
+        expect(validate(itemListContract, listed.json)).toEqual([]);
+        expect(listed.json as StoredItem[]).toHaveLength(1);
+        expect((listed.json as StoredItem[])[0]!.id).toBe((created.json as StoredItem).id);
+    });
+
+    it("applies body overrides on create", async () => {
+        const created = await run(itemsHandler, "POST", {
+            body: { name: "Override Blade", category: "sword", quality: "epic" },
+        });
+        const item = created.json as StoredItem;
+        expect(item.name).toBe("Override Blade");
+        expect(item.category).toBe("sword");
+        expect(item.quality).toBe("epic");
+    });
+
+    it("rejects an unsupported method with 405 + Allow header", async () => {
+        const res = await run(itemsHandler, "PUT");
+        expect(res.statusCode).toBe(405);
+        expect(res.headers["Allow"]).toContain("GET");
+    });
+
+    it("answers a CORS preflight", async () => {
+        const res = await run(itemsHandler, "OPTIONS");
+        expect(res.statusCode).toBe(204);
+        expect(res.ended).toBe(true);
+        expect(res.headers["Access-Control-Allow-Origin"]).toBe("*");
+    });
+});
+
+describe("GET/DELETE /api/armory/items/[id]", () => {
+    it("gets an item by id", async () => {
+        const created = (await run(itemsHandler, "POST", { body: {} })).json as StoredItem;
+        const got = await run(itemByIdHandler, "GET", { query: { id: created.id } });
+        expect(got.statusCode).toBe(200);
+        expect(validate(itemContract, got.json)).toEqual([]);
+        expect((got.json as StoredItem).id).toBe(created.id);
+    });
+
+    it("returns 404 for a missing id on GET and DELETE", async () => {
+        expect((await run(itemByIdHandler, "GET", { query: { id: "missing" } })).statusCode).toBe(
+            404
+        );
+        expect(
+            (await run(itemByIdHandler, "DELETE", { query: { id: "missing" } })).statusCode
+        ).toBe(404);
+    });
+
+    it("returns 400 when the id is absent", async () => {
+        expect((await run(itemByIdHandler, "GET")).statusCode).toBe(400);
+    });
+
+    it("deletes an item and returns it (contract-valid)", async () => {
+        const created = (await run(itemsHandler, "POST", { body: {} })).json as StoredItem;
+        const deleted = await run(itemByIdHandler, "DELETE", { query: { id: created.id } });
+        expect(deleted.statusCode).toBe(200);
+        expect(validate(itemContract, deleted.json)).toEqual([]);
+        expect((deleted.json as StoredItem).id).toBe(created.id);
+        // Gone afterwards.
+        expect((await run(itemByIdHandler, "GET", { query: { id: created.id } })).statusCode).toBe(
+            404
+        );
+    });
+});
+
+describe("POST /api/armory/store/create", () => {
+    it("batch-generates N contract-valid items", async () => {
+        const res = await run(storeCreateHandler, "POST", { body: { amount: 5 } });
+        expect(res.statusCode).toBe(200);
+        expect(validate(itemListContract, res.json)).toEqual([]);
+        expect(res.json as StoredItem[]).toHaveLength(5);
+        expect((await run(itemsHandler, "GET")).json as StoredItem[]).toHaveLength(5);
+    });
+
+    it("defaults to a single item when no amount is given", async () => {
+        const res = await run(storeCreateHandler, "POST", { body: {} });
+        expect(res.json as StoredItem[]).toHaveLength(1);
+    });
+
+    it("rejects an invalid amount with 400", async () => {
+        expect((await run(storeCreateHandler, "POST", { body: { amount: 0 } })).statusCode).toBe(
+            400
+        );
+        expect((await run(storeCreateHandler, "POST", { body: { amount: 1.5 } })).statusCode).toBe(
+            400
+        );
+        expect((await run(storeCreateHandler, "POST", { body: { amount: 9999 } })).statusCode).toBe(
+            400
+        );
+    });
+});
+
+describe("POST /api/armory/store/clear", () => {
+    it("empties the store and returns the legacy plain-text body", async () => {
+        await run(storeCreateHandler, "POST", { body: { amount: 3 } });
+        const res = await run(storeClearHandler, "POST");
+        expect(res.statusCode).toBe(200);
+        expect(res.text).toBe("Success, store cleared!");
+        expect(res.headers["Content-Type"]).toBe("text/plain");
+        expect((await run(itemsHandler, "GET")).json as StoredItem[]).toEqual([]);
+    });
+});
+
+describe("full CRUD smoke through the handlers", () => {
+    it("clear → stock(5) → list → get → delete → list", async () => {
+        await run(storeClearHandler, "POST");
+
+        const stocked = await run(storeCreateHandler, "POST", { body: { amount: 5 } });
+        expect(validate(itemListContract, stocked.json)).toEqual([]);
+
+        const list = (await run(itemsHandler, "GET")).json as StoredItem[];
+        expect(list).toHaveLength(5);
+
+        const target = list[0]!;
+        const got = await run(itemByIdHandler, "GET", { query: { id: target.id } });
+        expect((got.json as StoredItem).id).toBe(target.id);
+
+        const deleted = await run(itemByIdHandler, "DELETE", { query: { id: target.id } });
+        expect((deleted.json as StoredItem).id).toBe(target.id);
+
+        expect((await run(itemsHandler, "GET")).json as StoredItem[]).toHaveLength(4);
+    });
+});

--- a/api/armory/health.ts
+++ b/api/armory/health.ts
@@ -1,0 +1,36 @@
+// TEMP diagnostic endpoint (Phase 7 bring-up): GET /api/armory/health
+// Reports the runtime Node version and which KV-related env vars the Vercel KV
+// store injected (names only — never values). Used to confirm the `armory-kv`
+// binding is wired with the names @vercel/kv expects (KV_REST_API_URL /
+// KV_REST_API_TOKEN). Remove before merging PR2.
+
+import {
+    type ApiRequest,
+    type ApiResponse,
+    handlePreflight,
+    methodNotAllowed,
+    sendJson,
+    withErrors,
+} from "./_lib/http";
+
+async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+    if (handlePreflight(req, res)) return;
+    if (req.method !== "GET") {
+        methodNotAllowed(res, "GET, OPTIONS");
+        return;
+    }
+
+    const storageEnvKeys = Object.keys(process.env)
+        .filter((k) => /KV|REDIS|UPSTASH|STORAGE/i.test(k))
+        .sort();
+
+    sendJson(res, 200, {
+        ok: true,
+        node: process.version,
+        kvUrlPresent: Boolean(process.env.KV_REST_API_URL),
+        kvTokenPresent: Boolean(process.env.KV_REST_API_TOKEN),
+        storageEnvKeys,
+    });
+}
+
+export default withErrors(handler);

--- a/api/armory/health.ts
+++ b/api/armory/health.ts
@@ -27,8 +27,7 @@ async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
     sendJson(res, 200, {
         ok: true,
         node: process.version,
-        kvUrlPresent: Boolean(process.env.KV_REST_API_URL),
-        kvTokenPresent: Boolean(process.env.KV_REST_API_TOKEN),
+        redisUrlPresent: Boolean(process.env.REDIS_URL),
         storageEnvKeys,
     });
 }

--- a/api/armory/items/[id].ts
+++ b/api/armory/items/[id].ts
@@ -9,10 +9,11 @@ import {
     handlePreflight,
     methodNotAllowed,
     sendJson,
+    withErrors,
 } from "../_lib/http";
 import { getItemStore } from "../_lib/itemStore";
 
-export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
     if (handlePreflight(req, res)) return;
 
     const id = firstQueryValue(req.query?.id);
@@ -45,3 +46,5 @@ export default async function handler(req: ApiRequest, res: ApiResponse): Promis
 
     methodNotAllowed(res, "GET, DELETE, OPTIONS");
 }
+
+export default withErrors(handler);

--- a/api/armory/items/[id].ts
+++ b/api/armory/items/[id].ts
@@ -1,0 +1,47 @@
+// /api/armory/items/[id]
+//   GET    → item by id (legacy: GET /items/{id})
+//   DELETE → remove + return the item (legacy: DELETE /items/{id}, ReturnValues ALL_OLD)
+
+import {
+    type ApiRequest,
+    type ApiResponse,
+    firstQueryValue,
+    handlePreflight,
+    methodNotAllowed,
+    sendJson,
+} from "../_lib/http";
+import { getItemStore } from "../_lib/itemStore";
+
+export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+    if (handlePreflight(req, res)) return;
+
+    const id = firstQueryValue(req.query?.id);
+    if (!id) {
+        sendJson(res, 400, { error: "Missing a valid item id." });
+        return;
+    }
+
+    const store = getItemStore();
+
+    if (req.method === "GET") {
+        const item = await store.get(id);
+        if (!item) {
+            sendJson(res, 404, { error: "No item found with that ID." });
+            return;
+        }
+        sendJson(res, 200, item);
+        return;
+    }
+
+    if (req.method === "DELETE") {
+        const removed = await store.remove(id);
+        if (!removed) {
+            sendJson(res, 404, { error: "No item found with that ID." });
+            return;
+        }
+        sendJson(res, 200, removed);
+        return;
+    }
+
+    methodNotAllowed(res, "GET, DELETE, OPTIONS");
+}

--- a/api/armory/items/index.ts
+++ b/api/armory/items/index.ts
@@ -9,12 +9,13 @@ import {
     methodNotAllowed,
     parseBody,
     sendJson,
+    withErrors,
 } from "../_lib/http";
 import { getItemStore } from "../_lib/itemStore";
 import { createStoredItem } from "../_lib/item";
 import type { ItemInput } from "../_lib/types";
 
-export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
     if (handlePreflight(req, res)) return;
     const store = getItemStore();
 
@@ -33,3 +34,5 @@ export default async function handler(req: ApiRequest, res: ApiResponse): Promis
 
     methodNotAllowed(res, "GET, POST, OPTIONS");
 }
+
+export default withErrors(handler);

--- a/api/armory/items/index.ts
+++ b/api/armory/items/index.ts
@@ -1,0 +1,35 @@
+// /api/armory/items
+//   GET  → all items (legacy: GET /items)
+//   POST → generate + store one item, optional overrides in body (legacy: POST /items)
+
+import {
+    type ApiRequest,
+    type ApiResponse,
+    handlePreflight,
+    methodNotAllowed,
+    parseBody,
+    sendJson,
+} from "../_lib/http";
+import { getItemStore } from "../_lib/itemStore";
+import { createStoredItem } from "../_lib/item";
+import type { ItemInput } from "../_lib/types";
+
+export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+    if (handlePreflight(req, res)) return;
+    const store = getItemStore();
+
+    if (req.method === "GET") {
+        sendJson(res, 200, await store.list());
+        return;
+    }
+
+    if (req.method === "POST") {
+        const input = (parseBody(req) ?? undefined) as ItemInput | undefined;
+        const item = createStoredItem(input);
+        await store.put(item);
+        sendJson(res, 200, item);
+        return;
+    }
+
+    methodNotAllowed(res, "GET, POST, OPTIONS");
+}

--- a/api/armory/store/clear.ts
+++ b/api/armory/store/clear.ts
@@ -1,0 +1,23 @@
+// /api/armory/store/clear
+//   POST → empty the store (legacy: POST /clearStore)
+// Matches the legacy plain-text response body, not JSON.
+
+import {
+    type ApiRequest,
+    type ApiResponse,
+    handlePreflight,
+    methodNotAllowed,
+    sendText,
+} from "../_lib/http";
+import { getItemStore } from "../_lib/itemStore";
+
+export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+    if (handlePreflight(req, res)) return;
+    if (req.method !== "POST") {
+        methodNotAllowed(res, "POST, OPTIONS");
+        return;
+    }
+
+    await getItemStore().clear();
+    sendText(res, 200, "Success, store cleared!");
+}

--- a/api/armory/store/clear.ts
+++ b/api/armory/store/clear.ts
@@ -8,10 +8,11 @@ import {
     handlePreflight,
     methodNotAllowed,
     sendText,
+    withErrors,
 } from "../_lib/http";
 import { getItemStore } from "../_lib/itemStore";
 
-export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
     if (handlePreflight(req, res)) return;
     if (req.method !== "POST") {
         methodNotAllowed(res, "POST, OPTIONS");
@@ -21,3 +22,5 @@ export default async function handler(req: ApiRequest, res: ApiResponse): Promis
     await getItemStore().clear();
     sendText(res, 200, "Success, store cleared!");
 }
+
+export default withErrors(handler);

--- a/api/armory/store/create.ts
+++ b/api/armory/store/create.ts
@@ -9,6 +9,7 @@ import {
     methodNotAllowed,
     parseBody,
     sendJson,
+    withErrors,
 } from "../_lib/http";
 import { getItemStore } from "../_lib/itemStore";
 import { createStoredItem } from "../_lib/item";
@@ -18,7 +19,7 @@ import { createStoredItem } from "../_lib/item";
 // asks for 45, well within it) so a single request can't generate unbounded items.
 const MAX_AMOUNT = 200;
 
-export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
     if (handlePreflight(req, res)) return;
     if (req.method !== "POST") {
         methodNotAllowed(res, "POST, OPTIONS");
@@ -38,3 +39,5 @@ export default async function handler(req: ApiRequest, res: ApiResponse): Promis
     await store.putMany(items);
     sendJson(res, 200, items);
 }
+
+export default withErrors(handler);

--- a/api/armory/store/create.ts
+++ b/api/armory/store/create.ts
@@ -1,0 +1,40 @@
+// /api/armory/store/create
+//   POST { amount } → batch-generate + store N items, return them
+//   (legacy: POST /createStore)
+
+import {
+    type ApiRequest,
+    type ApiResponse,
+    handlePreflight,
+    methodNotAllowed,
+    parseBody,
+    sendJson,
+} from "../_lib/http";
+import { getItemStore } from "../_lib/itemStore";
+import { createStoredItem } from "../_lib/item";
+
+// Legacy `createStore` defaulted to 1 and had no upper bound. The default and
+// generation are unchanged; the cap is a new safety guard (the frontend restock
+// asks for 45, well within it) so a single request can't generate unbounded items.
+const MAX_AMOUNT = 200;
+
+export default async function handler(req: ApiRequest, res: ApiResponse): Promise<void> {
+    if (handlePreflight(req, res)) return;
+    if (req.method !== "POST") {
+        methodNotAllowed(res, "POST, OPTIONS");
+        return;
+    }
+
+    const body = (parseBody(req) ?? {}) as { amount?: unknown };
+    const amount = body.amount === undefined ? 1 : Number(body.amount);
+
+    if (!Number.isInteger(amount) || amount < 1 || amount > MAX_AMOUNT) {
+        sendJson(res, 400, { error: `amount must be an integer between 1 and ${MAX_AMOUNT}.` });
+        return;
+    }
+
+    const store = getItemStore();
+    const items = Array.from({ length: amount }, () => createStoredItem());
+    await store.putMany(items);
+    sendJson(res, 200, items);
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    // Vercel's Node function builder walks up from each `api/**` handler to find
+    // the nearest tsconfig. Without this it picks up the root config, whose
+    // `module: "esnext"` / `moduleResolution: "bundler"` (tuned for Vite) make it
+    // emit ESM into the CommonJS function runtime — which crashes at runtime with
+    // FUNCTION_INVOCATION_FAILED. Force CommonJS output for the functions only;
+    // the root config (and `npm run typecheck`) is unaffected.
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "moduleResolution": "node"
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["**/*.test.ts"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
             "dependencies": {
                 "@apollo/client": "^3.13.8",
                 "@reduxjs/toolkit": "^2.8.2",
-                "@vercel/kv": "^3.0.0",
                 "fantasy-content-generator": "^4.9.1",
+                "ioredis": "^5.11.1",
                 "lodash": "^4.18.1",
                 "number-to-words": "^1.2.4",
                 "phaser": "^3.90.0",
@@ -1188,6 +1188,12 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
+        "node_modules/@ioredis/commands": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+            "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+            "license": "MIT"
+        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -2087,28 +2093,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
-            }
-        },
-        "node_modules/@upstash/redis": {
-            "version": "1.38.0",
-            "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
-            "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
-            "license": "MIT",
-            "dependencies": {
-                "uncrypto": "^0.1.3"
-            }
-        },
-        "node_modules/@vercel/kv": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
-            "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
-            "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@upstash/redis": "^1.34.0"
-            },
-            "engines": {
-                "node": ">=14.6"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -3072,6 +3056,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/cluster-key-slot": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+            "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3304,7 +3297,6 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -3376,6 +3368,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/dequal": {
@@ -4814,6 +4815,28 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/ioredis": {
+            "version": "5.11.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+            "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+            "license": "MIT",
+            "dependencies": {
+                "@ioredis/commands": "1.10.0",
+                "cluster-key-slot": "1.1.1",
+                "debug": "4.4.3",
+                "denque": "2.1.0",
+                "redis-errors": "1.2.0",
+                "redis-parser": "3.0.0",
+                "standard-as-callback": "2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
+            }
+        },
         "node_modules/is-array-buffer": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -6152,7 +6175,6 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/nanoid": {
@@ -7035,6 +7057,27 @@
                 "node": ">=8"
             }
         },
+        "node_modules/redis-errors": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+            "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/redis-parser": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+            "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+            "license": "MIT",
+            "dependencies": {
+                "redis-errors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/redux": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -7754,6 +7797,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/standard-as-callback": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+            "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+            "license": "MIT"
+        },
         "node_modules/std-env": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -8356,12 +8405,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/uncrypto": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
-            "license": "MIT"
         },
         "node_modules/undici": {
             "version": "7.28.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
             "dependencies": {
                 "@apollo/client": "^3.13.8",
                 "@reduxjs/toolkit": "^2.8.2",
+                "@vercel/kv": "^3.0.0",
+                "fantasy-content-generator": "^4.9.1",
                 "lodash": "^4.18.1",
                 "number-to-words": "^1.2.4",
                 "phaser": "^3.90.0",
@@ -394,6 +396,33 @@
                 "node": ">=20.19.0"
             }
         },
+        "node_modules/@edge-runtime/primitives": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@edge-runtime/primitives/-/primitives-4.1.0.tgz",
+            "integrity": "sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "peer": true,
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/@edge-runtime/vm": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@edge-runtime/vm/-/vm-3.2.0.tgz",
+            "integrity": "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@edge-runtime/primitives": "4.1.0"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
         "node_modules/@emnapi/core": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -427,6 +456,474 @@
             "optional": true,
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+            "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+            "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+            "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+            "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+            "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+            "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+            "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+            "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+            "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+            "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+            "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+            "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+            "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+            "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+            "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+            "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+            "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+            "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+            "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+            "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+            "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+            "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+            "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+            "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+            "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+            "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "peer": true,
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -1590,6 +2087,28 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@upstash/redis": {
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.38.0.tgz",
+            "integrity": "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==",
+            "license": "MIT",
+            "dependencies": {
+                "uncrypto": "^0.1.3"
+            }
+        },
+        "node_modules/@vercel/kv": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
+            "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
+            "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@upstash/redis": "^1.34.0"
+            },
+            "engines": {
+                "node": ">=14.6"
             }
         },
         "node_modules/@vitejs/plugin-react": {
@@ -3179,6 +3698,50 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+            "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.0",
+                "@esbuild/android-arm": "0.27.0",
+                "@esbuild/android-arm64": "0.27.0",
+                "@esbuild/android-x64": "0.27.0",
+                "@esbuild/darwin-arm64": "0.27.0",
+                "@esbuild/darwin-x64": "0.27.0",
+                "@esbuild/freebsd-arm64": "0.27.0",
+                "@esbuild/freebsd-x64": "0.27.0",
+                "@esbuild/linux-arm": "0.27.0",
+                "@esbuild/linux-arm64": "0.27.0",
+                "@esbuild/linux-ia32": "0.27.0",
+                "@esbuild/linux-loong64": "0.27.0",
+                "@esbuild/linux-mips64el": "0.27.0",
+                "@esbuild/linux-ppc64": "0.27.0",
+                "@esbuild/linux-riscv64": "0.27.0",
+                "@esbuild/linux-s390x": "0.27.0",
+                "@esbuild/linux-x64": "0.27.0",
+                "@esbuild/netbsd-arm64": "0.27.0",
+                "@esbuild/netbsd-x64": "0.27.0",
+                "@esbuild/openbsd-arm64": "0.27.0",
+                "@esbuild/openbsd-x64": "0.27.0",
+                "@esbuild/openharmony-arm64": "0.27.0",
+                "@esbuild/sunos-x64": "0.27.0",
+                "@esbuild/win32-arm64": "0.27.0",
+                "@esbuild/win32-ia32": "0.27.0",
+                "@esbuild/win32-x64": "0.27.0"
+            }
+        },
         "node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -3489,6 +4052,15 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=12.0.0"
+            }
+        },
+        "node_modules/fantasy-content-generator": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/fantasy-content-generator/-/fantasy-content-generator-4.9.1.tgz",
+            "integrity": "sha512-VGi+amKGNgntiBBpkLpKRG8Q3Z45QiomNgzb9GYfbSTFH6z7YosvAiRyFNujB0AkZvRDa1OQYDm1+CjPjII5tQ==",
+            "license": "MIT",
+            "dependencies": {
+                "seedrandom": "^3.0.5"
             }
         },
         "node_modules/fast-deep-equal": {
@@ -3881,6 +4453,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.14.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/gh-pages": {
@@ -6599,6 +7186,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/restore-cursor": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
@@ -6794,6 +7393,12 @@
             "version": "0.25.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
             "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+            "license": "MIT"
+        },
+        "node_modules/seedrandom": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+            "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
             "license": "MIT"
         },
         "node_modules/semver": {
@@ -7593,6 +8198,28 @@
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
         },
+        "node_modules/tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "esbuild": "~0.27.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7729,6 +8356,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/uncrypto": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+            "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+            "license": "MIT"
         },
         "node_modules/undici": {
             "version": "7.28.0",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "dependencies": {
         "@apollo/client": "^3.13.8",
         "@reduxjs/toolkit": "^2.8.2",
-        "@vercel/kv": "^3.0.0",
         "fantasy-content-generator": "^4.9.1",
+        "ioredis": "^5.11.1",
         "lodash": "^4.18.1",
         "number-to-words": "^1.2.4",
         "phaser": "^3.90.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,14 @@
         "format:check": "prettier --check .",
         "prepare": "simple-git-hooks",
         "gateway": "cd server && yarn start",
-        "service:armory": "cd services/armory && sls offline start"
+        "service:armory": "cd services/armory && sls offline start",
+        "armory:smoke": "tsx scripts/armory-smoke.ts"
     },
     "dependencies": {
         "@apollo/client": "^3.13.8",
         "@reduxjs/toolkit": "^2.8.2",
+        "@vercel/kv": "^3.0.0",
+        "fantasy-content-generator": "^4.9.1",
         "lodash": "^4.18.1",
         "number-to-words": "^1.2.4",
         "phaser": "^3.90.0",

--- a/scripts/armory-smoke.ts
+++ b/scripts/armory-smoke.ts
@@ -1,0 +1,87 @@
+/**
+ * Standalone armory smoke test — exercises the real Vercel handlers against the
+ * in-memory store (no Vercel, no KV, no network) so you can watch items being
+ * generated, stored, retrieved and deleted.
+ *
+ *   npm run armory:smoke
+ *
+ * For an over-the-wire run use `vercel dev` with a Vercel KV binding (see
+ * api/armory/README.md). The authoritative, CI-enforced version of these checks
+ * lives in api/armory/handlers.test.ts.
+ */
+import itemsHandler from "../api/armory/items/index";
+import itemByIdHandler from "../api/armory/items/[id]";
+import storeCreateHandler from "../api/armory/store/create";
+import storeClearHandler from "../api/armory/store/clear";
+import { MemoryItemStore, setItemStore } from "../api/armory/_lib/itemStore";
+import type { ApiRequest, ApiResponse } from "../api/armory/_lib/http";
+import type { StoredItem } from "../api/armory/_lib/types";
+
+type Handler = (req: ApiRequest, res: ApiResponse) => Promise<void>;
+interface Result {
+    status: number;
+    body: unknown;
+}
+
+const call = async (
+    handler: Handler,
+    method: string,
+    opts: { query?: ApiRequest["query"]; body?: unknown } = {}
+): Promise<Result> => {
+    const result: Result = { status: 0, body: undefined };
+    const res: ApiResponse = {
+        setHeader() {},
+        status(code) {
+            result.status = code;
+            return res;
+        },
+        json(body) {
+            result.body = body;
+        },
+        send(body) {
+            result.body = body;
+        },
+        end() {},
+    };
+    await handler({ method, query: opts.query, body: opts.body }, res);
+    return result;
+};
+
+const log = (label: string, result: Result) => {
+    console.log(`\n▸ ${label}  →  HTTP ${result.status}`);
+    console.log(JSON.stringify(result.body, null, 2));
+};
+
+const main = async () => {
+    setItemStore(new MemoryItemStore());
+
+    console.log("=== Armory standalone smoke (in-memory store) ===");
+
+    log("POST /store/clear (start clean)", await call(storeClearHandler, "POST"));
+
+    const created = await call(itemsHandler, "POST", { body: {} });
+    log("POST /items (generate + store one)", created);
+    const id = (created.body as StoredItem).id;
+
+    log(
+        "POST /store/create { amount: 3 } (batch generate)",
+        await call(storeCreateHandler, "POST", { body: { amount: 3 } })
+    );
+
+    log("GET /items (list all)", await call(itemsHandler, "GET"));
+
+    log(`GET /items/${id} (retrieve one)`, await call(itemByIdHandler, "GET", { query: { id } }));
+
+    log(
+        `DELETE /items/${id} (remove one)`,
+        await call(itemByIdHandler, "DELETE", { query: { id } })
+    );
+
+    const finalList = (await call(itemsHandler, "GET")).body as StoredItem[];
+    console.log(`\n✔ Done. ${finalList.length} items remain after deleting 1 of 4.`);
+};
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,8 +40,13 @@ export default defineConfig({
         globals: true,
         setupFiles: ["./vitest.setup.ts"],
         // `src/**` is the app suite; `test/**` holds cross-cutting suites that
-        // aren't tied to a single source file (e.g. the armory REST contract).
-        include: ["src/**/*.{test,spec}.{ts,tsx}", "test/**/*.{test,spec}.{ts,tsx}"],
+        // aren't tied to a single source file (e.g. the armory REST contract);
+        // `api/**` holds the Vercel Functions and their tests.
+        include: [
+            "src/**/*.{test,spec}.{ts,tsx}",
+            "test/**/*.{test,spec}.{ts,tsx}",
+            "api/**/*.{test,spec}.{ts,tsx}",
+        ],
         exclude: ["node_modules", "dist", ".next", "server", "services"],
         css: false,
         coverage: {


### PR DESCRIPTION
Closes #358 (Phase 7, PR2 — PR1 landed in #357).

## What & why

Second of four PRs for the non-destructive armory migration. Stands up the **new armory as Vercel Functions** under `/api/armory/*`, **alongside** the legacy AWS one. **Nothing old is touched** and **nothing is wired to the frontend yet** (that's Phase 8 / PR3). Responses are **structurally identical** to the legacy armory, asserted against the shared contract added in #357.

## Endpoints

| Method | Path | Legacy equivalent |
| --- | --- | --- |
| `GET` | `/api/armory/items` | `GET /items` |
| `POST` | `/api/armory/items` | `POST /items` |
| `GET` | `/api/armory/items/:id` | `GET /items/{id}` |
| `DELETE` | `/api/armory/items/:id` | `DELETE /items/{id}` |
| `POST` | `/api/armory/store/create` | `POST /createStore` |
| `POST` | `/api/armory/store/clear` | `POST /clearStore` |

## Implementation

- **`_lib/generateItem.ts` + `constants.ts`** — ported **verbatim** from `services/armory/src/common` (no algorithm changes). Only the seams differ: hand-written `ItemInput` type instead of `json-schema-to-ts`, local constant imports, and the stray debug `console.log` dropped.
- **`_lib/itemStore.ts`** — `ItemStore` interface with two implementations: `MemoryItemStore` (tests/local/harness) and `KvItemStore` (Vercel KV = Upstash Redis hash, field = item id, value = item). Factory uses KV when `KV_REST_API_URL` is set, else memory — so nothing breaks before the store is provisioned.
- **`_lib/http.ts`** — structural `ApiRequest`/`ApiResponse` (deliberately **not** `@vercel/node`, which drags in a build toolchain + audit advisories) and CORS/JSON/text helpers. CORS, OPTIONS preflight, and 405/Allow handled.
- New deps: `fantasy-content-generator` (name generation, same as legacy) and `@vercel/kv`. **`npm audit`: 0 vulnerabilities.**

## Verification (standalone, no infra)

- **`npm run armory:smoke`** — runnable harness against the in-memory store, printing generate → store → list → retrieve → delete.
- **24 tests** (`api/armory/handlers.test.ts`, `_lib/generateItem.test.ts`, `_lib/itemStore.test.ts`): full CRUD through the handlers + **contract parity** (250-roll generator fuzz, store CRUD/clone-isolation, error/404/400/405/preflight cases). `vitest.config.ts` now discovers `api/**`.

## Test evidence

`typecheck`, `lint`, `format:check`, `test` (226 passed, 2 skipped = PR1's opt-in live checks), and `build` all pass locally.

## Deliberate, documented choices (mechanics)

- `store/create` keeps the legacy default of 1 and unchanged generation, but adds a **max of 200** as a safety guard (frontend restock asks for 45 — well within).
- Missing-id GET/DELETE return **404** (the legacy Lambda threw a 400). Success-shape parity is unchanged; only the not-found status is more conventional.

## Risk

Low — purely additive. New code path, not referenced by the game or gateway. The only shared touch points are `package.json`/lockfile (two new deps) and the `vitest.config.ts` include.

## Maintainer follow-up (not in this PR)

Create + bind a Vercel KV store (injects `KV_REST_API_URL`/`KV_REST_API_TOKEN`) and deploy. See `api/armory/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AmjrULVBXGrogjkfKvCjxA)_