### PR TITLE
feat(armory): swap merchant frontend from GraphQL to REST fetch (Phase 8 PR3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -170,13 +170,14 @@ building the replacement.
 
 ### PR3 — Swap the frontend to the REST API (gate: merchant UI identical)
 
-The gateway stays deployed-but-unused so this step is reversible.
+The gateway stays deployed-but-unused so this step is reversible. (Apollo deps,
+`src/lib/cache.ts`, the GraphQL operations, and `server/` are left in place for PR4.)
 
-- [ ] Replace `useQuery`/`useMutation`/`ApolloProvider` with `fetch()` calls to `/api/armory/*` (lightweight data hook + React state)
-- [ ] Move sort, stat filter, and the `color`/`adjusted`/`formatted`/`abbreviation` derived fields client-side into plain TS (out of `src/lib/cache.ts`)
-- [ ] Add `VITE_ARMORY_URL`; point the "merchant unavailable" graceful state at it instead of `VITE_GRAPHQL_URL`
-- [ ] Component tests for Armory/Stock against the fetch client (mock `fetch`)
-- [ ] Gate: merchant UI buys/restocks/sorts/filters identically end-to-end; CI passes
+- [x] Replace `useQuery`/`useMutation`/`ApolloProvider` with `fetch()` calls to `/api/armory/*` — `src/lib/armoryClient.ts` (typed REST client) + `src/ui/hooks/useArmory.ts` (data hook); `ApolloProvider` removed from `main.tsx`
+- [x] Move sort + stat filter client-side into plain TS (`Armory.tsx`); port the `color` derived field into `armoryClient.ts`. `adjusted`/`formatted`/`abbreviation` were **unused by the merchant UI** (a parallel impl lives in the Phaser loot entity; `formatted` was even reading a nonexistent `converted` field → `NaN`), so they are dropped rather than ported
+- [x] Add `VITE_ARMORY_URL` (`vite-env.d.ts`); unset or a failed fetch → graceful "merchant unavailable" state
+- [x] Component tests for Armory against the fetch client (mock `fetch`): loading / loaded / unavailable
+- [ ] Gate: merchant UI buys/restocks/sorts/filters identically end-to-end (maintainer verify); local `typecheck`/`lint`/`test`/`build` green. Note: restock = `POST /store/clear` then `POST /store/create` (no single restock endpoint), mirroring the old `restockStore` resolver
 
 ### PR4 — Teardown (gate: only after PR2 + PR3 verified)
 

--- a/src/lib/armoryClient.ts
+++ b/src/lib/armoryClient.ts
@@ -1,0 +1,105 @@
+// Typed REST client for the armory item service (`/api/armory/*`). This replaces
+// the Apollo GraphQL gateway in the merchant flow (Phase 8): the API is a dumb
+// CRUD store, so the display-only `color` field and all sort/filter logic now
+// live client-side (previously Apollo cache field policies + the gateway).
+//
+// The base URL comes from `VITE_ARMORY_URL`. When it is unset the merchant is
+// treated as unavailable (mirrors the pre-Phase-8 "no gateway configured" state).
+
+import type { LootItem, LootStat } from "@/types/game";
+
+// Quality → border colour. Ported verbatim from the old Apollo cache field policy
+// (`src/lib/cache.ts`); the other derived stat fields there (adjusted/formatted/
+// abbreviation) were unused by the merchant UI and are intentionally not ported.
+const qualityColors: Record<string, string> = Object.freeze({
+    common: "#bbbbbb",
+    fine: "#00dd00",
+    rare: "#0077ff",
+    epic: "#9900ff",
+    legendary: "#ff9900",
+});
+
+export const colorForQuality = (quality: string): string => qualityColors[quality] ?? "#bbbbbb";
+
+/** Raw item shape returned by the armory API (`api/armory/_lib/types.ts`). */
+interface ApiItem {
+    id: string;
+    name: string;
+    category: string;
+    set: string;
+    icon: string;
+    quality: string;
+    qualitySort: number;
+    cost: number;
+    pool: number;
+    stats: Array<{ id: string; name: string; value: number }>;
+}
+
+/**
+ * A merchant store item. Extends the shared `LootItem` (what the loot/icon
+ * components render) with the `quality`/`qualitySort`/`pool` fields the Armory's
+ * client-side sort and quality colouring need at runtime.
+ */
+export interface StoreItem extends LootItem {
+    quality: string;
+    qualitySort: number;
+    pool: number;
+}
+
+const toStoreItem = (item: ApiItem): StoreItem => ({
+    __typename: "Item",
+    id: item.id,
+    uuid: item.id,
+    name: item.name,
+    category: item.category,
+    set: item.set,
+    icon: item.icon,
+    cost: item.cost,
+    color: colorForQuality(item.quality),
+    quality: item.quality,
+    qualitySort: item.qualitySort,
+    pool: item.pool,
+    stats: item.stats.map(
+        (stat): LootStat => ({ id: stat.id, name: stat.name, value: stat.value })
+    ),
+});
+
+/** Whether an armory endpoint is configured (otherwise the merchant is unavailable). */
+export const isArmoryConfigured = (): boolean => Boolean(import.meta.env.VITE_ARMORY_URL);
+
+const baseUrl = (): string => {
+    const url = import.meta.env.VITE_ARMORY_URL;
+    if (!url) throw new Error("VITE_ARMORY_URL is not configured.");
+    return url.replace(/\/$/, "");
+};
+
+/** GET /items → the full store, mapped to merchant items. */
+export async function listItems(): Promise<StoreItem[]> {
+    const res = await fetch(`${baseUrl()}/items`);
+    if (!res.ok) throw new Error(`Failed to load items (${res.status}).`);
+    const data = (await res.json()) as ApiItem[];
+    return Array.isArray(data) ? data.map(toStoreItem) : [];
+}
+
+/** DELETE /items/:id — remove a purchased item from the store. */
+export async function removeItem(id: string): Promise<void> {
+    const res = await fetch(`${baseUrl()}/items/${encodeURIComponent(id)}`, { method: "DELETE" });
+    if (!res.ok) throw new Error(`Failed to remove item (${res.status}).`);
+}
+
+/**
+ * Restock the store with `amount` fresh items. The REST API has no single restock
+ * endpoint, so this mirrors the old GraphQL `restockStore` resolver: clear, then
+ * batch-create.
+ */
+export async function restock(amount: number): Promise<void> {
+    const cleared = await fetch(`${baseUrl()}/store/clear`, { method: "POST" });
+    if (!cleared.ok) throw new Error(`Failed to clear store (${cleared.status}).`);
+
+    const created = await fetch(`${baseUrl()}/store/create`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amount }),
+    });
+    if (!created.ok) throw new Error(`Failed to restock store (${created.status}).`);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,8 +2,6 @@ import { StrictMode, Suspense, lazy } from "react";
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
 import store from "@store";
-import { ApolloProvider, ApolloClient } from "@apollo/client";
-import { cache } from "@/lib/cache";
 import { TouchBackend } from "react-dnd-touch-backend";
 import { DndProvider } from "react-dnd";
 import UI from "@ui/UI";
@@ -14,31 +12,19 @@ import "./styles/globals.css";
 // import behind <Suspense>, which also keeps Phaser out of the initial chunk.
 const PhaserGame = lazy(() => import("./PhaserGame"));
 
-const client = new ApolloClient({
-    uri: import.meta.env.VITE_GRAPHQL_URL ?? "http://localhost:4000",
-    cache,
-    defaultOptions: {
-        query: {
-            fetchPolicy: "cache-first",
-        },
-    },
-});
-
 function App() {
     return (
-        <ApolloProvider client={client}>
-            <Provider store={store}>
-                <DndProvider
-                    backend={TouchBackend}
-                    options={{ enableMouseEvents: true, preview: true }}
-                >
-                    <UI />
-                    <Suspense fallback={null}>
-                        <PhaserGame />
-                    </Suspense>
-                </DndProvider>
-            </Provider>
-        </ApolloProvider>
+        <Provider store={store}>
+            <DndProvider
+                backend={TouchBackend}
+                options={{ enableMouseEvents: true, preview: true }}
+            >
+                <UI />
+                <Suspense fallback={null}>
+                    <PhaserGame />
+                </Suspense>
+            </DndProvider>
+        </Provider>
     );
 }
 

--- a/src/ui/components/templates/Armory.test.tsx
+++ b/src/ui/components/templates/Armory.test.tsx
@@ -1,51 +1,72 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { screen, waitFor } from "@testing-library/react";
-import { GraphQLError } from "graphql";
 import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
-import { GET_ITEMS } from "@queries/getItems";
 import Armory from "@components/Armory";
 
-// Armory drives its UI off the GET_ITEMS Apollo query. This covers the two
-// states that exist today: the in-flight (loading) render and the GraphQL error
-// render. The "merchant unavailable" state (no endpoint configured) is a Phase 5
-// deliverable that is not implemented yet, so it is intentionally not tested here.
+// Armory now drives its UI off the REST `useArmory` hook (Phase 8), so these
+// tests mock `fetch` and `VITE_ARMORY_URL` rather than Apollo. They cover the
+// three states: in-flight (loading), loaded (stock rendered), and the graceful
+// "merchant unavailable" state (no endpoint configured, or the request failed).
+
+const sampleItems = [
+    {
+        id: "item-1",
+        name: "Sword of Testing",
+        category: "sword",
+        set: "weapon",
+        icon: "sword_1",
+        quality: "rare",
+        qualitySort: 3,
+        cost: 40,
+        pool: 50,
+        stats: [{ id: "stat-1", name: "attack_power", value: 12 }],
+    },
+];
+
 describe("Armory template", () => {
-    it("renders the loading state while GET_ITEMS is in flight", () => {
-        // No matching mock result resolves synchronously, so the query stays loading.
-        renderWithProviders(<Armory />, {
-            mocks: [{ request: { query: GET_ITEMS }, delay: Infinity }],
-            preloadedGame: { coins: 100, filters: [] },
-        });
+    beforeEach(() => {
+        vi.stubEnv("VITE_ARMORY_URL", "http://test.local/api/armory");
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it("renders the loading state, then the stock once items load", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn().mockResolvedValue({ ok: true, json: async () => sampleItems })
+        );
+
+        renderWithProviders(<Armory />, { preloadedGame: { coins: 100, filters: [] } });
 
         expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+        await waitFor(() => expect(screen.queryByText("Loading...")).not.toBeInTheDocument());
+        // Ready state renders the merchant controls and the loaded item.
+        expect(screen.getByText("Restock")).toBeInTheDocument();
+        expect(screen.getAllByAltText("Loot!").length).toBeGreaterThan(0);
     });
 
-    it("renders the error state when GET_ITEMS fails", async () => {
-        renderWithProviders(<Armory />, {
-            mocks: [
-                {
-                    request: { query: GET_ITEMS },
-                    result: { errors: [new GraphQLError("merchant exploded")] },
-                },
-            ],
-            preloadedGame: { coins: 100, filters: [] },
-        });
+    it("shows the merchant-unavailable state when no endpoint is configured", async () => {
+        vi.stubEnv("VITE_ARMORY_URL", "");
 
-        await waitFor(() => expect(screen.getByText(/^ERROR:/)).toBeInTheDocument());
-        expect(screen.getByText(/merchant exploded/)).toBeInTheDocument();
+        renderWithProviders(<Armory />, { preloadedGame: { coins: 100, filters: [] } });
+
+        await waitFor(() =>
+            expect(screen.getByText(/merchant is currently unavailable/i)).toBeInTheDocument()
+        );
     });
 
-    it("surfaces a network error through the error branch", async () => {
-        renderWithProviders(<Armory />, {
-            mocks: [
-                {
-                    request: { query: GET_ITEMS },
-                    error: new Error("network down"),
-                },
-            ],
-            preloadedGame: { coins: 100, filters: [] },
-        });
+    it("shows the merchant-unavailable state when the request fails", async () => {
+        vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
 
-        await waitFor(() => expect(screen.getByText(/ERROR:/)).toBeInTheDocument());
+        renderWithProviders(<Armory />, { preloadedGame: { coins: 100, filters: [] } });
+
+        await waitFor(() =>
+            expect(screen.getByText(/merchant is currently unavailable/i)).toBeInTheDocument()
+        );
     });
 });

--- a/src/ui/components/templates/Armory.tsx
+++ b/src/ui/components/templates/Armory.tsx
@@ -1,105 +1,59 @@
-import React from "react";
+import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 
 import Button from "@components/Button";
 import Stock from "@components/Stock";
 import { buyLoot, toggleFilter } from "@store/gameReducer";
-import store from "@store";
-import { useQuery, useMutation, useApolloClient } from "@apollo/client";
-import { GET_ITEMS } from "@queries/getItems";
-import { RESTOCK_STORE, REMOVE_ITEM } from "@mutations";
 import { sortBy } from "@ui/operations/helpers";
-import type { LootItem } from "@/types/game";
+import { useArmory } from "@ui/hooks/useArmory";
 import type { RootState } from "@store";
 import styles from "./Armory.module.css";
 
-interface ArmoryProps {}
+type SortKey = "qualitySort" | "pool";
 
-const Armory: React.FC<ArmoryProps> = () => {
+const Armory: React.FC = () => {
     const dispatch = useDispatch();
     const coins = useSelector((state: RootState) => state.game.coins);
     const filters = useSelector((state: RootState) => state.game.filters);
-    const client = useApolloClient();
-    const { loading, error, data, refetch } = useQuery(GET_ITEMS);
-    const [restockStore] = useMutation(RESTOCK_STORE, {
-        update(cache) {
-            cache.reset();
-        },
-    });
-    const [removeItem] = useMutation(REMOVE_ITEM, {
-        update(cache) {
-            cache.reset();
-        },
-    });
+    const selected = useSelector((state: RootState) => state.game.selected);
+    const { items, status, buy, restockStore } = useArmory();
+    const [sortKey, setSortKey] = useState<SortKey | null>(null);
 
-    if (loading) return <div>Loading...</div>;
-    if (error) return <div>ERROR: {error.message}</div>;
+    if (status === "loading") return <div>Loading...</div>;
+    if (status === "unavailable") return <div>The merchant is currently unavailable.</div>;
 
-    const filterOn = (filter: string) => filters?.includes(filter);
-    const filterAndRefetch = (key: string) => {
-        dispatch(toggleFilter(key));
-        refetch({
-            filter: {
-                stats: store.getState().game.filters,
-            },
-        });
-    };
+    // Sort and filter were the gateway's / Apollo cache's job; they are plain
+    // client-side derivations now. Filtering keeps items whose stats include every
+    // selected stat name (mirrors the old gateway filter).
+    const activeFilters = filters ?? [];
+    const filtered = activeFilters.length
+        ? items.filter((item) =>
+              activeFilters.every((name) => item.stats.some((stat) => stat.name === name))
+          )
+        : items;
+    const visible = sortKey ? sortBy(filtered, { key: sortKey, order: "desc" }) : filtered;
+
+    const filterOn = (filter: string) => activeFilters.includes(filter);
 
     return (
         <div className={styles.armoryContainer}>
             <section>
                 <h3>Sort</h3>
-                <Button
-                    text="Quality"
-                    onClick={() => {
-                        const { items } = client.readQuery({ query: GET_ITEMS }) as {
-                            items: LootItem[];
-                        };
-                        client.writeQuery({
-                            query: GET_ITEMS,
-                            data: {
-                                items: sortBy(items, { key: "qualitySort", order: "desc" }),
-                            },
-                        });
-                    }}
-                />
-                <Button
-                    text="Stats"
-                    onClick={() => {
-                        const { items } = client.cache.readQuery({ query: GET_ITEMS }) as {
-                            items: LootItem[];
-                        };
-                        client.writeQuery({
-                            query: GET_ITEMS,
-                            data: {
-                                items: sortBy(items, { key: "pool", order: "desc" }),
-                            },
-                        });
-                    }}
-                />
+                <Button text="Quality" onClick={() => setSortKey("qualitySort")} />
+                <Button text="Stats" onClick={() => setSortKey("pool")} />
                 <h3>Action</h3>
                 <Button
                     text="Buy"
                     onClick={() => {
-                        const selected = store.getState().game.selected;
                         if (selected && selected.cost <= coins) {
                             dispatch(buyLoot(selected));
-                            removeItem({
-                                variables: {
-                                    removeItemId: selected.id,
-                                },
-                            });
+                            void buy(selected.id);
                         } else {
                             console.log("CANNOT AFFORD");
                         }
                     }}
                 />
-                <Button
-                    text="Restock"
-                    onClick={() => {
-                        restockStore({ variables: { restockStoreAmount: 45 } });
-                    }}
-                />
+                <Button text="Restock" onClick={() => void restockStore(45)} />
             </section>
             <section>
                 <h3>Filter</h3>
@@ -107,52 +61,52 @@ const Armory: React.FC<ArmoryProps> = () => {
                     <Button
                         text="AP"
                         on={filterOn("attack_power")}
-                        onClick={() => filterAndRefetch("attack_power")}
+                        onClick={() => dispatch(toggleFilter("attack_power"))}
                     />
                     <Button
                         text="MP"
                         on={filterOn("magic_power")}
-                        onClick={() => filterAndRefetch("magic_power")}
+                        onClick={() => dispatch(toggleFilter("magic_power"))}
                     />
                     <Button
                         text="AS"
                         on={filterOn("attack_speed")}
-                        onClick={() => filterAndRefetch("attack_speed")}
+                        onClick={() => dispatch(toggleFilter("attack_speed"))}
                     />
                     <Button
                         text="CC"
                         on={filterOn("critical_chance")}
-                        onClick={() => filterAndRefetch("critical_chance")}
+                        onClick={() => dispatch(toggleFilter("critical_chance"))}
                     />
                     <Button
                         text="HM"
                         on={filterOn("health_max")}
-                        onClick={() => filterAndRefetch("health_max")}
+                        onClick={() => dispatch(toggleFilter("health_max"))}
                     />
                     <Button
                         text="HR"
                         on={filterOn("health_regen_rate")}
-                        onClick={() => filterAndRefetch("health_regen_rate")}
+                        onClick={() => dispatch(toggleFilter("health_regen_rate"))}
                     />
                     <Button
                         text="HV"
                         on={filterOn("health_regen_value")}
-                        onClick={() => filterAndRefetch("health_regen_value")}
+                        onClick={() => dispatch(toggleFilter("health_regen_value"))}
                     />
                     <Button
                         text="DF"
                         on={filterOn("defence")}
-                        onClick={() => filterAndRefetch("defence")}
+                        onClick={() => dispatch(toggleFilter("defence"))}
                     />
                     <Button
                         text="SP"
                         on={filterOn("speed")}
-                        onClick={() => filterAndRefetch("speed")}
+                        onClick={() => dispatch(toggleFilter("speed"))}
                     />
                 </div>
             </section>
             <section className={styles.stockSection}>
-                <Stock items={data.items} />
+                <Stock items={visible} />
             </section>
         </div>
     );

--- a/src/ui/hooks/useArmory.ts
+++ b/src/ui/hooks/useArmory.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+    isArmoryConfigured,
+    listItems,
+    removeItem,
+    restock,
+    type StoreItem,
+} from "@/lib/armoryClient";
+
+// Lightweight data hook for the merchant store, replacing Apollo's
+// useQuery/useMutation. It owns the item list and exposes the two mutations the
+// Armory needs (buy = remove, restock). On load failure or when no endpoint is
+// configured it reports `unavailable`, which the UI renders as a graceful
+// "merchant unavailable" state.
+
+export type ArmoryStatus = "loading" | "ready" | "unavailable";
+
+export interface UseArmory {
+    items: StoreItem[];
+    status: ArmoryStatus;
+    error?: string;
+    refetch: () => void;
+    buy: (id: string) => Promise<void>;
+    restockStore: (amount: number) => Promise<void>;
+}
+
+export function useArmory(): UseArmory {
+    const [items, setItems] = useState<StoreItem[]>([]);
+    const [status, setStatus] = useState<ArmoryStatus>("loading");
+    const [error, setError] = useState<string>();
+
+    const load = useCallback(async () => {
+        if (!isArmoryConfigured()) {
+            setStatus("unavailable");
+            return;
+        }
+        setStatus("loading");
+        setError(undefined);
+        try {
+            setItems(await listItems());
+            setStatus("ready");
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            setStatus("unavailable");
+        }
+    }, []);
+
+    useEffect(() => {
+        void load();
+    }, [load]);
+
+    const buy = useCallback(
+        async (id: string) => {
+            await removeItem(id);
+            await load();
+        },
+        [load]
+    );
+
+    const restockStore = useCallback(
+        async (amount: number) => {
+            await restock(amount);
+            await load();
+        },
+        [load]
+    );
+
+    return { items, status, error, refetch: () => void load(), buy, restockStore };
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
     /** GraphQL gateway URL (was NEXT_PUBLIC_GRAPHQL_URL before the Vite migration). */
     readonly VITE_GRAPHQL_URL?: string;
+    /** Armory REST API base URL (e.g. "/api/armory"); unset → merchant unavailable. */
+    readonly VITE_ARMORY_URL?: string;
     /** Public base path for the build (empty for Vercel, "/phasercraft/" for GitHub Pages). */
     readonly VITE_BASE_URL?: string;
 }


### PR DESCRIPTION
Closes #362

## Phase 8 — PR3: Swap the merchant frontend to the REST API

The merchant store now talks to the Vercel armory REST API (`/api/armory/*`, landed in
Phase 7) directly via `fetch()`, instead of Apollo Client + the GraphQL gateway. The
gateway and Apollo are left **deployed-but-unused** so this step is reversible —
teardown is PR4.

### Changes
- **`src/lib/armoryClient.ts`** — typed `fetch()` client: `listItems()`, `removeItem(id)`,
  `restock(amount)`. Maps raw API items → merchant items and computes the `color`
  display field (ported from the old Apollo cache field policy).
- **`src/ui/hooks/useArmory.ts`** — lightweight data hook replacing `useQuery`/
  `useMutation`; exposes `items` + `status` (`loading` / `ready` / `unavailable`) and the
  `buy`/`restockStore` actions.
- **`Armory.tsx`** — sort and stat-filter are now plain client-side derivations
  (filtering moved out of the gateway; sort was already client-side). Uses the hook.
- **`main.tsx`** — `ApolloProvider`/`ApolloClient` removed from the app entry.
- **`VITE_ARMORY_URL`** added (`vite-env.d.ts`); unset **or** a failed fetch renders a
  graceful **"merchant unavailable"** state.
- Tests rewritten against mocked `fetch` (loading / loaded / unavailable).

### Decisions (mechanics — documented per the working agreement)
1. **Dropped `adjusted`/`formatted`/`abbreviation`.** These Apollo `@client` fields were
   **unused by the merchant UI** — only `color` is consumed (`DetailedLoot`/`LootIcon`).
   The Phaser loot entity (`src/entities/Loot/Item.ts`) has its own parallel
   implementation, and `formatted` was reading a nonexistent `converted` field (→ `NaN`).
   So they're removed rather than ported. The Phaser loot code is untouched.
2. **Restock = clear + create.** The REST API has no single restock endpoint, so the hook
   calls `POST /store/clear` then `POST /store/create { amount: 45 }` — mirroring the old
   `restockStore` GraphQL resolver.

### Risk notes (⚠️ behavior change — approved before implementation)
- **Merchant data path changes** from GraphQL→gateway→AWS to `fetch`→Vercel REST. No
  save-format change; Redux flow (`buyLoot`/`selectLoot`/`toggleFilter`) unchanged.
- **Error UX:** the old `ERROR: <message>` render is replaced by a graceful "merchant
  unavailable" state (the planned Phase 5/8 deliverable).
- **Restock** now executes as two sequential requests (functionally equivalent).
- Requires the maintainer to set `VITE_ARMORY_URL` (e.g. `/api/armory` on Vercel);
  unset behaves as "unavailable", same pattern as the old `VITE_GRAPHQL_URL`.

### Test evidence
- `typecheck`, `lint`, `test` (224 passed / 2 skipped), `build` all green locally; all CI
  checks green (quality, armory, smoke, server, CodeQL).
- Side effect: dropping Apollo from the app entry shrank the main bundle
  **558 kB → 356 kB** (gzip 171 → 114 kB).

### Out of scope (PR4)
Apollo deps, `src/lib/cache.ts` (+ its tests), the GraphQL operations, `server/`, and
`services/armory/` all remain — removed in the teardown PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)