### PR TITLE
feat: game startup flow — intro splash, main menu, and settings

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -10,16 +10,19 @@ import { CHARACTERS, makeSave, seedSave, expectGameCanvas } from "./helpers";
 // (the wave readout), it is marked `test.fixme` with the reason inline rather
 // than shipped as a flaky/failing test.
 //
-// Boot sequence the specs rely on (see src/scenes/LoadScene.ts):
-//   LoadScene.create() dispatches toggleUi("save") and starts SelectScene, so
-//   the "Pick a Game Save" overlay is the first interactive UI. Each empty slot
-//   offers a "Select" button -> setSaveSlot + switchUi("select") -> the
-//   "Character Select" menu. Picking a character dispatches selectCharacter,
-//   which sets showUi:false (the overlay closes and the run begins).
+// Boot sequence the specs rely on (see src/scenes/LoadScene.ts and #377):
+//   LoadScene.create() dispatches toggleUi("menu") and starts SelectScene, so
+//   the Main Menu overlay is the first interactive UI. From there "New Game"
+//   opens the "Pick a Game Save" picker (empty slots offer "Select" ->
+//   setSaveSlot + switchUi("select") -> "Character Select"), and "Load" (shown
+//   only when a save exists) opens the picker in load mode. Picking a character
+//   or loading a save dispatches selectCharacter, which sets showUi:false (the
+//   overlay closes and the run begins). SelectScene is the passive listener that
+//   starts GameScene once a character is set.
 
 test.describe("Phasercraft smoke", () => {
     // ── Flow 1: game boots ───────────────────────────────────────────────────
-    test("game boots: page mounts, canvas renders, initial UI appears", async ({ page }) => {
+    test("game boots: page mounts, canvas renders, main menu appears", async ({ page }) => {
         await page.goto("/");
 
         // The Phaser host div is always rendered by React.
@@ -29,35 +32,30 @@ test.describe("Phasercraft smoke", () => {
         const canvas = await expectGameCanvas(page);
         await expect(canvas).toBeAttached();
 
-        // LoadScene.create() opens the "Pick a Game Save" overlay once the scene
-        // boots and preload completes. We key off the menu shell
-        // ([data-testid="menu-container"], rendered only while a menu is open) plus
-        // the save-slot headings rather
-        // than the menu's derived id: UI.tsx builds the id with
-        // `title.toLowerCase().replace(" ", "-")`, and String.replace swaps only
-        // the FIRST space, so "Pick a Game Save" yields the id "pick-a game save"
-        // (a pre-existing quirk). Visible text / slot headings are the stable hook.
+        // LoadScene.create() opens the Main Menu overlay once the scene boots and
+        // preload completes. Key off the menu shell ([data-testid="menu-container"],
+        // rendered only while a menu is open), the title, and the New Game action.
         await expect(page.locator('[data-testid="menu-container"]')).toBeVisible();
-        // Three save slots render with "Slot 1".."Slot 3" headings.
-        await expect(page.getByRole("heading", { name: "Slot 1" })).toBeVisible();
+        await expect(page.getByRole("heading", { name: "Phasercraft" })).toBeVisible();
+        await expect(page.getByRole("button", { name: "New Game" })).toBeVisible();
     });
 
-    // ── Flow 2: character select ─────────────────────────────────────────────
-    test("character select: choosing a class closes the overlay and starts the run", async ({
-        page,
-    }) => {
+    // ── Flow 2: new game -> character select ─────────────────────────────────
+    test("new game: choosing a class closes the overlay and starts the run", async ({ page }) => {
         await page.goto("/");
         await expectGameCanvas(page);
 
-        // From the save menu, an empty slot's "Select" button opens character select.
-        // (The save menu's derived id contains a space — see Flow 1 — so key off the
-        // menu shell and the Select button instead.)
+        // From the main menu, "New Game" opens the save picker.
         await expect(page.locator('[data-testid="menu-container"]')).toBeVisible();
+        await page.getByRole("button", { name: "New Game" }).click();
+
+        // An empty slot's "Select" button opens character select. (The save menu's
+        // derived id contains a space — UI.tsx builds it via title.replace(" ", "-"),
+        // which swaps only the first space — so key off the Select button instead.)
         await page.getByRole("button", { name: "Select" }).first().click();
 
-        // The Character Select menu renders ("Character Select" has a single space,
-        // so its derived id "character-select" is well-formed); assert a button per
-        // playable class as the stable signal.
+        // The Character Select menu renders ("Character Select" -> id "character-select");
+        // assert a button per playable class as the stable signal.
         await expect(page.locator("#character-select")).toBeVisible();
         for (const name of CHARACTERS) {
             await expect(page.getByRole("button", { name, exact: true })).toBeVisible();
@@ -103,11 +101,10 @@ test.describe("Phasercraft smoke", () => {
         await page.goto("/");
         await expectGameCanvas(page);
 
-        // The boot overlay is the save picker, which lists every slot. A populated
-        // slot renders the saved character plus a "Load" button (empty slots show
-        // "Select"), so no extra navigation is needed. Key off the menu shell (the
-        // save menu's derived id contains a space — see Flow 1).
+        // With a save present, the main menu offers "Load", which opens the picker
+        // in load mode (populated slots only).
         await expect(page.locator('[data-testid="menu-container"]')).toBeVisible();
+        await page.getByRole("button", { name: "Load", exact: true }).click();
 
         // The seeded slot surfaces the persisted wave/coins straight from the
         // save service — proof the localStorage roundtrip survived a fresh load.
@@ -116,7 +113,7 @@ test.describe("Phasercraft smoke", () => {
 
         // Loading the save dispatches loadGame + selectCharacter, which closes the
         // overlay (showUi:false) and drops us into the restored run.
-        await page.getByRole("button", { name: "Load" }).first().click();
+        await page.getByRole("button", { name: "Load", exact: true }).first().click();
         // The overlay tears down (showUi:false) — no menu shell remains.
         await expect(page.locator('[data-testid="menu-container"]')).toHaveCount(0);
 

--- a/graphify-out/.graphify_labels.json
+++ b/graphify-out/.graphify_labels.json
@@ -86,5 +86,6 @@
   "84": "graphify reference: incremental update and cluster-only",
   "85": "graphify reference: GitHub clone and cross-repo merge",
   "86": "graphify reference: transcribe video and audio",
-  "87": "extraction-spec.md"
+  "87": "extraction-spec.md",
+  "88": "repository"
 }

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
-# Graph Report - phasercraft  (2026-07-02)
+# Graph Report - phasercraft  (2026-07-04)
 
 ## Corpus Check
-- 204 files · ~337,238 words
+- 213 files · ~339,733 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 1256 nodes · 2352 edges · 88 communities (65 shown, 23 thin omitted)
-- Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 21 edges (avg confidence: 0.63)
+- 1279 nodes · 2498 edges · 89 communities (68 shown, 21 thin omitted)
+- Extraction: 99% EXTRACTED · 1% INFERRED · 0% AMBIGUOUS · INFERRED: 31 edges (avg confidence: 0.68)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `48741fb9`
+- Built from commit: `f4e7d7bc`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -83,6 +83,7 @@
 - [[_COMMUNITY_eslint.config.mjs|eslint.config.mjs]]
 - [[_COMMUNITY_playwright.config.ts|playwright.config.ts]]
 - [[_COMMUNITY_vitest.setup.ts|vitest.setup.ts]]
+- [[_COMMUNITY_number-to-words.d.ts|number-to-words.d.ts]]
 - [[_COMMUNITY_graphify reference extra exports and benchmark|graphify reference: extra exports and benchmark]]
 - [[_COMMUNITY_Healer|Healer]]
 - [[_COMMUNITY_Faith|Faith]]
@@ -98,6 +99,7 @@
 - [[_COMMUNITY_graphify reference GitHub clone and cross-repo merge|graphify reference: GitHub clone and cross-repo merge]]
 - [[_COMMUNITY_graphify reference transcribe video and audio|graphify reference: transcribe video and audio]]
 - [[_COMMUNITY_extraction-spec|extraction-spec.md]]
+- [[_COMMUNITY_repository|repository]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `Enemy` - 73 edges
@@ -106,62 +108,62 @@
 4. `SpellOptions` - 36 edges
 5. `Resource` - 29 edges
 6. `LootItem` - 25 edges
-7. `GameScene` - 23 edges
-8. `StoredItem` - 22 edges
-9. `TownScene` - 22 edges
+7. `GameScene` - 24 edges
+8. `TownScene` - 23 edges
+9. `StoredItem` - 22 edges
 10. `Item` - 21 edges
 
 ## Surprising Connections (you probably didn't know these)
+- `LootListDrag()` --indirect_call--> `icon()`  [INFERRED]
+  src/ui/components/molecules/LootListDrag.tsx → scripts/generate-pwa-icons.mjs
+- `Header()` --calls--> `toggleUi`  [INFERRED]
+  src/ui/components/organisms/Header.tsx → src/store/gameReducer.ts
+- `UI()` --indirect_call--> `Character()`  [INFERRED]
+  src/ui/UI.tsx → src/ui/components/templates/Character.tsx
 - `main()` --calls--> `setItemStore()`  [EXTRACTED]
   scripts/armory-smoke.ts → api/armory/_lib/itemStore.ts
-- `SystemProps` --references--> `RootState`  [EXTRACTED]
-  src/ui/components/templates/System.tsx → src/store/index.ts
-- `DetailedLootProps` --references--> `LootItem`  [EXTRACTED]
-  src/ui/components/molecules/DetailedLoot.tsx → src/types/game.ts
-- `LootProps` --references--> `LootItem`  [EXTRACTED]
-  src/ui/components/molecules/Loot.tsx → src/types/game.ts
-- `UI()` --indirect_call--> `Armory()`  [INFERRED]
-  src/ui/UI.tsx → src/ui/components/templates/Armory.tsx
+- `PhaserGame()` --indirect_call--> `GameScene`  [INFERRED]
+  src/PhaserGame.tsx → src/scenes/GameScene.ts
 
 ## Import Cycles
-- 3-file cycle: `src/entities/Player/Player.ts -> src/entities/Resources/AssignResource.ts -> src/entities/Resources/Rage.ts -> src/entities/Player/Player.ts`
-- 3-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Player.ts -> src/store/gameReducer.ts -> src/entities/Player/AssignClass.ts`
-- 3-file cycle: `src/entities/Enemy/Enemy.ts -> src/entities/Enemy/Monster.ts -> src/entities/Player/Player.ts -> src/entities/Enemy/Enemy.ts`
 - 3-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
-- 3-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/ManaShield.ts -> src/entities/Player/Player.ts`
+- 3-file cycle: `src/entities/Enemy/Enemy.ts -> src/entities/Enemy/Monster.ts -> src/entities/Player/Player.ts -> src/entities/Enemy/Enemy.ts`
+- 3-file cycle: `src/entities/Player/Player.ts -> src/entities/Resources/AssignResource.ts -> src/entities/Resources/Rage.ts -> src/entities/Player/Player.ts`
 - 3-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Faith.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Mage.ts -> src/entities/Player/Player.ts -> src/store/gameReducer.ts -> src/entities/Player/AssignClass.ts`
-- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Mage.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
-- 4-file cycle: `src/entities/Enemy/Enemy.ts -> src/entities/Resources/AssignResource.ts -> src/entities/Resources/Rage.ts -> src/entities/Player/Player.ts -> src/entities/Enemy/Enemy.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Consecration.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
+- 3-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/ManaShield.ts -> src/entities/Player/Player.ts`
+- 3-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Player.ts -> src/store/gameReducer.ts -> src/entities/Player/AssignClass.ts`
 - 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/EarthShield.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Faith.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Fireball.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Frostbolt.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Heal.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/ManaShield.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Multishot.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
 - 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/SiphonSoul.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
+- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Consecration.ts -> src/entities/Weapons/AreaEffect.ts -> src/entities/Player/Player.ts`
 - 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Smite.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
-- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/SnareTrap.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Cleric.ts -> src/entities/Player/Player.ts -> src/store/gameReducer.ts -> src/entities/Player/AssignClass.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Cleric.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Player.ts -> src/entities/UI/Boons.ts -> src/store/gameReducer.ts -> src/entities/Player/AssignClass.ts`
+- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Consecration.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
+- 4-file cycle: `src/entities/Player/Player.ts -> src/entities/Spells/AssignSpell.ts -> src/entities/Spells/Frostbolt.ts -> src/entities/Spells/Spell.ts -> src/entities/Player/Player.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Mage.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Occultist.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
+- 4-file cycle: `src/entities/Enemy/Enemy.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts -> src/entities/Player/Player.ts -> src/entities/Enemy/Enemy.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Ranger.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
+- 4-file cycle: `src/entities/Player/AssignClass.ts -> src/entities/Player/Warrior.ts -> src/entities/Player/Player.ts -> src/types/scene.ts -> src/entities/Player/AssignClass.ts`
 
-## Communities (88 total, 23 thin omitted)
+## Communities (89 total, 21 thin omitted)
 
 ### Community 0 - "Player"
-Cohesion: 0.11
-Nodes (4): MonsterConfig, Player, setBaseStats, setLevel
+Cohesion: 0.12
+Nodes (3): Player, setBaseStats, setLevel
 
 ### Community 1 - "Frostbolt.ts"
-Cohesion: 0.08
-Nodes (10): Boon, Enrage, EnrageValue, FrostboltValue, Invocation, InvocationValue, PowerInfusion, PowerInfusionValue (+2 more)
+Cohesion: 0.12
+Nodes (8): Boon, Enrage, EnrageValue, FrostboltValue, Invocation, InvocationValue, PowerInfusionValue, EffectValue
 
 ### Community 3 - "Item"
-Cohesion: 0.08
+Cohesion: 0.09
 Nodes (15): Common, Epic, Fine, AdjustedStat, Item, ItemConfig, StatInfo, StatIterator (+7 more)
 
 ### Community 4 - "Consecration"
-Cohesion: 0.06
-Nodes (10): Consecration, EarthShield, SnareTrap, AreaEffect, TrapUnderTest, Trap, dropIn(), DropInItem (+2 more)
+Cohesion: 0.08
+Nodes (5): Consecration, EarthShield, AreaEffect, TownScene, ArcadeCollisionObject
 
 ### Community 5 - "generateItem.ts"
 Cohesion: 0.10
@@ -172,52 +174,56 @@ Cohesion: 0.06
 Nodes (31): compilerOptions, allowJs, esModuleInterop, incremental, isolatedModules, jsx, lib, module (+23 more)
 
 ### Community 7 - "Player.ts"
-Cohesion: 0.32
+Cohesion: 0.38
 Nodes (4): clone(), targetVector(), TargetWithBody, VectorResult
 
 ### Community 8 - "Gem.ts"
-Cohesion: 0.08
-Nodes (18): CirclingConfig, EnemyStates, HitParams, Coin, CoinConfig, Crafting, CraftingConfig, Gem (+10 more)
+Cohesion: 0.09
+Nodes (10): Coin, CoinConfig, Crafting, CraftingConfig, Gem, GemConfig, GemUnderTest, getRandomVelocity() (+2 more)
 
 ### Community 9 - "AssignSpell.ts"
-Cohesion: 0.16
-Nodes (7): MoveOptions, classes, Fireball, Heal, SpellValue, SpellOptions, TargetType
+Cohesion: 0.19
+Nodes (7): PlayerType, classes, Smite, SpellValue, OverlapTarget, SpellOptions, GameSceneLike
 
 ### Community 10 - "devDependencies"
 Cohesion: 0.07
 Nodes (30): devDependencies, eslint, eslint-config-prettier, eslint-plugin-react, eslint-plugin-react-hooks, gh-pages, jsdom, lint-staged (+22 more)
 
 ### Community 11 - "Armory.tsx"
-Cohesion: 0.11
-Nodes (25): ApiItem, baseUrl(), colorForQuality(), isArmoryConfigured(), listItems(), qualityColors, removeItem(), restock() (+17 more)
+Cohesion: 0.31
+Nodes (12): ApiItem, baseUrl(), colorForQuality(), isArmoryConfigured(), listItems(), qualityColors, removeItem(), restock() (+4 more)
+
+### Community 12 - "Enemy"
+Cohesion: 0.06
+Nodes (11): AssignType, classes, Boss, Enemy, Healer, Melee, Monster, Ranged (+3 more)
 
 ### Community 13 - "LootItem"
-Cohesion: 0.14
-Nodes (14): equipLoot, selectLoot, unequipLoot, LootItem, DroppableSlot(), DroppableSlotProps, helm, SlotComponentProps (+6 more)
+Cohesion: 0.27
+Nodes (9): equipLoot, unequipLoot, DroppableSlot(), DroppableSlotProps, Loot(), LootProps, LootListDrag(), LootListDragProps (+1 more)
 
 ### Community 14 - "PlayerStats"
-Cohesion: 0.17
-Nodes (6): StatProps, HealthProps, HealthStats, StatItem, StatsProps, StatsStyles
+Cohesion: 0.08
+Nodes (16): PlayerStats, AttributeProps, StatProps, Attributes(), AttributesProps, AttributesStyles, HealthProps, HealthStats (+8 more)
 
 ### Community 15 - "StoredItem"
 Cohesion: 0.16
 Nodes (8): client(), clone(), createItemStore(), ItemStore, MemoryItemStore, parse(), RedisItemStore, StoredItem
 
 ### Community 16 - "index.ts"
-Cohesion: 0.29
+Cohesion: 0.30
 Nodes (15): handler(), handler(), ApiRequest, ApiResponse, applyCors(), firstQueryValue(), handlePreflight(), methodNotAllowed() (+7 more)
 
 ### Community 17 - "EnemyOptions"
-Cohesion: 0.18
-Nodes (6): AssignType, classes, Boss, Melee, Ranged, EnemyOptions
+Cohesion: 0.12
+Nodes (6): SnareTrap, TrapUnderTest, Trap, dropIn(), DropInItem, DropInOptions
 
 ### Community 18 - "UI.tsx"
-Cohesion: 0.13
-Nodes (14): container, PhaserGame, Arcanum(), Character(), CharacterSelect(), Equipment(), HUD(), Level (+6 more)
+Cohesion: 0.15
+Nodes (9): container, PhaserGame, Arcanum(), CharacterSelect(), HUD(), Level, asMenuComponent(), MenuComponent (+1 more)
 
 ### Community 19 - "System.tsx"
-Cohesion: 0.22
-Nodes (7): Title(), TitleProps, HeaderConfig, HeaderProps, PixelBackgroundOptions, pixelBackgroundVars(), PixelEmbossOptions
+Cohesion: 0.20
+Nodes (9): Title(), TitleProps, Navigation(), Header(), HeaderConfig, HeaderProps, PixelBackgroundOptions, pixelBackgroundVars() (+1 more)
 
 ### Community 20 - "Agentic Readiness Roadmap"
 Cohesion: 0.09
@@ -228,28 +234,28 @@ Cohesion: 0.09
 Nodes (21): Advanced Magic System, Available Commands, Code Quality, Combat Tips, 🎮 Controls, Deep Loot & Progression, 🛠️ Development, Development Setup (+13 more)
 
 ### Community 22 - "game.ts"
-Cohesion: 0.10
-Nodes (20): EnemyStats, SpellType, AdjustValue, CHARACTER_BASE_STATS, CharacterData, COMBAT_TYPES, CombatType, EnemyAttributes (+12 more)
+Cohesion: 0.08
+Nodes (26): CirclingConfig, EnemyStates, EnemyStats, HitParams, MoveOptions, SpellType, AdjustValue, CHARACTER_BASE_STATS (+18 more)
 
 ### Community 23 - "gameReducer.ts"
-Cohesion: 0.16
-Nodes (11): addXP, buyLoot, initState, Level, nextWave, sellLoot, setPlayerPosition, setSaveSlot (+3 more)
+Cohesion: 0.15
+Nodes (13): fontConfig, AssignClass, PlayerName, GameSceneConfig, addLoot, addXP, initState, Level (+5 more)
 
 ### Community 24 - "HUD.ts"
-Cohesion: 0.24
-Nodes (11): LabelledContainer, styles, readAllSaves(), readSave(), removeSave(), SAVE_SLOTS, SaveData, SaveSlot (+3 more)
+Cohesion: 0.18
+Nodes (12): LabelledContainer, styles, MapStateOptions, mapStateToData(), state$, readSave(), removeSave(), SAVE_SLOTS (+4 more)
 
 ### Community 25 - "index.ts"
-Cohesion: 0.17
-Nodes (12): gameReducer, GameState, loadGame, RootState, Inventory(), sampleItems, initialGame, seed() (+4 more)
+Cohesion: 0.14
+Nodes (13): gameReducer, GameState, loadGame, sellLoot, RootState, helm, Inventory(), Equipment() (+5 more)
 
 ### Community 26 - "AssignResource.ts"
 Cohesion: 0.05
 Nodes (21): AssignResourceName, classes, Energy, EnergyOptions, Health, HealthOptions, Mana, ManaOptions (+13 more)
 
 ### Community 27 - "TownScene"
-Cohesion: 0.13
-Nodes (5): AssignClass, GameSceneConfig, TownScene, setCurrentArea, toggleHUD
+Cohesion: 0.29
+Nodes (11): addStats(), Comparable, readKey(), removeStats(), sortAscending(), sortBy(), sortDescending(), SortOptions (+3 more)
 
 ### Community 28 - "handlers.test.ts"
 Cohesion: 0.16
@@ -264,8 +270,8 @@ Cohesion: 0.08
 Nodes (24): For /graphify add and --watch, For /graphify query, For the commit hook and native CLAUDE.md integration, For --update and --cluster-only, /graphify, Honesty Rules, Interpreter guard for subcommands, Part A - Structural extraction for code files (+16 more)
 
 ### Community 31 - "package.json"
-Cohesion: 0.12
-Nodes (16): description, engines, node, homepage, keywords, lint-staged, *.{json,md,css,yml,yaml}, *.{ts,tsx,js,jsx,mjs} (+8 more)
+Cohesion: 0.18
+Nodes (10): description, engines, node, homepage, keywords, name, private, simple-git-hooks (+2 more)
 
 ### Community 32 - "dependencies"
 Cohesion: 0.12
@@ -280,28 +286,24 @@ Cohesion: 0.10
 Nodes (4): GameScene, FakeTimer, SceneUnderTest, EnemyType
 
 ### Community 35 - "classes.ts"
-Cohesion: 0.20
+Cohesion: 0.21
 Nodes (13): ascended_classes, ascended_schools, AscendedClassType, AscendedSchoolType, class_schools, ClassType, CombatType, getAscendedClass() (+5 more)
 
 ### Community 36 - "Resource.test.ts"
-Cohesion: 0.19
-Nodes (6): Banes, Boons, StatusEffect, StatusEffects, setStats, updateStats
+Cohesion: 0.18
+Nodes (7): Banes, IndexableStats, Boons, StatusEffect, StatusEffects, setStats, updateStats
 
 ### Community 37 - "LoadScene.ts"
-Cohesion: 0.10
-Nodes (9): AnimationConfig, createAnimations(), EnemyConfig, EnemyType, fontConfig, GameOverScene, LoadScene, SelectScene (+1 more)
+Cohesion: 0.08
+Nodes (16): AnimationConfig, createAnimations(), EnemyConfig, EnemyType, PhaserGame(), BootScene, createLogo(), LogoOptions (+8 more)
 
 ### Community 38 - "SceneUnderTest"
-Cohesion: 0.16
-Nodes (9): AttributeProps, Slot(), Attributes(), AttributesProps, AttributesStyles, DetailedLoot(), DetailedLootProps, GroupedAttributes() (+1 more)
+Cohesion: 0.33
+Nodes (7): LootItem, Slot(), SlotComponentProps, SlotProps, DetailedLoot(), DetailedLootProps, Character()
 
 ### Community 39 - "Health.ts"
-Cohesion: 0.21
-Nodes (8): PlayerName, selectCharacter, Button(), ButtonProps, CharacterCardProps, Dialog(), DialogProps, SystemProps
-
-### Community 40 - "UI"
-Cohesion: 0.20
-Nodes (4): UI, MapStateOptions, mapStateToData(), state$
+Cohesion: 0.18
+Nodes (16): readAllSaves(), selectCharacter, setSaveSlot, switchUi, Button(), ButtonProps, CharacterCard(), CharacterCardProps (+8 more)
 
 ### Community 41 - "ItemTooltip.tsx"
 Cohesion: 0.24
@@ -316,8 +318,8 @@ Cohesion: 0.39
 Nodes (6): Character, CHARACTERS, expectGameCanvas(), makeSave(), SAVE_SLOTS, seedSave()
 
 ### Community 45 - "SnareTrap"
-Cohesion: 0.20
-Nodes (6): Destination, DrawBarOptions, AssignResourceType, AssignSpell, Weapon, WeaponConfig
+Cohesion: 0.17
+Nodes (7): MonsterConfig, Destination, DrawBarOptions, AssignResourceType, AssignSpell, Weapon, WeaponConfig
 
 ### Community 46 - "armory-smoke.ts"
 Cohesion: 0.43
@@ -341,7 +343,11 @@ Nodes (6): CLAUDE.md — Working agreement and project conventions, Code convent
 
 ### Community 51 - "generate-pwa-icons.mjs"
 Cohesion: 0.33
-Nodes (4): BG, ICON_DIR, root, SOURCE
+Nodes (5): BG, icon(), ICON_DIR, root, SOURCE
+
+### Community 52 - "Multishot"
+Cohesion: 0.18
+Nodes (3): Fireball, Heal, TargetType
 
 ### Community 54 - "StatBar.tsx"
 Cohesion: 0.53
@@ -356,8 +362,8 @@ Cohesion: 0.40
 Nodes (4): Notes, One-time maintainer steps (Vercel dashboard), Vercel deployment (Phase 6), What's config-as-code (already in the repo)
 
 ### Community 59 - "GameOverScene"
-Cohesion: 0.27
-Nodes (7): LootIcon(), LootIconProps, LootIconStyles, LootProps, CustomDragLayer(), getItemStyles(), Offset
+Cohesion: 0.32
+Nodes (6): LootIcon(), LootIconProps, LootIconStyles, CustomDragLayer(), getItemStyles(), Offset
 
 ### Community 60 - "qa-review.md"
 Cohesion: 0.50
@@ -372,8 +378,16 @@ Cohesion: 0.33
 Nodes (5): For /graphify explain, For /graphify path, graphify reference: query, path, explain, Step 0 — Constrained query expansion (REQUIRED before traversal), Step 1 — Traversal
 
 ### Community 79 - "PlayerStats"
-Cohesion: 0.40
-Nodes (4): PlayerStats, GroupedAttributesProps, GroupedStatsProps, StatItem
+Cohesion: 0.38
+Nodes (5): buyLoot, toggleFilter, Armory(), SortKey, sampleItems
+
+### Community 80 - "Monster"
+Cohesion: 0.47
+Nodes (4): selectLoot, LootList(), LootListProps, Stock()
+
+### Community 81 - "Smite"
+Cohesion: 0.67
+Nodes (3): lint-staged, *.{json,md,css,yml,yaml}, *.{ts,tsx,js,jsx,mjs}
 
 ### Community 82 - "graphify reference: add a URL and watch a folder"
 Cohesion: 0.50
@@ -387,25 +401,29 @@ Nodes (3): For git commit hook, For native CLAUDE.md integration, graphify refer
 Cohesion: 0.50
 Nodes (3): For --cluster-only, For --update (incremental re-extraction), graphify reference: incremental update and cluster-only
 
+### Community 88 - "repository"
+Cohesion: 0.67
+Nodes (3): repository, type, url
+
 ## Knowledge Gaps
 - **356 isolated node(s):** `semi`, `singleQuote`, `trailingComma`, `tabWidth`, `useTabs` (+351 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **23 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **21 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Player` connect `Player` to `Resource`, `Spell`, `Resource.test.ts`, `LoadScene.ts`, `Player.ts`, `Gem.ts`, `AssignSpell.ts`, `Faith`, `Hero`, `SnareTrap`, `ManaShield`, `PlayerStats`, `EnemyOptions`, `game.ts`, `AssignResource.ts`, `TownScene`?**
-  _High betweenness centrality (0.051) - this node is a cross-community bridge._
-- **Why does `Spell` connect `Spell` to `Player`, `Frostbolt.ts`, `Consecration`, `Gem.ts`, `AssignSpell.ts`, `Faith`, `Frostbolt`, `ManaShield`, `Resource.ts`, `Smite`, `Multishot`, `Whirlwind`, `Shield`?**
-  _High betweenness centrality (0.042) - this node is a cross-community bridge._
-- **Why does `Enemy` connect `Enemy` to `Player`, `Frostbolt.ts`, `Resource.test.ts`, `Consecration`, `Player.ts`, `Gem.ts`, `AssignSpell.ts`, `Healer`, `SnareTrap`, `Frostbolt`, `Monster`, `EnemyOptions`, `Smite`, `Multishot`, `Whirlwind`, `game.ts`, `Shield`?**
-  _High betweenness centrality (0.037) - this node is a cross-community bridge._
+- **Why does `Player` connect `Player` to `Resource`, `Spell`, `Resource.test.ts`, `Consecration`, `AssignSpell.ts`, `Faith`, `Hero`, `SnareTrap`, `PlayerStats`, `ManaShield`, `Enemy`, `game.ts`, `gameReducer.ts`, `AssignResource.ts`?**
+  _High betweenness centrality (0.050) - this node is a cross-community bridge._
+- **Why does `Spell` connect `Spell` to `Player`, `Frostbolt.ts`, `Consecration`, `AssignSpell.ts`, `Faith`, `Enemy`, `Frostbolt`, `ManaShield`, `Resource.ts`, `EnemyOptions`, `Multishot`, `Whirlwind`, `Shield`?**
+  _High betweenness centrality (0.041) - this node is a cross-community bridge._
+- **Why does `Enemy` connect `Enemy` to `Player`, `Frostbolt.ts`, `Resource.test.ts`, `Consecration`, `AssignSpell.ts`, `SnareTrap`, `Frostbolt`, `EnemyOptions`, `Multishot`, `Whirlwind`, `game.ts`, `Shield`?**
+  _High betweenness centrality (0.036) - this node is a cross-community bridge._
 - **What connects `semi`, `singleQuote`, `trailingComma` to the rest of the system?**
   _356 weakly-connected nodes found - possible documentation gaps or missing edges._
 - **Should `Player` be split into smaller, more focused modules?**
-  _Cohesion score 0.1103448275862069 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11822660098522167 - nodes in this community are weakly interconnected._
 - **Should `Frostbolt.ts` be split into smaller, more focused modules?**
-  _Cohesion score 0.08021390374331551 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11666666666666667 - nodes in this community are weakly interconnected._
 - **Should `Spell` be split into smaller, more focused modules?**
-  _Cohesion score 0.1402116402116402 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.1455026455026455 - nodes in this community are weakly interconnected._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1390,7 +1390,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "package_repository",
-      "community": 31,
+      "community": 88,
       "norm_label": "repository"
     },
     {
@@ -1400,7 +1400,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "package_repository_type",
-      "community": 31,
+      "community": 88,
       "norm_label": "type"
     },
     {
@@ -1410,7 +1410,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "package_repository_url",
-      "community": 31,
+      "community": 88,
       "norm_label": "url"
     },
     {
@@ -2100,7 +2100,7 @@
       "source_location": "L92",
       "_origin": "ast",
       "id": "package_lint_staged",
-      "community": 31,
+      "community": 81,
       "norm_label": "lint-staged"
     },
     {
@@ -2110,7 +2110,7 @@
       "source_location": "L93",
       "_origin": "ast",
       "id": "package_lint_staged_ts_tsx_js_jsx_mjs",
-      "community": 31,
+      "community": 81,
       "norm_label": "*.{ts,tsx,js,jsx,mjs}"
     },
     {
@@ -2120,7 +2120,7 @@
       "source_location": "L97",
       "_origin": "ast",
       "id": "package_lint_staged_json_md_css_yml_yaml",
-      "community": 31,
+      "community": 81,
       "norm_label": "*.{json,md,css,yml,yaml}"
     },
     {
@@ -2277,7 +2277,7 @@
       "label": "PhaserGame()",
       "file_type": "code",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L9",
+      "source_location": "L11",
       "_origin": "ast",
       "id": "src_phasergame_phasergame",
       "community": 37,
@@ -2490,7 +2490,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_config_fonts",
-      "community": 37,
+      "community": 23,
       "norm_label": "fonts.ts"
     },
     {
@@ -2500,7 +2500,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "src_config_fonts_fontconfig",
-      "community": 37,
+      "community": 23,
       "norm_label": "fontconfig"
     },
     {
@@ -2510,7 +2510,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_assigntype",
-      "community": 17,
+      "community": 12,
       "norm_label": "assigntype.ts"
     },
     {
@@ -2520,7 +2520,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "src_entities_enemy_assigntype_classes",
-      "community": 17,
+      "community": 12,
       "norm_label": "classes"
     },
     {
@@ -2530,7 +2530,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_entities_enemy_assigntype_assigntype",
-      "community": 17,
+      "community": 12,
       "norm_label": "assigntype"
     },
     {
@@ -2540,7 +2540,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_entities_enemy_assigntype_assigntype_constructor",
-      "community": 17,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -2550,7 +2550,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_boss",
-      "community": 17,
+      "community": 12,
       "norm_label": "boss.ts"
     },
     {
@@ -2560,7 +2560,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_entities_enemy_boss_boss",
-      "community": 17,
+      "community": 12,
       "norm_label": "boss"
     },
     {
@@ -2570,7 +2570,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "src_entities_enemy_boss_boss_constructor",
-      "community": 17,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -2580,7 +2580,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_enemy",
-      "community": 8,
+      "community": 22,
       "norm_label": "enemy.ts"
     },
     {
@@ -2600,7 +2600,7 @@
       "source_location": "L21",
       "_origin": "ast",
       "id": "src_entities_enemy_enemy_enemystates",
-      "community": 8,
+      "community": 22,
       "norm_label": "enemystates"
     },
     {
@@ -2610,7 +2610,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "src_entities_enemy_enemy_circlingconfig",
-      "community": 8,
+      "community": 22,
       "norm_label": "circlingconfig"
     },
     {
@@ -2620,7 +2620,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "src_entities_enemy_enemy_moveoptions",
-      "community": 9,
+      "community": 22,
       "norm_label": "moveoptions"
     },
     {
@@ -2630,7 +2630,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_entities_enemy_enemy_hitparams",
-      "community": 8,
+      "community": 22,
       "norm_label": "hitparams"
     },
     {
@@ -2910,7 +2910,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_healer",
-      "community": 17,
+      "community": 12,
       "norm_label": "healer.ts"
     },
     {
@@ -2920,7 +2920,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer",
-      "community": 74,
+      "community": 12,
       "norm_label": "healer"
     },
     {
@@ -2930,7 +2930,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer_constructor",
-      "community": 74,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -2940,7 +2940,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer_update",
-      "community": 74,
+      "community": 12,
       "norm_label": ".update()"
     },
     {
@@ -2950,7 +2950,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer_gethealtarget",
-      "community": 74,
+      "community": 12,
       "norm_label": ".gethealtarget()"
     },
     {
@@ -2960,7 +2960,7 @@
       "source_location": "L44",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer_healtarget",
-      "community": 74,
+      "community": 12,
       "norm_label": ".healtarget()"
     },
     {
@@ -2970,7 +2970,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer_getmissinghealth",
-      "community": 74,
+      "community": 12,
       "norm_label": ".getmissinghealth()"
     },
     {
@@ -2980,7 +2980,7 @@
       "source_location": "L61",
       "_origin": "ast",
       "id": "src_entities_enemy_healer_healer_laststanding",
-      "community": 74,
+      "community": 12,
       "norm_label": ".laststanding()"
     },
     {
@@ -2990,7 +2990,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_melee",
-      "community": 17,
+      "community": 12,
       "norm_label": "melee.ts"
     },
     {
@@ -3000,7 +3000,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_entities_enemy_melee_melee",
-      "community": 17,
+      "community": 12,
       "norm_label": "melee"
     },
     {
@@ -3010,7 +3010,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_entities_enemy_melee_melee_constructor",
-      "community": 17,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -3020,7 +3020,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_entities_enemy_melee_melee_update",
-      "community": 17,
+      "community": 12,
       "norm_label": ".update()"
     },
     {
@@ -3030,7 +3030,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_monster",
-      "community": 0,
+      "community": 45,
       "norm_label": "monster.ts"
     },
     {
@@ -3040,7 +3040,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_entities_enemy_monster_monsterconfig",
-      "community": 0,
+      "community": 45,
       "norm_label": "monsterconfig"
     },
     {
@@ -3050,7 +3050,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_entities_enemy_monster_monster",
-      "community": 80,
+      "community": 12,
       "norm_label": "monster"
     },
     {
@@ -3060,7 +3060,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_entities_enemy_monster_monster_constructor",
-      "community": 80,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -3070,7 +3070,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_entities_enemy_monster_monster_walk",
-      "community": 80,
+      "community": 12,
       "norm_label": ".walk()"
     },
     {
@@ -3080,7 +3080,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_entities_enemy_monster_monster_idle",
-      "community": 80,
+      "community": 12,
       "norm_label": ".idle()"
     },
     {
@@ -3090,7 +3090,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "src_entities_enemy_monster_monster_death",
-      "community": 80,
+      "community": 12,
       "norm_label": ".death()"
     },
     {
@@ -3100,7 +3100,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_enemy_ranged",
-      "community": 17,
+      "community": 12,
       "norm_label": "ranged.ts"
     },
     {
@@ -3110,7 +3110,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_entities_enemy_ranged_ranged",
-      "community": 17,
+      "community": 12,
       "norm_label": "ranged"
     },
     {
@@ -3120,7 +3120,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_entities_enemy_ranged_ranged_constructor",
-      "community": 17,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -3130,7 +3130,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_entities_enemy_ranged_ranged_update",
-      "community": 17,
+      "community": 12,
       "norm_label": ".update()"
     },
     {
@@ -3830,7 +3830,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_entities_player_assignclass_playertype",
-      "community": 8,
+      "community": 9,
       "norm_label": "playertype"
     },
     {
@@ -3840,7 +3840,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_entities_player_assignclass_playername",
-      "community": 39,
+      "community": 23,
       "norm_label": "playername"
     },
     {
@@ -3850,7 +3850,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "src_entities_player_assignclass_assignclass",
-      "community": 27,
+      "community": 23,
       "norm_label": "assignclass"
     },
     {
@@ -3860,7 +3860,7 @@
       "source_location": "L27",
       "_origin": "ast",
       "id": "src_entities_player_assignclass_assignclass_constructor",
-      "community": 27,
+      "community": 23,
       "norm_label": ".constructor()"
     },
     {
@@ -4270,7 +4270,7 @@
       "source_location": "L364",
       "_origin": "ast",
       "id": "src_entities_player_player_player_positionweapon",
-      "community": 7,
+      "community": 0,
       "norm_label": ".positionweapon()"
     },
     {
@@ -5480,7 +5480,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_spells_fireball",
-      "community": 9,
+      "community": 52,
       "norm_label": "fireball.ts"
     },
     {
@@ -5490,7 +5490,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_entities_spells_fireball_fireball",
-      "community": 9,
+      "community": 52,
       "norm_label": "fireball"
     },
     {
@@ -5500,7 +5500,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_entities_spells_fireball_fireball_constructor",
-      "community": 9,
+      "community": 52,
       "norm_label": ".constructor()"
     },
     {
@@ -5510,7 +5510,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_entities_spells_fireball_fireball_setcastevents",
-      "community": 9,
+      "community": 52,
       "norm_label": ".setcastevents()"
     },
     {
@@ -5520,7 +5520,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "src_entities_spells_fireball_fireball_effect",
-      "community": 9,
+      "community": 52,
       "norm_label": ".effect()"
     },
     {
@@ -5530,7 +5530,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_entities_spells_fireball_fireball_animationupdate",
-      "community": 9,
+      "community": 52,
       "norm_label": ".animationupdate()"
     },
     {
@@ -5630,7 +5630,7 @@
       "source_location": "L4",
       "_origin": "ast",
       "id": "src_entities_spells_heal_heal",
-      "community": 9,
+      "community": 52,
       "norm_label": "heal"
     },
     {
@@ -5640,7 +5640,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_entities_spells_heal_heal_constructor",
-      "community": 9,
+      "community": 52,
       "norm_label": ".constructor()"
     },
     {
@@ -5650,7 +5650,7 @@
       "source_location": "L24",
       "_origin": "ast",
       "id": "src_entities_spells_heal_heal_setcastevents",
-      "community": 9,
+      "community": 52,
       "norm_label": ".setcastevents()"
     },
     {
@@ -5660,7 +5660,7 @@
       "source_location": "L33",
       "_origin": "ast",
       "id": "src_entities_spells_heal_heal_effect",
-      "community": 9,
+      "community": 52,
       "norm_label": ".effect()"
     },
     {
@@ -5670,7 +5670,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_entities_spells_heal_heal_animationupdate",
-      "community": 9,
+      "community": 52,
       "norm_label": ".animationupdate()"
     },
     {
@@ -5840,7 +5840,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_entities_spells_multishot_multishot",
-      "community": 52,
+      "community": 12,
       "norm_label": "multishot"
     },
     {
@@ -5850,7 +5850,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "src_entities_spells_multishot_multishot_constructor",
-      "community": 52,
+      "community": 12,
       "norm_label": ".constructor()"
     },
     {
@@ -5860,7 +5860,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "src_entities_spells_multishot_multishot_setcastevents",
-      "community": 52,
+      "community": 12,
       "norm_label": ".setcastevents()"
     },
     {
@@ -5870,7 +5870,7 @@
       "source_location": "L40",
       "_origin": "ast",
       "id": "src_entities_spells_multishot_multishot_effect",
-      "community": 52,
+      "community": 12,
       "norm_label": ".effect()"
     },
     {
@@ -5880,7 +5880,7 @@
       "source_location": "L48",
       "_origin": "ast",
       "id": "src_entities_spells_multishot_multishot_startanimation",
-      "community": 52,
+      "community": 12,
       "norm_label": ".startanimation()"
     },
     {
@@ -5890,7 +5890,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "src_entities_spells_multishot_multishot_updateanimation",
-      "community": 52,
+      "community": 12,
       "norm_label": ".updateanimation()"
     },
     {
@@ -5920,7 +5920,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion",
-      "community": 1,
+      "community": 74,
       "norm_label": "powerinfusion"
     },
     {
@@ -5930,7 +5930,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion_constructor",
-      "community": 1,
+      "community": 74,
       "norm_label": ".constructor()"
     },
     {
@@ -5940,7 +5940,7 @@
       "source_location": "L60",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion_setcastevents",
-      "community": 1,
+      "community": 74,
       "norm_label": ".setcastevents()"
     },
     {
@@ -5950,7 +5950,7 @@
       "source_location": "L69",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion_effect",
-      "community": 1,
+      "community": 74,
       "norm_label": ".effect()"
     },
     {
@@ -5960,7 +5960,7 @@
       "source_location": "L81",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion_cleareffect",
-      "community": 1,
+      "community": 74,
       "norm_label": ".cleareffect()"
     },
     {
@@ -5970,7 +5970,7 @@
       "source_location": "L86",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion_setanimation",
-      "community": 1,
+      "community": 74,
       "norm_label": ".setanimation()"
     },
     {
@@ -5980,7 +5980,7 @@
       "source_location": "L87",
       "_origin": "ast",
       "id": "src_entities_spells_powerinfusion_powerinfusion_animationupdate",
-      "community": 1,
+      "community": 74,
       "norm_label": ".animationupdate()"
     },
     {
@@ -6110,7 +6110,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_entities_spells_smite_smite",
-      "community": 81,
+      "community": 9,
       "norm_label": "smite"
     },
     {
@@ -6120,7 +6120,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_entities_spells_smite_smite_constructor",
-      "community": 81,
+      "community": 9,
       "norm_label": ".constructor()"
     },
     {
@@ -6130,7 +6130,7 @@
       "source_location": "L25",
       "_origin": "ast",
       "id": "src_entities_spells_smite_smite_setcastevents",
-      "community": 81,
+      "community": 9,
       "norm_label": ".setcastevents()"
     },
     {
@@ -6140,7 +6140,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "src_entities_spells_smite_smite_effect",
-      "community": 81,
+      "community": 9,
       "norm_label": ".effect()"
     },
     {
@@ -6150,7 +6150,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "src_entities_spells_smite_smite_animationupdate",
-      "community": 81,
+      "community": 9,
       "norm_label": ".animationupdate()"
     },
     {
@@ -6160,7 +6160,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap",
-      "community": 9,
+      "community": 17,
       "norm_label": "snaretrap.ts"
     },
     {
@@ -6170,7 +6170,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap",
-      "community": 4,
+      "community": 17,
       "norm_label": "snaretrap"
     },
     {
@@ -6180,7 +6180,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_constructor",
-      "community": 4,
+      "community": 17,
       "norm_label": ".constructor()"
     },
     {
@@ -6190,7 +6190,7 @@
       "source_location": "L34",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_setanimation",
-      "community": 4,
+      "community": 17,
       "norm_label": ".setanimation()"
     },
     {
@@ -6200,7 +6200,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_startanimation",
-      "community": 4,
+      "community": 17,
       "norm_label": ".startanimation()"
     },
     {
@@ -6210,7 +6210,7 @@
       "source_location": "L37",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_setcastevents",
-      "community": 4,
+      "community": 17,
       "norm_label": ".setcastevents()"
     },
     {
@@ -6220,7 +6220,7 @@
       "source_location": "L46",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_triggertrap",
-      "community": 4,
+      "community": 17,
       "norm_label": ".triggertrap()"
     },
     {
@@ -6230,7 +6230,7 @@
       "source_location": "L65",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_laytrap",
-      "community": 4,
+      "community": 17,
       "norm_label": ".laytrap()"
     },
     {
@@ -6240,7 +6240,7 @@
       "source_location": "L74",
       "_origin": "ast",
       "id": "src_entities_spells_snaretrap_snaretrap_effect",
-      "community": 4,
+      "community": 17,
       "norm_label": ".effect()"
     },
     {
@@ -6660,7 +6660,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_spells_whirlwind",
-      "community": 8,
+      "community": 9,
       "norm_label": "whirlwind.ts"
     },
     {
@@ -6730,7 +6730,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_ui_banes",
-      "community": 1,
+      "community": 36,
       "norm_label": "banes.ts"
     },
     {
@@ -6740,7 +6740,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_entities_ui_banes_indexablestats",
-      "community": 1,
+      "community": 36,
       "norm_label": "indexablestats"
     },
     {
@@ -6870,7 +6870,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_ui_hud_test",
-      "community": 25,
+      "community": 58,
       "norm_label": "hud.test.ts"
     },
     {
@@ -6930,7 +6930,7 @@
       "source_location": "L23",
       "_origin": "ast",
       "id": "src_entities_ui_hud_test_makehud",
-      "community": 25,
+      "community": 58,
       "norm_label": "makehud()"
     },
     {
@@ -7060,7 +7060,7 @@
       "source_location": "L154",
       "_origin": "ast",
       "id": "src_entities_ui_hud_ui_loadsavedgame",
-      "community": 25,
+      "community": 40,
       "norm_label": ".loadsavedgame()"
     },
     {
@@ -7210,7 +7210,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_weapons_areaeffect",
-      "community": 8,
+      "community": 9,
       "norm_label": "areaeffect.ts"
     },
     {
@@ -7220,7 +7220,7 @@
       "source_location": "L9",
       "_origin": "ast",
       "id": "src_entities_weapons_areaeffect_overlaptarget",
-      "community": 8,
+      "community": 9,
       "norm_label": "overlaptarget"
     },
     {
@@ -7270,7 +7270,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_test",
-      "community": 4,
+      "community": 17,
       "norm_label": "trap.test.ts"
     },
     {
@@ -7280,7 +7280,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_test_trapundertest",
-      "community": 4,
+      "community": 17,
       "norm_label": "trapundertest"
     },
     {
@@ -7290,7 +7290,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_test_trapundertest_cleanup",
-      "community": 4,
+      "community": 17,
       "norm_label": ".cleanup()"
     },
     {
@@ -7300,7 +7300,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_test_maketrap",
-      "community": 4,
+      "community": 17,
       "norm_label": "maketrap()"
     },
     {
@@ -7310,7 +7310,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_entities_weapons_trap",
-      "community": 4,
+      "community": 17,
       "norm_label": "trap.ts"
     },
     {
@@ -7320,7 +7320,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_trap",
-      "community": 4,
+      "community": 17,
       "norm_label": "trap"
     },
     {
@@ -7330,7 +7330,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_trap_constructor",
-      "community": 4,
+      "community": 17,
       "norm_label": ".constructor()"
     },
     {
@@ -7340,7 +7340,7 @@
       "source_location": "L45",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_trap_collide",
-      "community": 4,
+      "community": 17,
       "norm_label": ".collide()"
     },
     {
@@ -7350,7 +7350,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_trap_spawnedhandler",
-      "community": 4,
+      "community": 17,
       "norm_label": ".spawnedhandler()"
     },
     {
@@ -7360,7 +7360,7 @@
       "source_location": "L73",
       "_origin": "ast",
       "id": "src_entities_weapons_trap_trap_cleanup",
-      "community": 4,
+      "community": 17,
       "norm_label": ".cleanup()"
     },
     {
@@ -7430,7 +7430,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_helpers_mapstatetodata",
-      "community": 40,
+      "community": 24,
       "norm_label": "mapstatetodata.ts"
     },
     {
@@ -7440,7 +7440,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_helpers_mapstatetodata_state",
-      "community": 40,
+      "community": 24,
       "norm_label": "state$"
     },
     {
@@ -7450,7 +7450,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_helpers_mapstatetodata_mapstateoptions",
-      "community": 40,
+      "community": 24,
       "norm_label": "mapstateoptions"
     },
     {
@@ -7460,7 +7460,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_helpers_mapstatetodata_mapstatetodata",
-      "community": 40,
+      "community": 24,
       "norm_label": "mapstatetodata()"
     },
     {
@@ -7470,7 +7470,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_helpers_spawnstyle",
-      "community": 4,
+      "community": 17,
       "norm_label": "spawnstyle.ts"
     },
     {
@@ -7480,7 +7480,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "src_helpers_spawnstyle_dropinoptions",
-      "community": 4,
+      "community": 17,
       "norm_label": "dropinoptions"
     },
     {
@@ -7490,7 +7490,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_helpers_spawnstyle_dropinitem",
-      "community": 4,
+      "community": 17,
       "norm_label": "dropinitem"
     },
     {
@@ -7500,7 +7500,7 @@
       "source_location": "L17",
       "_origin": "ast",
       "id": "src_helpers_spawnstyle_dropin",
-      "community": 4,
+      "community": 17,
       "norm_label": "dropin()"
     },
     {
@@ -7724,13 +7724,63 @@
       "norm_label": "container"
     },
     {
+      "label": "BootScene.ts",
+      "file_type": "code",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_scenes_bootscene",
+      "community": 37,
+      "norm_label": "bootscene.ts"
+    },
+    {
+      "label": "BootScene",
+      "file_type": "code",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "src_scenes_bootscene_bootscene",
+      "community": 37,
+      "norm_label": "bootscene"
+    },
+    {
+      "label": ".constructor()",
+      "file_type": "code",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "src_scenes_bootscene_bootscene_constructor",
+      "community": 37,
+      "norm_label": ".constructor()"
+    },
+    {
+      "label": ".preload()",
+      "file_type": "code",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L16",
+      "_origin": "ast",
+      "id": "src_scenes_bootscene_bootscene_preload",
+      "community": 37,
+      "norm_label": ".preload()"
+    },
+    {
+      "label": ".create()",
+      "file_type": "code",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "src_scenes_bootscene_bootscene_create",
+      "community": 37,
+      "norm_label": ".create()"
+    },
+    {
       "label": "GameOverScene.ts",
       "file_type": "code",
       "source_file": "src/scenes/GameOverScene.ts",
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_scenes_gameoverscene",
-      "community": 37,
+      "community": 23,
       "norm_label": "gameoverscene.ts"
     },
     {
@@ -7900,7 +7950,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_scenes_gamescene",
-      "community": 37,
+      "community": 23,
       "norm_label": "gamescene.ts"
     },
     {
@@ -7930,7 +7980,7 @@
       "source_location": "L50",
       "_origin": "ast",
       "id": "src_scenes_gamescene_gamescene_init",
-      "community": 27,
+      "community": 34,
       "norm_label": ".init()"
     },
     {
@@ -8090,14 +8140,14 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_scenes_loadscene",
-      "community": 37,
+      "community": 23,
       "norm_label": "loadscene.ts"
     },
     {
       "label": "LoadScene",
       "file_type": "code",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L7",
+      "source_location": "L8",
       "_origin": "ast",
       "id": "src_scenes_loadscene_loadscene",
       "community": 37,
@@ -8107,7 +8157,7 @@
       "label": ".constructor()",
       "file_type": "code",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L8",
+      "source_location": "L12",
       "_origin": "ast",
       "id": "src_scenes_loadscene_loadscene_constructor",
       "community": 37,
@@ -8117,7 +8167,7 @@
       "label": ".preload()",
       "file_type": "code",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L13",
+      "source_location": "L17",
       "_origin": "ast",
       "id": "src_scenes_loadscene_loadscene_preload",
       "community": 37,
@@ -8127,7 +8177,7 @@
       "label": ".create()",
       "file_type": "code",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L266",
+      "source_location": "L293",
       "_origin": "ast",
       "id": "src_scenes_loadscene_loadscene_create",
       "community": 37,
@@ -8137,7 +8187,7 @@
       "label": ".shutdown()",
       "file_type": "code",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L272",
+      "source_location": "L306",
       "_origin": "ast",
       "id": "src_scenes_loadscene_loadscene_shutdown",
       "community": 37,
@@ -8150,7 +8200,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_scenes_selectscene",
-      "community": 37,
+      "community": 23,
       "norm_label": "selectscene.ts"
     },
     {
@@ -8160,7 +8210,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_scenes_selectscene_gamesceneconfig",
-      "community": 27,
+      "community": 23,
       "norm_label": "gamesceneconfig"
     },
     {
@@ -8210,7 +8260,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_scenes_townscene",
-      "community": 27,
+      "community": 23,
       "norm_label": "townscene.ts"
     },
     {
@@ -8220,7 +8270,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene",
-      "community": 27,
+      "community": 4,
       "norm_label": "townscene"
     },
     {
@@ -8230,7 +8280,7 @@
       "source_location": "L26",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_setdepthbyy",
-      "community": 27,
+      "community": 4,
       "norm_label": ".setdepthbyy()"
     },
     {
@@ -8240,7 +8290,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_createanimationforsprite",
-      "community": 27,
+      "community": 4,
       "norm_label": ".createanimationforsprite()"
     },
     {
@@ -8250,7 +8300,7 @@
       "source_location": "L64",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_constructor",
-      "community": 27,
+      "community": 4,
       "norm_label": ".constructor()"
     },
     {
@@ -8260,7 +8310,7 @@
       "source_location": "L68",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_init",
-      "community": 27,
+      "community": 4,
       "norm_label": ".init()"
     },
     {
@@ -8270,7 +8320,7 @@
       "source_location": "L72",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_create",
-      "community": 27,
+      "community": 4,
       "norm_label": ".create()"
     },
     {
@@ -8280,7 +8330,7 @@
       "source_location": "L136",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_createtownenvironment",
-      "community": 27,
+      "community": 4,
       "norm_label": ".createtownenvironment()"
     },
     {
@@ -8290,7 +8340,7 @@
       "source_location": "L284",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_createobjectlayers",
-      "community": 27,
+      "community": 4,
       "norm_label": ".createobjectlayers()"
     },
     {
@@ -8300,7 +8350,7 @@
       "source_location": "L314",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_addanimationstosprite",
-      "community": 27,
+      "community": 4,
       "norm_label": ".addanimationstosprite()"
     },
     {
@@ -8310,7 +8360,7 @@
       "source_location": "L348",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_setupcollisions",
-      "community": 27,
+      "community": 4,
       "norm_label": ".setupcollisions()"
     },
     {
@@ -8320,7 +8370,7 @@
       "source_location": "L401",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_handlecollisionidle",
-      "community": 27,
+      "community": 4,
       "norm_label": ".handlecollisionidle()"
     },
     {
@@ -8330,7 +8380,7 @@
       "source_location": "L416",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_setuppoiinteractions",
-      "community": 27,
+      "community": 4,
       "norm_label": ".setuppoiinteractions()"
     },
     {
@@ -8340,7 +8390,7 @@
       "source_location": "L453",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_mappoitointeraction",
-      "community": 27,
+      "community": 4,
       "norm_label": ".mappoitointeraction()"
     },
     {
@@ -8350,7 +8400,7 @@
       "source_location": "L478",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_createtownui",
-      "community": 27,
+      "community": 4,
       "norm_label": ".createtownui()"
     },
     {
@@ -8360,7 +8410,7 @@
       "source_location": "L482",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_handlezoneoverlap",
-      "community": 27,
+      "community": 4,
       "norm_label": ".handlezoneoverlap()"
     },
     {
@@ -8370,7 +8420,7 @@
       "source_location": "L488",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_handleinteraction",
-      "community": 27,
+      "community": 23,
       "norm_label": ".handleinteraction()"
     },
     {
@@ -8380,7 +8430,7 @@
       "source_location": "L520",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_update",
-      "community": 27,
+      "community": 4,
       "norm_label": ".update()"
     },
     {
@@ -8390,8 +8440,38 @@
       "source_location": "L531",
       "_origin": "ast",
       "id": "src_scenes_townscene_townscene_shutdown",
-      "community": 27,
+      "community": 4,
       "norm_label": ".shutdown()"
+    },
+    {
+      "label": "createLogo.ts",
+      "file_type": "code",
+      "source_file": "src/scenes/createLogo.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_scenes_createlogo",
+      "community": 37,
+      "norm_label": "createlogo.ts"
+    },
+    {
+      "label": "LogoOptions",
+      "file_type": "code",
+      "source_file": "src/scenes/createLogo.ts",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "src_scenes_createlogo_logooptions",
+      "community": 37,
+      "norm_label": "logooptions"
+    },
+    {
+      "label": "createLogo()",
+      "file_type": "code",
+      "source_file": "src/scenes/createLogo.ts",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "src_scenes_createlogo_createlogo",
+      "community": 37,
+      "norm_label": "createlogo()"
     },
     {
       "label": "saveStorage.test.ts",
@@ -8480,8 +8560,68 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "src_services_savestorage_readallsaves",
-      "community": 24,
+      "community": 39,
       "norm_label": "readallsaves()"
+    },
+    {
+      "label": "settingsStorage.test.ts",
+      "file_type": "code",
+      "source_file": "src/services/settingsStorage.test.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_services_settingsstorage_test",
+      "community": 37,
+      "norm_label": "settingsstorage.test.ts"
+    },
+    {
+      "label": "settingsStorage.ts",
+      "file_type": "code",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_services_settingsstorage",
+      "community": 37,
+      "norm_label": "settingsstorage.ts"
+    },
+    {
+      "label": "Settings",
+      "file_type": "code",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "src_services_settingsstorage_settings",
+      "community": 37,
+      "norm_label": "settings"
+    },
+    {
+      "label": "DEFAULT_SETTINGS",
+      "file_type": "code",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "src_services_settingsstorage_default_settings",
+      "community": 37,
+      "norm_label": "default_settings"
+    },
+    {
+      "label": "readSettings()",
+      "file_type": "code",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "src_services_settingsstorage_readsettings",
+      "community": 37,
+      "norm_label": "readsettings()"
+    },
+    {
+      "label": "writeSettings()",
+      "file_type": "code",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "src_services_settingsstorage_writesettings",
+      "community": 37,
+      "norm_label": "writesettings()"
     },
     {
       "label": "gameReducer.test.ts",
@@ -8497,7 +8637,7 @@
       "label": "makeItem()",
       "file_type": "code",
       "source_file": "src/store/gameReducer.test.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "_origin": "ast",
       "id": "src_store_gamereducer_test_makeitem",
       "community": 23,
@@ -8537,7 +8677,7 @@
       "label": "initState",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L44",
+      "source_location": "L45",
       "_origin": "ast",
       "id": "src_store_gamereducer_initstate",
       "community": 23,
@@ -8547,7 +8687,7 @@
       "label": "addCoins",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L76",
+      "source_location": "L78",
       "_origin": "ast",
       "id": "src_store_gamereducer_addcoins",
       "community": 8,
@@ -8557,7 +8697,7 @@
       "label": "addCrafting",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L80",
+      "source_location": "L82",
       "_origin": "ast",
       "id": "src_store_gamereducer_addcrafting",
       "community": 8,
@@ -8567,17 +8707,17 @@
       "label": "addLoot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L84",
+      "source_location": "L86",
       "_origin": "ast",
       "id": "src_store_gamereducer_addloot",
-      "community": 24,
+      "community": 23,
       "norm_label": "addloot"
     },
     {
       "label": "addXP",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L88",
+      "source_location": "L90",
       "_origin": "ast",
       "id": "src_store_gamereducer_addxp",
       "community": 23,
@@ -8587,17 +8727,17 @@
       "label": "buyLoot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L92",
+      "source_location": "L94",
       "_origin": "ast",
       "id": "src_store_gamereducer_buyloot",
-      "community": 23,
+      "community": 79,
       "norm_label": "buyloot"
     },
     {
       "label": "equipLoot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L96",
+      "source_location": "L98",
       "_origin": "ast",
       "id": "src_store_gamereducer_equiploot",
       "community": 13,
@@ -8607,7 +8747,7 @@
       "label": "loadGame",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L100",
+      "source_location": "L102",
       "_origin": "ast",
       "id": "src_store_gamereducer_loadgame",
       "community": 25,
@@ -8617,7 +8757,7 @@
       "label": "nextWave",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L104",
+      "source_location": "L106",
       "_origin": "ast",
       "id": "src_store_gamereducer_nextwave",
       "community": 23,
@@ -8627,7 +8767,7 @@
       "label": "selectCharacter",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L106",
+      "source_location": "L108",
       "_origin": "ast",
       "id": "src_store_gamereducer_selectcharacter",
       "community": 39,
@@ -8637,27 +8777,27 @@
       "label": "selectLoot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L110",
+      "source_location": "L112",
       "_origin": "ast",
       "id": "src_store_gamereducer_selectloot",
-      "community": 13,
+      "community": 80,
       "norm_label": "selectloot"
     },
     {
       "label": "sellLoot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L114",
+      "source_location": "L116",
       "_origin": "ast",
       "id": "src_store_gamereducer_sellloot",
-      "community": 23,
+      "community": 25,
       "norm_label": "sellloot"
     },
     {
       "label": "setBaseStats",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L118",
+      "source_location": "L120",
       "_origin": "ast",
       "id": "src_store_gamereducer_setbasestats",
       "community": 0,
@@ -8667,7 +8807,7 @@
       "label": "setLevel",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L125",
+      "source_location": "L127",
       "_origin": "ast",
       "id": "src_store_gamereducer_setlevel",
       "community": 0,
@@ -8677,17 +8817,17 @@
       "label": "setSaveSlot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L129",
+      "source_location": "L131",
       "_origin": "ast",
       "id": "src_store_gamereducer_setsaveslot",
-      "community": 23,
+      "community": 39,
       "norm_label": "setsaveslot"
     },
     {
       "label": "setStats",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L133",
+      "source_location": "L135",
       "_origin": "ast",
       "id": "src_store_gamereducer_setstats",
       "community": 36,
@@ -8697,47 +8837,47 @@
       "label": "switchUi",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L140",
+      "source_location": "L142",
       "_origin": "ast",
       "id": "src_store_gamereducer_switchui",
-      "community": 23,
+      "community": 39,
       "norm_label": "switchui"
     },
     {
       "label": "toggleFilter",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L144",
+      "source_location": "L146",
       "_origin": "ast",
       "id": "src_store_gamereducer_togglefilter",
-      "community": 23,
+      "community": 79,
       "norm_label": "togglefilter"
     },
     {
       "label": "toggleHUD",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L148",
+      "source_location": "L150",
       "_origin": "ast",
       "id": "src_store_gamereducer_togglehud",
-      "community": 27,
+      "community": 23,
       "norm_label": "togglehud"
     },
     {
       "label": "toggleUi",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L152",
+      "source_location": "L154",
       "_origin": "ast",
       "id": "src_store_gamereducer_toggleui",
-      "community": 37,
+      "community": 40,
       "norm_label": "toggleui"
     },
     {
       "label": "unequipLoot",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L156",
+      "source_location": "L158",
       "_origin": "ast",
       "id": "src_store_gamereducer_unequiploot",
       "community": 13,
@@ -8747,7 +8887,7 @@
       "label": "updateBaseStats",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L160",
+      "source_location": "L162",
       "_origin": "ast",
       "id": "src_store_gamereducer_updatebasestats",
       "community": 23,
@@ -8757,7 +8897,7 @@
       "label": "updateStats",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L167",
+      "source_location": "L169",
       "_origin": "ast",
       "id": "src_store_gamereducer_updatestats",
       "community": 36,
@@ -8767,17 +8907,17 @@
       "label": "setCurrentArea",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L171",
+      "source_location": "L173",
       "_origin": "ast",
       "id": "src_store_gamereducer_setcurrentarea",
-      "community": 27,
+      "community": 23,
       "norm_label": "setcurrentarea"
     },
     {
       "label": "setPlayerPosition",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L175",
+      "source_location": "L177",
       "_origin": "ast",
       "id": "src_store_gamereducer_setplayerposition",
       "community": 23,
@@ -8787,7 +8927,7 @@
       "label": "syncStats()",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L183",
+      "source_location": "L185",
       "_origin": "ast",
       "id": "src_store_gamereducer_syncstats",
       "community": 23,
@@ -8797,7 +8937,7 @@
       "label": "gameReducer",
       "file_type": "code",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L186",
+      "source_location": "L188",
       "_origin": "ast",
       "id": "src_store_gamereducer_gamereducer",
       "community": 25,
@@ -8950,7 +9090,7 @@
       "source_location": "L186",
       "_origin": "ast",
       "id": "src_types_game_lootitem",
-      "community": 13,
+      "community": 38,
       "norm_label": "lootitem"
     },
     {
@@ -8990,7 +9130,7 @@
       "source_location": "L217",
       "_origin": "ast",
       "id": "src_types_game_loottable",
-      "community": 8,
+      "community": 22,
       "norm_label": "loottable"
     },
     {
@@ -9000,7 +9140,7 @@
       "source_location": "L218",
       "_origin": "ast",
       "id": "src_types_game_playerstats",
-      "community": 79,
+      "community": 14,
       "norm_label": "playerstats"
     },
     {
@@ -9050,7 +9190,7 @@
       "source_location": "L265",
       "_origin": "ast",
       "id": "src_types_game_targettype",
-      "community": 9,
+      "community": 52,
       "norm_label": "targettype"
     },
     {
@@ -9080,7 +9220,7 @@
       "source_location": "L281",
       "_origin": "ast",
       "id": "src_types_game_enemyoptions",
-      "community": 17,
+      "community": 12,
       "norm_label": "enemyoptions"
     },
     {
@@ -9110,7 +9250,7 @@
       "source_location": "L322",
       "_origin": "ast",
       "id": "src_types_game_entitywithvector",
-      "community": 8,
+      "community": 22,
       "norm_label": "entitywithvector"
     },
     {
@@ -9154,13 +9294,23 @@
       "norm_label": "number-to-words.d.ts"
     },
     {
+      "label": "number-to-words",
+      "file_type": "code",
+      "source_file": "src/types/number-to-words.d.ts",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "src_types_number_to_words_d_number_to_words",
+      "community": 72,
+      "norm_label": "number-to-words"
+    },
+    {
       "label": "scene.ts",
       "file_type": "code",
       "source_file": "src/types/scene.ts",
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_types_scene",
-      "community": 8,
+      "community": 9,
       "norm_label": "scene.ts"
     },
     {
@@ -9170,8 +9320,18 @@
       "source_location": "L19",
       "_origin": "ast",
       "id": "src_types_scene_gamescenelike",
-      "community": 8,
+      "community": 9,
       "norm_label": "gamescenelike"
+    },
+    {
+      "label": "UI.test.tsx",
+      "file_type": "code",
+      "source_file": "src/ui/UI.test.tsx",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_ui_ui_test",
+      "community": 18,
+      "norm_label": "ui.test.tsx"
     },
     {
       "label": "UI.tsx",
@@ -9187,7 +9347,7 @@
       "label": "MenuContext",
       "file_type": "code",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L19",
+      "source_location": "L21",
       "_origin": "ast",
       "id": "src_ui_ui_menucontext",
       "community": 41,
@@ -9197,7 +9357,7 @@
       "label": "MenuComponent",
       "file_type": "code",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L24",
+      "source_location": "L26",
       "_origin": "ast",
       "id": "src_ui_ui_menucomponent",
       "community": 18,
@@ -9207,7 +9367,7 @@
       "label": "MenuConfig",
       "file_type": "code",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L26",
+      "source_location": "L28",
       "_origin": "ast",
       "id": "src_ui_ui_menuconfig",
       "community": 18,
@@ -9217,7 +9377,7 @@
       "label": "asMenuComponent()",
       "file_type": "code",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L37",
+      "source_location": "L42",
       "_origin": "ast",
       "id": "src_ui_ui_asmenucomponent",
       "community": 18,
@@ -9227,10 +9387,10 @@
       "label": "UI()",
       "file_type": "code",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L40",
+      "source_location": "L45",
       "_origin": "ast",
       "id": "src_ui_ui_ui",
-      "community": 18,
+      "community": 39,
       "norm_label": "ui()"
     },
     {
@@ -9240,7 +9400,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_atoms_attribute",
-      "community": 38,
+      "community": 14,
       "norm_label": "attribute.tsx"
     },
     {
@@ -9250,7 +9410,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_ui_components_atoms_attribute_attributeprops",
-      "community": 38,
+      "community": 14,
       "norm_label": "attributeprops"
     },
     {
@@ -9260,7 +9420,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_ui_components_atoms_attribute_attribute",
-      "community": 38,
+      "community": 14,
       "norm_label": "attribute()"
     },
     {
@@ -9300,7 +9460,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_atoms_droppableslot_test",
-      "community": 13,
+      "community": 25,
       "norm_label": "droppableslot.test.tsx"
     },
     {
@@ -9310,7 +9470,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_ui_components_atoms_droppableslot_test_helm",
-      "community": 13,
+      "community": 25,
       "norm_label": "helm"
     },
     {
@@ -9420,7 +9580,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_atoms_slot",
-      "community": 13,
+      "community": 38,
       "norm_label": "slot.tsx"
     },
     {
@@ -9430,7 +9590,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_ui_components_atoms_slot_slotcomponentprops",
-      "community": 13,
+      "community": 38,
       "norm_label": "slotcomponentprops"
     },
     {
@@ -9440,7 +9600,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_ui_components_atoms_slot_slotprops",
-      "community": 13,
+      "community": 38,
       "norm_label": "slotprops"
     },
     {
@@ -9520,7 +9680,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_molecules_attributes",
-      "community": 38,
+      "community": 14,
       "norm_label": "attributes.tsx"
     },
     {
@@ -9530,7 +9690,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_ui_components_molecules_attributes_attributesstyles",
-      "community": 38,
+      "community": 14,
       "norm_label": "attributesstyles"
     },
     {
@@ -9540,7 +9700,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_ui_components_molecules_attributes_attributesprops",
-      "community": 38,
+      "community": 14,
       "norm_label": "attributesprops"
     },
     {
@@ -9550,7 +9710,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_ui_components_molecules_attributes_attributes",
-      "community": 38,
+      "community": 14,
       "norm_label": "attributes()"
     },
     {
@@ -9700,7 +9860,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_molecules_loot",
-      "community": 59,
+      "community": 13,
       "norm_label": "loot.tsx"
     },
     {
@@ -9710,7 +9870,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_ui_components_molecules_loot_lootprops",
-      "community": 59,
+      "community": 13,
       "norm_label": "lootprops"
     },
     {
@@ -9730,7 +9890,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_molecules_lootlist",
-      "community": 13,
+      "community": 80,
       "norm_label": "lootlist.tsx"
     },
     {
@@ -9740,7 +9900,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "src_ui_components_molecules_lootlist_lootlistprops",
-      "community": 13,
+      "community": 80,
       "norm_label": "lootlistprops"
     },
     {
@@ -9750,7 +9910,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_ui_components_molecules_lootlist_lootlist",
-      "community": 13,
+      "community": 80,
       "norm_label": "lootlist()"
     },
     {
@@ -9760,7 +9920,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_molecules_lootlistdrag_test",
-      "community": 13,
+      "community": 25,
       "norm_label": "lootlistdrag.test.tsx"
     },
     {
@@ -9770,7 +9930,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_ui_components_molecules_lootlistdrag_test_makeitem",
-      "community": 13,
+      "community": 25,
       "norm_label": "makeitem()"
     },
     {
@@ -9810,7 +9970,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_molecules_navigation",
-      "community": 23,
+      "community": 25,
       "norm_label": "navigation.tsx"
     },
     {
@@ -9820,7 +9980,7 @@
       "source_location": "L8",
       "_origin": "ast",
       "id": "src_ui_components_molecules_navigation_navigation",
-      "community": 23,
+      "community": 19,
       "norm_label": "navigation()"
     },
     {
@@ -9830,7 +9990,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "src_ui_components_molecules_navigation_mapstatetoprops",
-      "community": 23,
+      "community": 25,
       "norm_label": "mapstatetoprops()"
     },
     {
@@ -9950,7 +10110,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedattributes",
-      "community": 38,
+      "community": 14,
       "norm_label": "groupedattributes.tsx"
     },
     {
@@ -9960,7 +10120,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedattributes_groupedattributesprops",
-      "community": 79,
+      "community": 14,
       "norm_label": "groupedattributesprops"
     },
     {
@@ -9970,7 +10130,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedattributes_numericstats",
-      "community": 38,
+      "community": 14,
       "norm_label": "numericstats"
     },
     {
@@ -9980,7 +10140,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedattributes_groupedattributes",
-      "community": 38,
+      "community": 14,
       "norm_label": "groupedattributes()"
     },
     {
@@ -9990,7 +10150,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedstats",
-      "community": 79,
+      "community": 14,
       "norm_label": "groupedstats.tsx"
     },
     {
@@ -10000,7 +10160,7 @@
       "source_location": "L6",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedstats_statitem",
-      "community": 79,
+      "community": 14,
       "norm_label": "statitem"
     },
     {
@@ -10010,7 +10170,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedstats_groupedstatsprops",
-      "community": 79,
+      "community": 14,
       "norm_label": "groupedstatsprops"
     },
     {
@@ -10020,7 +10180,7 @@
       "source_location": "L16",
       "_origin": "ast",
       "id": "src_ui_components_organisms_groupedstats_groupedstats",
-      "community": 79,
+      "community": 14,
       "norm_label": "groupedstats()"
     },
     {
@@ -10090,7 +10250,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_organisms_stock",
-      "community": 13,
+      "community": 80,
       "norm_label": "stock.tsx"
     },
     {
@@ -10100,7 +10260,7 @@
       "source_location": "L5",
       "_origin": "ast",
       "id": "src_ui_components_organisms_stock_stock",
-      "community": 11,
+      "community": 80,
       "norm_label": "stock()"
     },
     {
@@ -10170,7 +10330,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_templates_armory_test",
-      "community": 25,
+      "community": 79,
       "norm_label": "armory.test.tsx"
     },
     {
@@ -10180,7 +10340,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_ui_components_templates_armory_test_sampleitems",
-      "community": 25,
+      "community": 79,
       "norm_label": "sampleitems"
     },
     {
@@ -10190,7 +10350,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_templates_armory",
-      "community": 11,
+      "community": 79,
       "norm_label": "armory.tsx"
     },
     {
@@ -10200,7 +10360,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_ui_components_templates_armory_sortkey",
-      "community": 11,
+      "community": 79,
       "norm_label": "sortkey"
     },
     {
@@ -10210,7 +10370,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_ui_components_templates_armory_armory",
-      "community": 11,
+      "community": 79,
       "norm_label": "armory()"
     },
     {
@@ -10230,7 +10390,7 @@
       "source_location": "L11",
       "_origin": "ast",
       "id": "src_ui_components_templates_character_character",
-      "community": 18,
+      "community": 38,
       "norm_label": "character()"
     },
     {
@@ -10310,7 +10470,7 @@
       "source_location": "L13",
       "_origin": "ast",
       "id": "src_ui_components_templates_equipment_equipment",
-      "community": 18,
+      "community": 25,
       "norm_label": "equipment()"
     },
     {
@@ -10344,6 +10504,46 @@
       "norm_label": "hud()"
     },
     {
+      "label": "MainMenu.test.tsx",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_mainmenu_test",
+      "community": 24,
+      "norm_label": "mainmenu.test.tsx"
+    },
+    {
+      "label": "makeSave()",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_mainmenu_test_makesave",
+      "community": 24,
+      "norm_label": "makesave()"
+    },
+    {
+      "label": "MainMenu.tsx",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_mainmenu",
+      "community": 39,
+      "norm_label": "mainmenu.tsx"
+    },
+    {
+      "label": "MainMenu()",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_mainmenu_mainmenu",
+      "community": 39,
+      "norm_label": "mainmenu()"
+    },
+    {
       "label": "Save.test.tsx",
       "file_type": "code",
       "source_file": "src/ui/components/templates/Save.test.tsx",
@@ -10370,7 +10570,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_components_templates_save",
-      "community": 24,
+      "community": 39,
       "norm_label": "save.tsx"
     },
     {
@@ -10380,7 +10580,7 @@
       "source_location": "L10",
       "_origin": "ast",
       "id": "src_ui_components_templates_save_saveprops",
-      "community": 24,
+      "community": 39,
       "norm_label": "saveprops"
     },
     {
@@ -10390,8 +10590,38 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_ui_components_templates_save_save",
-      "community": 18,
+      "community": 39,
       "norm_label": "save()"
+    },
+    {
+      "label": "Settings.test.tsx",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_settings_test",
+      "community": 37,
+      "norm_label": "settings.test.tsx"
+    },
+    {
+      "label": "Settings.tsx",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_settings",
+      "community": 37,
+      "norm_label": "settings.tsx"
+    },
+    {
+      "label": "Settings()",
+      "file_type": "code",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "src_ui_components_templates_settings_settings",
+      "community": 37,
+      "norm_label": "settings()"
     },
     {
       "label": "System.tsx",
@@ -10420,7 +10650,7 @@
       "source_location": "L14",
       "_origin": "ast",
       "id": "src_ui_components_templates_system_system",
-      "community": 18,
+      "community": 39,
       "norm_label": "system()"
     },
     {
@@ -10460,7 +10690,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_test",
-      "community": 11,
+      "community": 27,
       "norm_label": "helpers.test.ts"
     },
     {
@@ -10470,7 +10700,7 @@
       "source_location": "L1",
       "_origin": "ast",
       "id": "src_ui_operations_helpers",
-      "community": 11,
+      "community": 27,
       "norm_label": "helpers.ts"
     },
     {
@@ -10480,7 +10710,7 @@
       "source_location": "L3",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_statobject",
-      "community": 11,
+      "community": 27,
       "norm_label": "statobject"
     },
     {
@@ -10490,7 +10720,7 @@
       "source_location": "L7",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_statitem",
-      "community": 11,
+      "community": 27,
       "norm_label": "statitem"
     },
     {
@@ -10500,7 +10730,7 @@
       "source_location": "L12",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_removestats",
-      "community": 11,
+      "community": 27,
       "norm_label": "removestats()"
     },
     {
@@ -10510,7 +10740,7 @@
       "source_location": "L15",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_addstats",
-      "community": 11,
+      "community": 27,
       "norm_label": "addstats()"
     },
     {
@@ -10520,7 +10750,7 @@
       "source_location": "L18",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_statsarraytoobject",
-      "community": 11,
+      "community": 27,
       "norm_label": "statsarraytoobject()"
     },
     {
@@ -10530,7 +10760,7 @@
       "source_location": "L28",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_comparable",
-      "community": 11,
+      "community": 27,
       "norm_label": "comparable"
     },
     {
@@ -10540,7 +10770,7 @@
       "source_location": "L30",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_readkey",
-      "community": 11,
+      "community": 27,
       "norm_label": "readkey()"
     },
     {
@@ -10550,7 +10780,7 @@
       "source_location": "L32",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_sortascending",
-      "community": 11,
+      "community": 27,
       "norm_label": "sortascending()"
     },
     {
@@ -10560,7 +10790,7 @@
       "source_location": "L42",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_sortdescending",
-      "community": 11,
+      "community": 27,
       "norm_label": "sortdescending()"
     },
     {
@@ -10570,7 +10800,7 @@
       "source_location": "L52",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_sortoptions",
-      "community": 11,
+      "community": 27,
       "norm_label": "sortoptions"
     },
     {
@@ -10580,7 +10810,7 @@
       "source_location": "L57",
       "_origin": "ast",
       "id": "src_ui_operations_helpers_sortby",
-      "community": 11,
+      "community": 27,
       "norm_label": "sortby()"
     },
     {
@@ -10630,7 +10860,7 @@
       "source_location": "L35",
       "_origin": "ast",
       "id": "src_ui_test_utils_renderwithproviders_renderwithproviders",
-      "community": 25,
+      "community": 24,
       "norm_label": "renderwithproviders()"
     },
     {
@@ -13917,6 +14147,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "api/armory/_lib/http.ts",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "api_armory_lib_http_witherrors",
+      "target": "api_armory_lib_http_sendjson",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -16739,9 +16980,20 @@
     },
     {
       "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/ui/components/molecules/LootListDrag.tsx",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_lootlistdrag_lootlistdrag",
+      "target": "scripts_generate_pwa_icons_icon"
+    },
+    {
+      "relation": "indirect_call",
       "confidence": "INFERRED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L74",
+      "source_location": "L79",
       "weight": 1.0,
       "context": "argument",
       "source": "src_phasergame",
@@ -16753,7 +17005,29 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L7",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_phasergame",
+      "target": "src_scenes_bootscene",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_phasergame",
+      "target": "src_scenes_bootscene_bootscene",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L8",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_gameoverscene",
@@ -16764,7 +17038,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L7",
+      "source_location": "L8",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_gameoverscene_gameoverscene",
@@ -16775,7 +17049,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_gamescene",
@@ -16786,7 +17060,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L6",
+      "source_location": "L7",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_gamescene_gamescene",
@@ -16797,7 +17071,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L3",
+      "source_location": "L4",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_loadscene",
@@ -16808,7 +17082,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L3",
+      "source_location": "L4",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_loadscene_loadscene",
@@ -16819,7 +17093,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L4",
+      "source_location": "L5",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_selectscene",
@@ -16830,7 +17104,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L4",
+      "source_location": "L5",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_selectscene_selectscene",
@@ -16841,7 +17115,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L5",
+      "source_location": "L6",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_townscene",
@@ -16852,10 +17126,109 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/PhaserGame.tsx",
-      "source_location": "L5",
+      "source_location": "L6",
       "weight": 1.0,
       "source": "src_phasergame",
       "target": "src_scenes_townscene_townscene",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "src_phasergame",
+      "target": "src_services_settingsstorage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "src_phasergame",
+      "target": "src_services_settingsstorage_readsettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_scenes_bootscene_bootscene"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_scenes_gameoverscene_gameoverscene"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_scenes_gamescene_gamescene"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_scenes_loadscene_loadscene"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_scenes_selectscene_selectscene"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "collection",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_scenes_townscene_townscene"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/PhaserGame.tsx",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "src_phasergame_phasergame",
+      "target": "src_services_settingsstorage_readsettings",
       "confidence_score": 1.0
     },
     {
@@ -16926,7 +17299,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L267",
+      "source_location": "L294",
       "weight": 1.0,
       "source": "src_scenes_loadscene_loadscene_create",
       "target": "src_config_animations_createanimations"
@@ -17124,6 +17497,17 @@
       "source_location": "L109",
       "weight": 1.0,
       "source": "src_config_classes_getascendedclass",
+      "target": "src_config_classes_matchascended",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/config/classes.ts",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "src_config_classes_getascendedschools",
       "target": "src_config_classes_matchascended",
       "confidence_score": 1.0
     },
@@ -18832,10 +19216,43 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/Enemy/Enemy.ts",
+      "source_location": "L223",
+      "weight": 1.0,
+      "source": "src_entities_enemy_enemy_enemy_setcircling",
+      "target": "src_entities_enemy_enemy_enemy_isincirclingdistance",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Enemy/Enemy.ts",
+      "source_location": "L218",
+      "weight": 1.0,
+      "source": "src_entities_enemy_enemy_enemy_setcircling",
+      "target": "src_entities_enemy_enemy_enemy_stopcircling",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Enemy/Enemy.ts",
       "source_location": "L289",
       "weight": 1.0,
       "source": "src_entities_enemy_enemy_enemy_wander",
       "target": "src_entities_enemy_enemy_enemy_move",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Enemy/Enemy.ts",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "src_entities_enemy_enemy_enemy_enemyspawned",
+      "target": "src_entities_enemy_enemy_enemy_select",
       "confidence_score": 1.0
     },
     {
@@ -18869,6 +19286,17 @@
       "weight": 1.0,
       "source": "src_entities_enemy_enemy_enemy_spawningenemy",
       "target": "src_entities_enemy_enemy_enemy_enemyspawned",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Enemy/Enemy.ts",
+      "source_location": "L295",
+      "weight": 1.0,
+      "source": "src_entities_enemy_enemy_enemy_setwandering",
+      "target": "src_entities_enemy_enemy_enemy_wander",
       "confidence_score": 1.0
     },
     {
@@ -19038,6 +19466,17 @@
       "weight": 1.0,
       "source": "src_entities_enemy_healer_healer_update",
       "target": "src_entities_enemy_healer_healer_healtarget",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Enemy/Healer.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "src_entities_enemy_healer_healer_gethealtarget",
+      "target": "src_entities_enemy_healer_healer_getmissinghealth",
       "confidence_score": 1.0
     },
     {
@@ -20307,6 +20746,17 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/Loot/Item.ts",
+      "source_location": "L71",
+      "weight": 1.0,
+      "source": "src_entities_loot_item_item_constructor",
+      "target": "src_entities_loot_item_item_adjuststats",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Loot/Item.ts",
       "source_location": "L66",
       "weight": 1.0,
       "source": "src_entities_loot_item_item_constructor",
@@ -20469,6 +20919,17 @@
       "source_location": "L16",
       "weight": 1.0,
       "source": "src_entities_loot_loottable_loottable",
+      "target": "src_entities_loot_loottable_loottable_qualityroll",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Loot/LootTable.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "src_entities_loot_loottable_loottable_constructor",
       "target": "src_entities_loot_loottable_loottable_qualityroll",
       "confidence_score": 1.0
     },
@@ -22275,6 +22736,17 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/Player/Player.ts",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "src_entities_player_player_player_constructor",
+      "target": "src_entities_player_player_player_levelup",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Player/Player.ts",
       "source_location": "L94",
       "weight": 1.0,
       "source": "src_entities_player_player_player_constructor",
@@ -23707,6 +24179,17 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/Resources/Resource.ts",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "src_entities_resources_resource_resource_constructor",
+      "target": "src_entities_resources_resource_resource_normalisestat",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Resources/Resource.ts",
       "source_location": "L41",
       "weight": 1.0,
       "source": "src_entities_resources_resource_resource_constructor",
@@ -23745,6 +24228,17 @@
       "source": "src_entities_resources_resource_resource_constructor",
       "target": "src_entities_resources_resource_resource_setregenerationrate",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/Resources/Resource.ts",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "src_entities_resources_resource_resource_constructor",
+      "target": "src_helpers_mapstatetodata_mapstatetodata"
     },
     {
       "relation": "calls",
@@ -24879,6 +25373,17 @@
       "weight": 1.0,
       "source": "src_entities_spells_earthshield_earthshield_constructor",
       "target": "src_types_game_spelloptions",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/EarthShield.ts",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "src_entities_spells_earthshield_earthshield_effect",
+      "target": "src_entities_spells_earthshield_earthshield_end",
       "confidence_score": 1.0
     },
     {
@@ -26042,6 +26547,39 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/Multishot.ts",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "src_entities_spells_multishot_multishot_startanimation",
+      "target": "src_entities_spells_multishot_multishot_effect",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/Multishot.ts",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "src_entities_spells_multishot_multishot_startanimation",
+      "target": "src_entities_spells_multishot_multishot_updateanimation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/Spells/Multishot.ts",
+      "source_location": "L53",
+      "weight": 1.0,
+      "source": "src_entities_spells_multishot_multishot_startanimation",
+      "target": "src_helpers_targetvector_targetvector"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/Spells/PowerInfusion.ts",
@@ -26351,6 +26889,28 @@
       "weight": 1.0,
       "source": "src_entities_spells_siphonsoul_siphonsoul_startanimation",
       "target": "src_entities_spells_siphonsoul_siphonsoul_setparticles",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/SiphonSoul.ts",
+      "source_location": "L164",
+      "weight": 1.0,
+      "source": "src_entities_spells_siphonsoul_siphonsoul_startanimation",
+      "target": "src_entities_spells_siphonsoul_siphonsoul_cleareffect",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/SiphonSoul.ts",
+      "source_location": "L171",
+      "weight": 1.0,
+      "source": "src_entities_spells_siphonsoul_siphonsoul_startanimation",
+      "target": "src_entities_spells_siphonsoul_siphonsoul_clearparticleeffect",
       "confidence_score": 1.0
     },
     {
@@ -27351,6 +27911,17 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/Spells/Spell.ts",
+      "source_location": "L148",
+      "weight": 1.0,
+      "source": "src_entities_spells_spell_spell_setcooldown",
+      "target": "src_entities_spells_spell_spell_onresourcechangehandler",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/Spell.ts",
       "source_location": "L101",
       "weight": 1.0,
       "source": "src_entities_spells_spell_spell_enablespell",
@@ -27421,6 +27992,17 @@
       "weight": 1.0,
       "source": "src_entities_spells_spell_spell_castspell",
       "target": "src_entities_spells_spell_spell_killspell",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/Spells/Spell.ts",
+      "source_location": "L175",
+      "weight": 1.0,
+      "source": "src_entities_spells_spell_spell_clearlastprimedspell",
+      "target": "src_entities_spells_spell_spell_clearspell",
       "confidence_score": 1.0
     },
     {
@@ -27693,6 +28275,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/Spells/Whirlwind.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "src_entities_spells_whirlwind_whirlwind_effect",
+      "target": "src_helpers_targetvector_targetvector"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/UI/Banes.ts",
@@ -27948,6 +28541,17 @@
       "weight": 1.0,
       "source": "src_entities_ui_boons_boons_calculate",
       "target": "src_store_gamereducer_setstats"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/Boons.ts",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "src_entities_ui_boons_boons_calculate",
+      "target": "src_store_gamereducer_updatestats"
     },
     {
       "relation": "contains",
@@ -28492,6 +29096,39 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_constructor",
+      "target": "src_entities_ui_hud_ui_deletesaves",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_constructor",
+      "target": "src_entities_ui_hud_ui_loadsavedgame",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L77",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_constructor",
+      "target": "src_entities_ui_hud_ui_savegame",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/entities/UI/HUD.ts",
       "source_location": "L37",
       "weight": 1.0,
       "source": "src_entities_ui_hud_ui_constructor",
@@ -28559,10 +29196,76 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_constructor",
+      "target": "src_store_gamereducer_addloot"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_constructor",
+      "target": "src_store_gamereducer_togglehud"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_constructor",
+      "target": "src_store_gamereducer_toggleui"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_setinvetoryicon",
+      "target": "src_store_gamereducer_toggleui"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_setsystemicon",
+      "target": "src_store_gamereducer_toggleui"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/HUD.ts",
       "source_location": "L147",
       "weight": 1.0,
       "source": "src_entities_ui_hud_ui_savegame",
       "target": "src_services_savestorage_writesave"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/entities/UI/HUD.ts",
+      "source_location": "L151",
+      "weight": 1.0,
+      "source": "src_entities_ui_hud_ui_deletesaves",
+      "target": "src_services_savestorage_removesave"
     },
     {
       "relation": "calls",
@@ -29182,6 +29885,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "references",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/helpers/spawnStyle.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "src_helpers_spawnstyle_dropin",
+      "target": "src_helpers_spawnstyle_dropinitem"
+    },
+    {
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -29478,6 +30192,17 @@
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/hooks/useArmory.ts",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "src_ui_hooks_usearmory_usearmory",
+      "target": "src_lib_armoryclient_isarmoryconfigured"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
       "source_file": "src/lib/armoryClient.ts",
       "source_location": "L78",
       "weight": 1.0,
@@ -29519,6 +30244,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/hooks/useArmory.ts",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "src_ui_hooks_usearmory_usearmory",
+      "target": "src_lib_armoryclient_listitems"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -29530,6 +30266,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/hooks/useArmory.ts",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "src_ui_hooks_usearmory_usearmory",
+      "target": "src_lib_armoryclient_removeitem"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -29539,6 +30286,17 @@
       "source": "src_ui_hooks_usearmory",
       "target": "src_lib_armoryclient_restock",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/hooks/useArmory.ts",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "src_ui_hooks_usearmory_usearmory",
+      "target": "src_lib_armoryclient_restock"
     },
     {
       "relation": "contains",
@@ -29590,6 +30348,46 @@
       "weight": 1.0,
       "source": "src_main",
       "target": "src_ui_ui",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "src_scenes_bootscene",
+      "target": "src_scenes_bootscene_bootscene",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "src_scenes_bootscene_bootscene",
+      "target": "src_scenes_bootscene_bootscene_constructor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "src_scenes_bootscene_bootscene",
+      "target": "src_scenes_bootscene_bootscene_create",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "method",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/BootScene.ts",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "src_scenes_bootscene_bootscene",
+      "target": "src_scenes_bootscene_bootscene_preload",
       "confidence_score": 1.0
     },
     {
@@ -30190,11 +30988,33 @@
       "relation": "calls",
       "context": "call",
       "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/scenes/GameScene.ts",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "src_scenes_gamescene_gamescene_gameover",
+      "target": "src_store_gamereducer_togglehud"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
       "source_file": "src/scenes/GameScene.ts",
       "source_location": "L274",
       "weight": 1.0,
       "source": "src_scenes_gamescene_gamescene_wavecomplete",
       "target": "src_scenes_gamescene_gamescene_removenextleveltimer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/GameScene.ts",
+      "source_location": "L285",
+      "weight": 1.0,
+      "source": "src_scenes_gamescene_gamescene_spawnenemies",
+      "target": "src_scenes_gamescene_gamescene_spawnenemy",
       "confidence_score": 1.0
     },
     {
@@ -30253,10 +31073,32 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/LoadScene.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "src_scenes_loadscene",
+      "target": "src_scenes_createlogo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/LoadScene.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "src_scenes_loadscene",
+      "target": "src_scenes_createlogo_createlogo",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L7",
+      "source_location": "L8",
       "weight": 1.0,
       "source": "src_scenes_loadscene",
       "target": "src_scenes_loadscene_loadscene",
@@ -30299,7 +31141,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L8",
+      "source_location": "L12",
       "weight": 1.0,
       "source": "src_scenes_loadscene_loadscene",
       "target": "src_scenes_loadscene_loadscene_constructor",
@@ -30309,7 +31151,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L266",
+      "source_location": "L293",
       "weight": 1.0,
       "source": "src_scenes_loadscene_loadscene",
       "target": "src_scenes_loadscene_loadscene_create",
@@ -30319,7 +31161,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L13",
+      "source_location": "L17",
       "weight": 1.0,
       "source": "src_scenes_loadscene_loadscene",
       "target": "src_scenes_loadscene_loadscene_preload",
@@ -30329,7 +31171,7 @@
       "relation": "method",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L272",
+      "source_location": "L306",
       "weight": 1.0,
       "source": "src_scenes_loadscene_loadscene",
       "target": "src_scenes_loadscene_loadscene_shutdown",
@@ -30341,7 +31183,18 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "src/scenes/LoadScene.ts",
-      "source_location": "L268",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "src_scenes_loadscene_loadscene_preload",
+      "target": "src_scenes_createlogo_createlogo"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/scenes/LoadScene.ts",
+      "source_location": "L298",
       "weight": 1.0,
       "source": "src_scenes_loadscene_loadscene_create",
       "target": "src_store_gamereducer_toggleui"
@@ -30449,6 +31302,17 @@
       "weight": 1.0,
       "source": "src_scenes_selectscene_selectscene",
       "target": "src_scenes_selectscene_selectscene_create",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/SelectScene.ts",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "src_scenes_selectscene_selectscene_create",
+      "target": "src_scenes_selectscene_selectscene_choosecharacter",
       "confidence_score": 1.0
     },
     {
@@ -30713,6 +31577,28 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L307",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_createobjectlayers",
+      "target": "src_scenes_townscene_townscene_setdepthbyy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_createtownenvironment",
+      "target": "src_scenes_townscene_townscene_setdepthbyy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/TownScene.ts",
       "source_location": "L528",
       "weight": 1.0,
       "source": "src_scenes_townscene_townscene_update",
@@ -30812,6 +31698,61 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L308",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_createobjectlayers",
+      "target": "src_scenes_townscene_townscene_addanimationstosprite",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L396",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_setupcollisions",
+      "target": "src_scenes_townscene_townscene_handlecollisionidle",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L410",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_handlecollisionidle",
+      "target": "src_types_game_arcadecollisionobject"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_setuppoiinteractions",
+      "target": "src_scenes_townscene_townscene_handlezoneoverlap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L435",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_setuppoiinteractions",
+      "target": "src_scenes_townscene_townscene_mappoitointeraction",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/TownScene.ts",
       "source_location": "L485",
       "weight": 1.0,
       "source": "src_scenes_townscene_townscene_handlezoneoverlap",
@@ -30861,6 +31802,48 @@
       "weight": 1.0,
       "source": "src_scenes_townscene_townscene_handleinteraction",
       "target": "src_store_gamereducer_setplayerposition"
+    },
+    {
+      "relation": "references",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L525",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_update",
+      "target": "src_types_game_arcadecollisionobject"
+    },
+    {
+      "relation": "references",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/scenes/TownScene.ts",
+      "source_location": "L539",
+      "weight": 1.0,
+      "source": "src_scenes_townscene_townscene_shutdown",
+      "target": "src_types_game_arcadecollisionobject"
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/createLogo.ts",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "src_scenes_createlogo",
+      "target": "src_scenes_createlogo_createlogo",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/scenes/createLogo.ts",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "src_scenes_createlogo",
+      "target": "src_scenes_createlogo_logooptions",
+      "confidence_score": 1.0
     },
     {
       "relation": "imports_from",
@@ -31024,6 +32007,28 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_services_savestorage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_services_savestorage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.tsx",
       "source_location": "L6",
       "weight": 1.0,
@@ -31057,11 +32062,44 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_services_savestorage_savedata",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.test.tsx",
       "source_location": "L4",
       "weight": 1.0,
       "source": "src_ui_components_templates_save_test",
       "target": "src_services_savestorage_savedata",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_services_savestorage_save_slots",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_services_savestorage_save_slots",
       "confidence_score": 1.0
     },
     {
@@ -31101,6 +32139,17 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_services_savestorage_writesave",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.test.tsx",
       "source_location": "L4",
       "weight": 1.0,
@@ -31120,6 +32169,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/System.tsx",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_system_system",
+      "target": "src_services_savestorage_writesave"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31131,6 +32191,39 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Save.tsx",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_save_save",
+      "target": "src_services_savestorage_removesave"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_services_savestorage_readallsaves",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_mainmenu",
+      "target": "src_services_savestorage_readallsaves"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31139,6 +32232,211 @@
       "weight": 1.0,
       "source": "src_ui_components_templates_save",
       "target": "src_services_savestorage_readallsaves",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Save.tsx",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_save_save",
+      "target": "src_services_savestorage_readallsaves"
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage_test",
+      "target": "src_services_settingsstorage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage_test",
+      "target": "src_services_settingsstorage_default_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage_test",
+      "target": "src_services_settingsstorage_readsettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage_test",
+      "target": "src_services_settingsstorage_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage_test",
+      "target": "src_services_settingsstorage_writesettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage",
+      "target": "src_services_settingsstorage_default_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage",
+      "target": "src_services_settingsstorage_readsettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage",
+      "target": "src_services_settingsstorage_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/services/settingsStorage.ts",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "src_services_settingsstorage",
+      "target": "src_services_settingsstorage_writesettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
+      "target": "src_services_settingsstorage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_test",
+      "target": "src_services_settingsstorage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
+      "target": "src_services_settingsstorage_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
+      "target": "src_services_settingsstorage_readsettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_settings",
+      "target": "src_services_settingsstorage_readsettings"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_test",
+      "target": "src_services_settingsstorage_readsettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
+      "target": "src_services_settingsstorage_writesettings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_settings",
+      "target": "src_services_settingsstorage_writesettings"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_test",
+      "target": "src_services_settingsstorage_writesettings",
       "confidence_score": 1.0
     },
     {
@@ -31252,10 +32550,21 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/store/gameReducer.test.ts",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_store_gamereducer_test",
+      "target": "src_store_gamereducer_switchui",
+      "confidence_score": 1.0
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.test.ts",
-      "source_location": "L16",
+      "source_location": "L17",
       "weight": 1.0,
       "source": "src_store_gamereducer_test",
       "target": "src_store_gamereducer_test_makeitem",
@@ -31277,7 +32586,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "weight": 1.0,
       "source": "src_store_gamereducer_test",
       "target": "src_types_game",
@@ -31288,7 +32597,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.test.ts",
-      "source_location": "L14",
+      "source_location": "L15",
       "weight": 1.0,
       "source": "src_store_gamereducer_test",
       "target": "src_types_game_lootitem",
@@ -31298,7 +32607,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L76",
+      "source_location": "L78",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_addcoins",
@@ -31308,7 +32617,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L80",
+      "source_location": "L82",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_addcrafting",
@@ -31318,7 +32627,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L84",
+      "source_location": "L86",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_addloot",
@@ -31328,7 +32637,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L88",
+      "source_location": "L90",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_addxp",
@@ -31338,7 +32647,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L92",
+      "source_location": "L94",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_buyloot",
@@ -31348,7 +32657,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L96",
+      "source_location": "L98",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_equiploot",
@@ -31358,7 +32667,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L186",
+      "source_location": "L188",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_gamereducer",
@@ -31378,7 +32687,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L44",
+      "source_location": "L45",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_initstate",
@@ -31398,7 +32707,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L100",
+      "source_location": "L102",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_loadgame",
@@ -31408,7 +32717,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L104",
+      "source_location": "L106",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_nextwave",
@@ -31418,7 +32727,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L106",
+      "source_location": "L108",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_selectcharacter",
@@ -31428,7 +32737,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L110",
+      "source_location": "L112",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_selectloot",
@@ -31438,7 +32747,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L114",
+      "source_location": "L116",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_sellloot",
@@ -31448,7 +32757,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L118",
+      "source_location": "L120",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_setbasestats",
@@ -31458,7 +32767,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L171",
+      "source_location": "L173",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_setcurrentarea",
@@ -31468,7 +32777,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L125",
+      "source_location": "L127",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_setlevel",
@@ -31478,7 +32787,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L175",
+      "source_location": "L177",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_setplayerposition",
@@ -31488,7 +32797,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L129",
+      "source_location": "L131",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_setsaveslot",
@@ -31498,7 +32807,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L133",
+      "source_location": "L135",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_setstats",
@@ -31508,7 +32817,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L140",
+      "source_location": "L142",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_switchui",
@@ -31518,7 +32827,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L183",
+      "source_location": "L185",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_syncstats",
@@ -31528,7 +32837,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L144",
+      "source_location": "L146",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_togglefilter",
@@ -31538,7 +32847,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L148",
+      "source_location": "L150",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_togglehud",
@@ -31548,7 +32857,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L152",
+      "source_location": "L154",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_toggleui",
@@ -31558,7 +32867,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L156",
+      "source_location": "L158",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_unequiploot",
@@ -31568,7 +32877,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L160",
+      "source_location": "L162",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_updatebasestats",
@@ -31578,7 +32887,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L167",
+      "source_location": "L169",
       "weight": 1.0,
       "source": "src_store_gamereducer",
       "target": "src_store_gamereducer_updatestats",
@@ -31742,6 +33051,17 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_store_gamereducer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.tsx",
       "source_location": "L3",
       "weight": 1.0,
@@ -31787,7 +33107,7 @@
       "context": "field",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L32",
+      "source_location": "L33",
       "weight": 1.0,
       "source": "src_store_gamereducer_gamestate",
       "target": "src_types_game_equipment",
@@ -31798,7 +33118,7 @@
       "context": "field",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L29",
+      "source_location": "L30",
       "weight": 1.0,
       "source": "src_store_gamereducer_gamestate",
       "target": "src_types_game_lootitem",
@@ -31809,7 +33129,7 @@
       "context": "field",
       "confidence": "EXTRACTED",
       "source_file": "src/store/gameReducer.ts",
-      "source_location": "L26",
+      "source_location": "L27",
       "weight": 1.0,
       "source": "src_store_gamereducer_gamestate",
       "target": "src_types_game_playerstats",
@@ -31882,6 +33202,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Armory.tsx",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_armory_armory",
+      "target": "src_store_gamereducer_buyloot"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31891,6 +33222,17 @@
       "source": "src_ui_components_molecules_lootlistdrag",
       "target": "src_store_gamereducer_equiploot",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/LootListDrag.tsx",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_lootlistdrag_lootlistdrag",
+      "target": "src_store_gamereducer_equiploot"
     },
     {
       "relation": "imports",
@@ -31926,6 +33268,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Save.tsx",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_save_save",
+      "target": "src_store_gamereducer_loadgame"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31937,6 +33290,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/CharacterCard.tsx",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_charactercard_charactercard",
+      "target": "src_store_gamereducer_selectcharacter"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31946,6 +33310,17 @@
       "source": "src_ui_components_templates_save",
       "target": "src_store_gamereducer_selectcharacter",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Save.tsx",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_save_save",
+      "target": "src_store_gamereducer_selectcharacter"
     },
     {
       "relation": "imports",
@@ -31959,6 +33334,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/LootList.tsx",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_lootlist_lootlist",
+      "target": "src_store_gamereducer_selectloot"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31968,6 +33354,17 @@
       "source": "src_ui_components_molecules_lootlistdrag",
       "target": "src_store_gamereducer_selectloot",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/LootListDrag.tsx",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_lootlistdrag_lootlistdrag",
+      "target": "src_store_gamereducer_selectloot"
     },
     {
       "relation": "imports",
@@ -31981,6 +33378,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Equipment.tsx",
+      "source_location": "L55",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_equipment_equipment",
+      "target": "src_store_gamereducer_sellloot"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -31990,6 +33398,17 @@
       "source": "src_ui_components_templates_save",
       "target": "src_store_gamereducer_setsaveslot",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Save.tsx",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_save_save",
+      "target": "src_store_gamereducer_setsaveslot"
     },
     {
       "relation": "imports",
@@ -32003,6 +33422,39 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/Navigation.tsx",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_navigation_navigation",
+      "target": "src_store_gamereducer_switchui"
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_store_gamereducer_switchui",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_mainmenu",
+      "target": "src_store_gamereducer_switchui"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -32014,6 +33466,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Save.tsx",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_save_save",
+      "target": "src_store_gamereducer_switchui"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -32023,6 +33486,28 @@
       "source": "src_ui_components_templates_system",
       "target": "src_store_gamereducer_switchui",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "src_ui_ui",
+      "target": "src_store_gamereducer_switchui",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "src_ui_ui_ui",
+      "target": "src_store_gamereducer_switchui"
     },
     {
       "relation": "imports",
@@ -32036,6 +33521,28 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/Armory.tsx",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_armory_armory",
+      "target": "src_store_gamereducer_togglefilter"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/ui/components/organisms/Header.tsx",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "src_ui_components_organisms_header_header",
+      "target": "src_store_gamereducer_toggleui"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -32045,6 +33552,17 @@
       "source": "src_ui_components_templates_system",
       "target": "src_store_gamereducer_toggleui",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/templates/System.tsx",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_system_system",
+      "target": "src_store_gamereducer_toggleui"
     },
     {
       "relation": "imports",
@@ -32058,6 +33576,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "src_ui_ui_ui",
+      "target": "src_store_gamereducer_toggleui"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -32069,6 +33598,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/atoms/DroppableSlot.tsx",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "src_ui_components_atoms_droppableslot_droppableslot",
+      "target": "src_store_gamereducer_unequiploot"
+    },
+    {
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
@@ -32078,6 +33618,17 @@
       "source": "src_ui_components_molecules_lootlistdrag",
       "target": "src_store_gamereducer_unequiploot",
       "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/LootListDrag.tsx",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_lootlistdrag_lootlistdrag",
+      "target": "src_store_gamereducer_unequiploot"
     },
     {
       "relation": "imports",
@@ -32270,7 +33821,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L17",
+      "source_location": "L19",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_store_index",
@@ -32435,7 +33986,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L17",
+      "source_location": "L19",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_store_index_rootstate",
@@ -33194,11 +34745,54 @@
     {
       "relation": "contains",
       "confidence": "EXTRACTED",
+      "source_file": "src/types/number-to-words.d.ts",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_types_number_to_words_d",
+      "target": "src_types_number_to_words_d_number_to_words",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
       "source_file": "src/types/scene.ts",
       "source_location": "L19",
       "weight": 1.0,
       "source": "src_types_scene",
       "target": "src_types_scene_gamescenelike",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/UI.test.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_ui_test",
+      "target": "src_ui_test_utils_renderwithproviders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/UI.test.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_ui_test",
+      "target": "src_ui_test_utils_renderwithproviders_renderwithproviders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/UI.test.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_ui_test",
+      "target": "src_ui_ui",
       "confidence_score": 1.0
     },
     {
@@ -33228,7 +34822,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L16",
+      "source_location": "L18",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_components_protons_customdraglayer",
@@ -33239,7 +34833,7 @@
       "context": "import",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L16",
+      "source_location": "L18",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_components_protons_customdraglayer_customdraglayer",
@@ -33352,7 +34946,7 @@
       "source_location": "L14",
       "weight": 1.0,
       "source": "src_ui_ui",
-      "target": "src_ui_components_templates_save",
+      "target": "src_ui_components_templates_mainmenu",
       "confidence_score": 1.0
     },
     {
@@ -33361,6 +34955,28 @@
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
       "source_location": "L15",
+      "weight": 1.0,
+      "source": "src_ui_ui",
+      "target": "src_ui_components_templates_save",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "src_ui_ui",
+      "target": "src_ui_components_templates_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L17",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_components_templates_system",
@@ -33392,7 +35008,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L37",
+      "source_location": "L42",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_ui_asmenucomponent",
@@ -33402,7 +35018,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L24",
+      "source_location": "L26",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_ui_menucomponent",
@@ -33412,7 +35028,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L26",
+      "source_location": "L28",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_ui_menuconfig",
@@ -33422,7 +35038,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L19",
+      "source_location": "L21",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_ui_menucontext",
@@ -33432,7 +35048,7 @@
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L40",
+      "source_location": "L45",
       "weight": 1.0,
       "source": "src_ui_ui",
       "target": "src_ui_ui_ui",
@@ -33454,7 +35070,7 @@
       "context": "call",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L52",
+      "source_location": "L54",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_ui_asmenucomponent",
@@ -33466,7 +35082,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L52",
+      "source_location": "L54",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_arcanum_arcanum"
@@ -33477,7 +35093,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L57",
+      "source_location": "L59",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_armory_armory"
@@ -33488,7 +35104,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L62",
+      "source_location": "L64",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_character_character"
@@ -33499,7 +35115,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L82",
+      "source_location": "L90",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_characterselect_characterselect"
@@ -33510,7 +35126,7 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L67",
+      "source_location": "L69",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_equipment_equipment"
@@ -33521,7 +35137,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L72",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "src_ui_ui_ui",
+      "target": "src_ui_components_templates_mainmenu_mainmenu"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "argument",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L74",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_save_save"
@@ -33532,7 +35159,18 @@
       "confidence": "INFERRED",
       "confidence_score": 0.8,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L86",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "src_ui_ui_ui",
+      "target": "src_ui_components_templates_settings_settings"
+    },
+    {
+      "relation": "indirect_call",
+      "context": "argument",
+      "confidence": "INFERRED",
+      "confidence_score": 0.8,
+      "source_file": "src/ui/UI.tsx",
+      "source_location": "L100",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_components_templates_system_system"
@@ -33543,7 +35181,7 @@
       "confidence": "EXTRACTED",
       "confidence_score": 1.0,
       "source_file": "src/ui/UI.tsx",
-      "source_location": "L109",
+      "source_location": "L133",
       "weight": 1.0,
       "source": "src_ui_ui_ui",
       "target": "src_ui_themes_pixelbackgroundvars"
@@ -33647,10 +35285,32 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_ui_components_atoms_button",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.tsx",
       "source_location": "L4",
       "weight": 1.0,
       "source": "src_ui_components_templates_save",
+      "target": "src_ui_components_atoms_button",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
       "target": "src_ui_components_atoms_button",
       "confidence_score": 1.0
     },
@@ -33713,10 +35373,32 @@
       "relation": "imports",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_ui_components_atoms_button_button",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.tsx",
       "source_location": "L4",
       "weight": 1.0,
       "source": "src_ui_components_templates_save",
+      "target": "src_ui_components_atoms_button_button",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
       "target": "src_ui_components_atoms_button_button",
       "confidence_score": 1.0
     },
@@ -34612,6 +36294,17 @@
       "confidence_score": 1.0
     },
     {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/components/molecules/Navigation.tsx",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "src_ui_components_molecules_navigation_navigation",
+      "target": "src_ui_themes_pixelbackgroundvars"
+    },
+    {
       "relation": "contains",
       "confidence": "EXTRACTED",
       "source_file": "src/ui/components/molecules/StatBar.tsx",
@@ -35274,6 +36967,59 @@
       "relation": "imports_from",
       "context": "import",
       "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_ui_components_templates_mainmenu",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_ui_components_templates_mainmenu_test_makesave",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_ui_test_utils_renderwithproviders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.test.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu_test",
+      "target": "src_ui_test_utils_renderwithproviders_renderwithproviders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/MainMenu.tsx",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_mainmenu",
+      "target": "src_ui_components_templates_mainmenu_mainmenu",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
       "source_file": "src/ui/components/templates/Save.test.tsx",
       "source_location": "L5",
       "weight": 1.0,
@@ -35331,6 +37077,49 @@
       "weight": 1.0,
       "source": "src_ui_components_templates_save",
       "target": "src_ui_components_templates_save_saveprops",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_test",
+      "target": "src_ui_components_templates_settings",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports_from",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_test",
+      "target": "src_ui_test_utils_renderwithproviders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "imports",
+      "context": "import",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.test.tsx",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings_test",
+      "target": "src_ui_test_utils_renderwithproviders_renderwithproviders",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/components/templates/Settings.tsx",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "src_ui_components_templates_settings",
+      "target": "src_ui_components_templates_settings_settings",
       "confidence_score": 1.0
     },
     {
@@ -35558,6 +37347,39 @@
       "weight": 1.0,
       "source": "src_ui_operations_helpers",
       "target": "src_ui_operations_helpers_statsarraytoobject",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "confidence_score": 1.0,
+      "source_file": "src/ui/operations/helpers.ts",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "src_ui_operations_helpers_statsarraytoobject",
+      "target": "src_ui_operations_helpers_statobject"
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/operations/helpers.ts",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "src_ui_operations_helpers_sortascending",
+      "target": "src_ui_operations_helpers_readkey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "src/ui/operations/helpers.ts",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "src_ui_operations_helpers_sortdescending",
+      "target": "src_ui_operations_helpers_readkey",
       "confidence_score": 1.0
     },
     {
@@ -37380,5 +39202,5 @@
     }
   ],
   "hyperedges": [],
-  "built_at_commit": "48741fb95d043cb96bfc860ea6ad2a1c864ac4d6"
+  "built_at_commit": "f4e7d7bc40f12409a2eb80dfb091161fd75a65ed"
 }

--- a/src/PhaserGame.tsx
+++ b/src/PhaserGame.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useRef } from "react";
 import { Game, AUTO, Scale } from "phaser";
+import BootScene from "@scenes/BootScene";
 import LoadScene from "@scenes/LoadScene";
 import SelectScene from "@scenes/SelectScene";
 import TownScene from "@scenes/TownScene";
@@ -48,7 +49,7 @@ const PhaserGame = () => {
                     },
                 },
             },
-            scene: [LoadScene, SelectScene, TownScene, GameScene, GameOverScene],
+            scene: [BootScene, LoadScene, SelectScene, TownScene, GameScene, GameOverScene],
             pixelArt: true,
             antialias: false,
         };

--- a/src/PhaserGame.tsx
+++ b/src/PhaserGame.tsx
@@ -5,6 +5,7 @@ import SelectScene from "@scenes/SelectScene";
 import TownScene from "@scenes/TownScene";
 import GameScene from "@scenes/GameScene";
 import GameOverScene from "@scenes/GameOverScene";
+import { readSettings } from "@services/settingsStorage";
 
 const PhaserGame = () => {
     const gameRef = useRef<Game | null>(null);
@@ -41,7 +42,10 @@ const PhaserGame = () => {
             physics: {
                 default: "arcade",
                 arcade: {
-                    debug: true,
+                    // Physics debug rendering follows the persisted setting and
+                    // applies on next launch (Enemy.showDebugInfo reads it off
+                    // sys.game.config.physics.arcade.debug). Defaults to false.
+                    debug: readSettings().debug,
                     gravity: {
                         x: 0,
                         y: 0,

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,0 +1,28 @@
+import { Scene } from "phaser";
+
+/**
+ * First scene in the boot flow. Loads ONLY the minimal assets needed to render
+ * the intro logo splash (the character sprite + the wayne-3d font image), then
+ * hands off to {@link LoadScene}, which shows that logo while the heavy asset
+ * load runs. Keeping this tiny means the splash appears almost immediately.
+ */
+export default class BootScene extends Scene {
+    constructor() {
+        super({
+            key: "BootScene",
+        });
+    }
+
+    preload(): void {
+        this.load.setPath("graphics");
+        this.load.image("wayne-3d", "fonts/wayne-3d.png");
+        this.load.spritesheet("warrior", "spritesheets/player/warrior.gif", {
+            frameWidth: 24,
+            frameHeight: 32,
+        });
+    }
+
+    create(): void {
+        this.scene.start("LoadScene");
+    }
+}

--- a/src/scenes/LoadScene.ts
+++ b/src/scenes/LoadScene.ts
@@ -292,11 +292,15 @@ export default class LoadScene extends Scene {
 
     create() {
         createAnimations(this);
-        // Hand off to the main menu (React overlay) rather than the save picker.
+        // Hand off to the main menu (React overlay) rather than the save picker:
         // toggleUi("menu") flips showUi to true and sets menu === "menu", which
-        // UI.tsx renders. The menu's own buttons drive navigation from here, so
-        // we intentionally do NOT auto-start SelectScene/GameScene.
+        // UI.tsx renders. The menu's buttons drive navigation from here.
         store.dispatch(toggleUi("menu"));
+        // SelectScene is the passive listener that starts GameScene once a
+        // character is chosen (New Game -> character select, or Load). It has no
+        // visuals, so starting it just shuts this scene down (clearing the splash
+        // logo via shutdown()) and leaves the React menu overlay on top.
+        this.scene.start("SelectScene");
     }
 
     shutdown(): void {

--- a/src/scenes/LoadScene.ts
+++ b/src/scenes/LoadScene.ts
@@ -3,29 +3,54 @@ import createAnimations from "../config/animations";
 import store from "@store";
 import { toggleUi } from "@store/gameReducer";
 import { fontConfig } from "../config/fonts";
+import createLogo from "./createLogo";
 
 export default class LoadScene extends Scene {
+    private logo?: GameObjects.Container;
+    private progressBar?: GameObjects.Graphics;
+
     constructor() {
         super({
             key: "LoadScene",
         });
     }
     preload() {
-        let progress = this.add.graphics();
+        const centerX = this.scale.width / 2;
+        const centerY = this.scale.height / 2;
+
+        // Intro splash: show the placeholder logo while the heavy asset load
+        // below runs. The character sprite + font image were already loaded by
+        // BootScene, so their textures are available synchronously here. Objects
+        // added in preload() render while the loader works through its queue.
+        this.logo = createLogo(this, { x: centerX, y: centerY - 60 });
+
+        // Progress bar beneath the logo.
+        const barWidth = Math.min(this.scale.width * 0.5, 400);
+        const barX = centerX - barWidth / 2;
+        const barY = centerY + 140;
+        const progress = this.add.graphics();
+        this.progressBar = progress;
 
         this.load.on("progress", (value: number) => {
             progress.clear();
+            progress.fillStyle(0x000000, 0.4);
+            progress.fillRect(barX - 2, barY - 2, barWidth + 4, 12);
             progress.fillStyle(0x00ff00, 1);
-            progress.fillRect(0, 0, this.scale.width * value, 4);
+            progress.fillRect(barX, barY, barWidth * value, 8);
         });
 
         this.load.on("complete", () => {
             progress.destroy();
+            this.progressBar = undefined;
         });
 
         this.load.setPath("graphics");
         // Game entities
-        this.load.image("wayne-3d", "fonts/wayne-3d.png");
+        // wayne-3d + warrior are preloaded by BootScene for the splash; guard the
+        // re-declaration so the loader doesn't warn about duplicate texture keys.
+        if (!this.textures.exists("wayne-3d")) {
+            this.load.image("wayne-3d", "fonts/wayne-3d.png");
+        }
         this.load.image("resource-frame", "images/resource-frame.png");
         this.load.spritesheet("player", "spritesheets/player/noob.gif", {
             frameWidth: 24,
@@ -47,10 +72,12 @@ export default class LoadScene extends Scene {
             frameWidth: 24,
             frameHeight: 32,
         });
-        this.load.spritesheet("warrior", "spritesheets/player/warrior.gif", {
-            frameWidth: 24,
-            frameHeight: 32,
-        });
+        if (!this.textures.exists("warrior")) {
+            this.load.spritesheet("warrior", "spritesheets/player/warrior.gif", {
+                frameWidth: 24,
+                frameHeight: 32,
+            });
+        }
         this.load.image("blank-gif", "images/blank.gif");
         this.load.spritesheet("attack-swoosh", "spritesheets/swoosh.png", {
             frameWidth: 32,
@@ -265,13 +292,23 @@ export default class LoadScene extends Scene {
 
     create() {
         createAnimations(this);
-        store.dispatch(toggleUi("save"));
-        this.scene.start("SelectScene");
+        // Hand off to the main menu (React overlay) rather than the save picker.
+        // toggleUi("menu") flips showUi to true and sets menu === "menu", which
+        // UI.tsx renders. The menu's own buttons drive navigation from here, so
+        // we intentionally do NOT auto-start SelectScene/GameScene.
+        store.dispatch(toggleUi("menu"));
     }
 
     shutdown(): void {
         // Clean up load event listeners
         this.load.off("progress");
         this.load.off("complete");
+
+        // Release the splash objects added in preload(). Phaser does not destroy
+        // GameObjects on scene SHUTDOWN, so drop them explicitly to avoid leaks.
+        this.logo?.destroy();
+        this.logo = undefined;
+        this.progressBar?.destroy();
+        this.progressBar = undefined;
     }
 }

--- a/src/scenes/createLogo.ts
+++ b/src/scenes/createLogo.ts
@@ -1,0 +1,76 @@
+import { GameObjects, Types, Scene } from "phaser";
+
+/**
+ * Options for {@link createLogo}.
+ */
+export interface LogoOptions {
+    /** Centre X of the logo in scene coordinates. */
+    x: number;
+    /** Centre Y of the logo in scene coordinates. */
+    y: number;
+    /** Overall scale multiplier applied to the whole logo. Defaults to 1. */
+    scale?: number;
+    /**
+     * Texture key of the character sprite to pair with the wordmark. Must be a
+     * spritesheet already present in the texture manager. Defaults to "warrior".
+     */
+    characterKey?: string;
+}
+
+const WORDMARK = "PHASERCRAFT";
+
+// A chunky monospace reads as "pixel-ish" without shipping a webfont, and keeps
+// this placeholder trivial to swap for real art later.
+const FONT_FAMILY = '"Courier New", "Courier", monospace';
+
+/**
+ * Builds the (placeholder) Phasercraft logo: a "PHASERCRAFT" wordmark with a
+ * thick black bold outline plus an offset duplicate behind it for a pixel
+ * 3D/drop-shadow effect, paired with a character sprite beneath it.
+ *
+ * Rendered with layered {@link GameObjects.Text} rather than the preloaded
+ * `wayne-3d` retro font: bitmap/retro fonts can't take a stroke or shadow, so
+ * styled Text is the cleaner fit for the requested black outline + pixel shadow.
+ * Everything is grouped in a single {@link GameObjects.Container} so callers can
+ * position, scale, or destroy the whole logo in one call.
+ */
+export default function createLogo(scene: Scene, options: LogoOptions): GameObjects.Container {
+    const { x, y, scale = 1, characterKey = "warrior" } = options;
+
+    const container = scene.add.container(x, y);
+
+    const baseStyle: Types.GameObjects.Text.TextStyle = {
+        fontFamily: FONT_FAMILY,
+        fontSize: "64px",
+        fontStyle: "bold",
+        color: "#f4c542",
+    };
+
+    // Offset duplicate behind the wordmark: this is the pixel shadow / 3D lift.
+    const shadow = scene.add.text(6, 6, WORDMARK, { ...baseStyle, color: "#101010" });
+    shadow.setOrigin(0.5);
+    shadow.setStroke("#000000", 8);
+    // Higher resolution keeps the stroked edges crisp; pixelArt on the game
+    // config already disables texture smoothing so it still reads as pixelly.
+    shadow.setResolution(3);
+
+    // Main wordmark on top with a thick black bold outline.
+    const wordmark = scene.add.text(0, 0, WORDMARK, baseStyle);
+    wordmark.setOrigin(0.5);
+    wordmark.setStroke("#000000", 8);
+    wordmark.setResolution(3);
+
+    container.add([shadow, wordmark]);
+
+    // Character sprite tucked beneath the wordmark (static idle frame).
+    if (scene.textures.exists(characterKey)) {
+        const sprite = scene.add.sprite(0, wordmark.height / 2 + 56, characterKey, 0);
+        sprite.setOrigin(0.5);
+        sprite.setScale(4);
+        container.add(sprite);
+    }
+
+    container.setScale(scale);
+
+    return container;
+}

--- a/src/services/settingsStorage.test.ts
+++ b/src/services/settingsStorage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+    readSettings,
+    writeSettings,
+    DEFAULT_SETTINGS,
+    SETTINGS_KEY,
+    type Settings,
+} from "./settingsStorage";
+
+// Unit tests for the typed settings/storage service (#378). All settings
+// persistence goes through here, so these pin the defaults, the JSON round-trip,
+// the corrupt-read fallback, and the partial-merge-over-defaults behaviour.
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+});
+
+describe("readSettings", () => {
+    it("returns the defaults when nothing is stored", () => {
+        expect(readSettings()).toEqual(DEFAULT_SETTINGS);
+    });
+
+    it("round-trips a written value", () => {
+        const settings: Settings = { debug: true };
+        expect(writeSettings(settings)).toBe(true);
+        expect(readSettings()).toEqual(settings);
+    });
+
+    it("falls back to defaults on corrupt JSON without throwing", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        localStorage.setItem(SETTINGS_KEY, "{ not valid json");
+
+        expect(() => readSettings()).not.toThrow();
+        expect(readSettings()).toEqual(DEFAULT_SETTINGS);
+        expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("merges a partial stored object over the defaults", () => {
+        // Store a payload missing `debug`; the default should fill it in.
+        localStorage.setItem(SETTINGS_KEY, JSON.stringify({}));
+
+        expect(readSettings()).toEqual(DEFAULT_SETTINGS);
+        expect(readSettings().debug).toBe(false);
+    });
+
+    it("returns defaults for a non-object payload", () => {
+        localStorage.setItem(SETTINGS_KEY, JSON.stringify("not-an-object"));
+
+        expect(readSettings()).toEqual(DEFAULT_SETTINGS);
+    });
+});
+
+describe("writeSettings", () => {
+    it("serializes the settings under the settings key and reports success", () => {
+        const settings: Settings = { debug: true };
+
+        expect(writeSettings(settings)).toBe(true);
+        expect(localStorage.getItem(SETTINGS_KEY)).toBe(JSON.stringify(settings));
+    });
+
+    it("returns false and warns when the write throws, without throwing", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+            throw new DOMException("quota exceeded", "QuotaExceededError");
+        });
+
+        expect(writeSettings({ debug: true })).toBe(false);
+        expect(console.warn).toHaveBeenCalled();
+    });
+});

--- a/src/services/settingsStorage.ts
+++ b/src/services/settingsStorage.ts
@@ -1,0 +1,50 @@
+// Typed, error-handled wrapper around the browser localStorage for user
+// settings. Mirrors the save/storage service (`saveStorage.ts`): the JSON
+// (de)serialization, the error handling (quota/privacy-mode writes, corrupt
+// reads, SSR where `localStorage` is undefined), and the on-disk shape all
+// live in one place so no caller touches `localStorage` directly.
+//
+// Settings live under their own key, distinct from the `slot_a/b/c` save slots.
+
+export interface Settings {
+    debug: boolean;
+}
+
+export const DEFAULT_SETTINGS: Settings = { debug: false };
+
+export const SETTINGS_KEY = "settings";
+
+// Read the persisted settings, merged over the defaults. A missing key, corrupt
+// JSON, a non-object payload, or any environment where localStorage is
+// unavailable all fall back to the defaults — never throws.
+export function readSettings(): Settings {
+    try {
+        const raw = localStorage.getItem(SETTINGS_KEY);
+        if (!raw) {
+            return { ...DEFAULT_SETTINGS };
+        }
+        const parsed = JSON.parse(raw) as unknown;
+        if (typeof parsed !== "object" || parsed === null) {
+            return { ...DEFAULT_SETTINGS };
+        }
+        // Merge stored fields over the defaults so a partial or forward-compatible
+        // payload still yields a complete, well-typed Settings object.
+        return { ...DEFAULT_SETTINGS, ...(parsed as Partial<Settings>) };
+    } catch (error) {
+        console.warn("Ignoring corrupt settings data", error);
+        return { ...DEFAULT_SETTINGS };
+    }
+}
+
+// Serialize and write the settings. Returns whether the write succeeded;
+// localStorage.setItem can throw on quota limits or in privacy mode, and a
+// failed write must not crash the caller.
+export function writeSettings(settings: Settings): boolean {
+    try {
+        localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+        return true;
+    } catch (error) {
+        console.warn("Failed to save settings", error);
+        return false;
+    }
+}

--- a/src/store/gameReducer.test.ts
+++ b/src/store/gameReducer.test.ts
@@ -10,6 +10,7 @@ import {
     setPlayerPosition,
     sellLoot,
     buyLoot,
+    switchUi,
 } from "./gameReducer";
 import type { LootItem } from "@/types/game";
 
@@ -72,6 +73,19 @@ describe("gameReducer", () => {
 
         const cleared = gameReducer(withTwo, toggleFilter(""));
         expect(cleared.filters).toEqual([]);
+    });
+
+    it("switchUi swaps the menu and records the previous one", () => {
+        const initial = gameReducer(undefined, { type: "@@INIT" });
+        const toMenu = gameReducer({ ...initial, menu: "menu" }, switchUi("settings"));
+        // The new screen is shown, and where we came from is remembered so a
+        // close button can navigate back to it.
+        expect(toMenu.menu).toBe("settings");
+        expect(toMenu.previousMenu).toBe("menu");
+
+        const back = gameReducer(toMenu, switchUi("menu"));
+        expect(back.menu).toBe("menu");
+        expect(back.previousMenu).toBe("settings");
     });
 
     it("setSaveSlot updates the save slot", () => {

--- a/src/store/gameReducer.ts
+++ b/src/store/gameReducer.ts
@@ -23,6 +23,7 @@ export interface GameState {
     showHUD: boolean;
     showUi: boolean;
     menu: string | undefined;
+    previousMenu: string | undefined;
     base_stats: PlayerStats;
     stats: PlayerStats;
     level: Level;
@@ -46,6 +47,7 @@ const initState: GameState = {
     showHUD: false,
     showUi: false,
     menu: "save",
+    previousMenu: undefined,
     base_stats: {} as PlayerStats,
     stats: {} as PlayerStats,
     level: {
@@ -281,7 +283,9 @@ export const gameReducer = createReducer(initState, (builder) => {
             }
         )
         .addCase(switchUi, (state, action: PayloadAction<{ menu: string }>) => {
-            return { ...state, ...action.payload };
+            // Record where we navigated from so a screen's close button can send
+            // the player back to the previous screen instead of closing the UI.
+            return { ...state, previousMenu: state.menu, ...action.payload };
         })
         .addCase(toggleFilter, (state, action: PayloadAction<{ key: string }>) => {
             const { key } = action.payload;

--- a/src/ui/UI.test.tsx
+++ b/src/ui/UI.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import UI from "./UI";
+
+beforeEach(() => {
+    localStorage.clear();
+    // Some screens portal dialogs into #app; provide the mount point.
+    const app = document.createElement("div");
+    app.id = "app";
+    document.body.appendChild(app);
+});
+
+afterEach(() => {
+    localStorage.clear();
+    document.getElementById("app")?.remove();
+});
+
+describe("UI overlay close/back navigation", () => {
+    it("closing Settings returns to the previous screen instead of closing the overlay", () => {
+        const { store } = renderWithProviders(<UI />, {
+            preloadedGame: { showUi: true, menu: "settings", previousMenu: "menu" },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "X" }));
+
+        const state = store.getState().game;
+        expect(state.menu).toBe("menu");
+        expect(state.showUi).toBe(true);
+    });
+
+    it("closing Settings falls back to the main menu when no previous screen was recorded", () => {
+        const { store } = renderWithProviders(<UI />, {
+            preloadedGame: { showUi: true, menu: "settings", previousMenu: undefined },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "X" }));
+
+        const state = store.getState().game;
+        expect(state.menu).toBe("menu");
+        expect(state.showUi).toBe(true);
+    });
+
+    it("closing a non-back screen still closes the whole overlay", () => {
+        const { store } = renderWithProviders(<UI />, {
+            preloadedGame: { showUi: true, menu: "load", previousMenu: "menu" },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "X" }));
+
+        expect(store.getState().game.showUi).toBe(false);
+    });
+});

--- a/src/ui/UI.test.tsx
+++ b/src/ui/UI.test.tsx
@@ -41,6 +41,18 @@ describe("UI overlay close/back navigation", () => {
         expect(state.showUi).toBe(true);
     });
 
+    it("closing the New Game (save) page returns to the main menu", () => {
+        const { store } = renderWithProviders(<UI />, {
+            preloadedGame: { showUi: true, menu: "save", previousMenu: "menu" },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "X" }));
+
+        const state = store.getState().game;
+        expect(state.menu).toBe("menu");
+        expect(state.showUi).toBe(true);
+    });
+
     it("closing a non-back screen still closes the whole overlay", () => {
         const { store } = renderWithProviders(<UI />, {
             preloadedGame: { showUi: true, menu: "load", previousMenu: "menu" },

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -11,6 +11,7 @@ import CharacterSelect from "@components/CharacterSelect";
 import Equipment from "@components/Equipment";
 import Header from "@components/Header";
 import HUD from "@components/HUD";
+import MainMenu from "@components/MainMenu";
 import Save from "@components/Save";
 import System from "@components/System";
 import CustomDragLayer from "@components/CustomDragLayer";
@@ -73,6 +74,10 @@ const UI: React.FC = () => {
             title: "Load Game",
             props: { load: true },
             close: true,
+        },
+        menu: {
+            component: asMenuComponent(MainMenu),
+            title: "Main Menu",
         },
         save: {
             component: asMenuComponent(Save),

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { pixelBackgroundVars } from "@ui/themes";
 import theme from "@ui/themes.module.css";
 import styles from "./UI.module.css";
-import { toggleUi } from "@store/gameReducer";
+import { switchUi, toggleUi } from "@store/gameReducer";
 import Arcanum from "@components/Arcanum";
 import Armory from "@components/Armory";
 import Character from "@components/Character";
@@ -31,6 +31,9 @@ interface MenuConfig {
     navigation?: boolean;
     props?: Record<string, unknown>;
     close?: boolean;
+    // When set, the close button navigates back to the previous screen instead
+    // of closing the whole overlay (e.g. Settings opened from the main menu).
+    back?: boolean;
     type?: string;
 }
 
@@ -42,12 +45,9 @@ const asMenuComponent = <P,>(component: React.ComponentType<P>): MenuComponent =
 const UI: React.FC = () => {
     const dispatch = useDispatch();
     const menu = useSelector((state: RootState) => state.game.menu);
+    const previousMenu = useSelector((state: RootState) => state.game.previousMenu);
     const showHUD = useSelector((state: RootState) => state.game.showHUD);
     const showUi = useSelector((state: RootState) => state.game.showUi);
-
-    const handleToggleUi = () => {
-        dispatch(toggleUi(menu));
-    };
 
     const config: Record<string, MenuConfig> = {
         arcanum: {
@@ -92,6 +92,7 @@ const UI: React.FC = () => {
             component: asMenuComponent(Settings),
             title: "Settings",
             close: true,
+            back: true,
         },
         system: {
             component: asMenuComponent(System),
@@ -104,13 +105,23 @@ const UI: React.FC = () => {
     const CurrentMenu = menu ? config[menu] : config.equipment;
     const isSystem = menu === "system";
 
+    // Screens flagged `back` return to the previous screen on close; everything
+    // else closes the overlay entirely (the original behavior).
+    const handleClose = () => {
+        if (CurrentMenu.back) {
+            dispatch(switchUi(previousMenu ?? "menu"));
+        } else {
+            dispatch(toggleUi(menu));
+        }
+    };
+
     return (
         <div className={styles.uiContainer}>
             {showHUD && <HUD />}
             {showUi && (
                 <div className={styles.uiMain}>
                     <div className={styles.headerContainer}>
-                        <Header config={CurrentMenu} toggleUi={handleToggleUi} />
+                        <Header config={CurrentMenu} toggleUi={handleClose} />
                     </div>
                     <div
                         id={CurrentMenu.title.toLowerCase().replace(" ", "-")}

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -83,6 +83,8 @@ const UI: React.FC = () => {
         save: {
             component: asMenuComponent(Save),
             title: "Pick a Game Save",
+            close: true,
+            back: true,
         },
         select: {
             component: asMenuComponent(CharacterSelect),

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -12,6 +12,7 @@ import Equipment from "@components/Equipment";
 import Header from "@components/Header";
 import HUD from "@components/HUD";
 import Save from "@components/Save";
+import Settings from "@components/Settings";
 import System from "@components/System";
 import CustomDragLayer from "@components/CustomDragLayer";
 import type { RootState } from "@store";
@@ -81,6 +82,11 @@ const UI: React.FC = () => {
         select: {
             component: asMenuComponent(CharacterSelect),
             title: "Character Select",
+        },
+        settings: {
+            component: asMenuComponent(Settings),
+            title: "Settings",
+            close: true,
         },
         system: {
             component: asMenuComponent(System),

--- a/src/ui/components/templates/MainMenu.module.css
+++ b/src/ui/components/templates/MainMenu.module.css
@@ -1,0 +1,42 @@
+.menu {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem 0;
+}
+
+.logo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+/* Placeholder pixel/3D wordmark; the Phaser splash owns the real canvas logo. */
+.title {
+    margin: 0;
+    font-size: 3rem;
+    letter-spacing: 0.1em;
+    color: #ffc93e;
+    text-transform: uppercase;
+    text-shadow:
+        -2px -2px 0 #000,
+        2px -2px 0 #000,
+        -2px 2px 0 #000,
+        2px 2px 0 #000,
+        4px 4px 0 rgba(0, 0, 0, 0.4);
+}
+
+.sprite {
+    image-rendering: pixelated;
+    width: 96px;
+    height: auto;
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-width: 220px;
+}

--- a/src/ui/components/templates/MainMenu.test.tsx
+++ b/src/ui/components/templates/MainMenu.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import { SAVE_SLOTS, writeSave, type SaveData } from "@services/saveStorage";
+import MainMenu from "@components/MainMenu";
+
+// Build a minimal persisted save (root state shape: `{ game: {...} }`) for a slot.
+function makeSave(overrides: Partial<SaveData["game"]> = {}): SaveData {
+    return {
+        game: {
+            character: "Warrior",
+            coins: 250,
+            wave: 7,
+            saveSlot: "slot_a",
+            ...overrides,
+        },
+    } as unknown as SaveData;
+}
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+afterEach(() => {
+    localStorage.clear();
+});
+
+describe("MainMenu template", () => {
+    it("renders the title placeholder and core actions", () => {
+        renderWithProviders(<MainMenu />);
+
+        expect(screen.getByRole("heading", { name: /phasercraft/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "New Game" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Quit" })).toBeInTheDocument();
+    });
+
+    it("enables New Game and hides Load when there are no saves", () => {
+        renderWithProviders(<MainMenu />);
+
+        expect(screen.getByRole("button", { name: "New Game" })).toBeEnabled();
+        expect(screen.queryByRole("button", { name: "Load" })).not.toBeInTheDocument();
+    });
+
+    it("disables New Game when all three slots are full", () => {
+        SAVE_SLOTS.forEach((slot) => writeSave(slot, makeSave({ saveSlot: slot })));
+
+        renderWithProviders(<MainMenu />);
+
+        expect(screen.getByRole("button", { name: "New Game" })).toBeDisabled();
+    });
+
+    it("renders Load once at least one slot is populated", () => {
+        writeSave(SAVE_SLOTS[0], makeSave({ saveSlot: SAVE_SLOTS[0] }));
+
+        renderWithProviders(<MainMenu />);
+
+        expect(screen.getByRole("button", { name: "Load" })).toBeInTheDocument();
+    });
+
+    it("New Game navigates to the save screen", () => {
+        const { store } = renderWithProviders(<MainMenu />);
+
+        fireEvent.click(screen.getByRole("button", { name: "New Game" }));
+
+        expect(store.getState().game.menu).toBe("save");
+    });
+
+    it("Load navigates to the load screen", () => {
+        writeSave(SAVE_SLOTS[0], makeSave({ saveSlot: SAVE_SLOTS[0] }));
+
+        const { store } = renderWithProviders(<MainMenu />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Load" }));
+
+        expect(store.getState().game.menu).toBe("load");
+    });
+
+    it("Settings navigates to the settings screen", () => {
+        const { store } = renderWithProviders(<MainMenu />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Settings" }));
+
+        expect(store.getState().game.menu).toBe("settings");
+    });
+});

--- a/src/ui/components/templates/MainMenu.tsx
+++ b/src/ui/components/templates/MainMenu.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useDispatch } from "react-redux";
+import { switchUi } from "@store/gameReducer";
+import Button from "@components/Button";
+import { readAllSaves, SAVE_SLOTS } from "@services/saveStorage";
+import styles from "./MainMenu.module.css";
+
+// Landing screen for the game startup flow (#382). Renders the title/logo
+// placeholder and the four top-level actions. New Game / Load availability is
+// derived from the persisted save slots so the menu reflects storage on render.
+const MainMenu: React.FC = () => {
+    const dispatch = useDispatch();
+    const saves = readAllSaves([...SAVE_SLOTS]);
+    // New Game needs a free slot; Load needs at least one populated slot.
+    const allSlotsFull = saves.every((save) => save !== null);
+    const hasSaves = saves.some((save) => save !== null);
+
+    return (
+        <div className={styles.menu}>
+            <div className={styles.logo}>
+                <h1 className={styles.title}>Phasercraft</h1>
+                <img className={styles.sprite} src="ui/player/warrior.gif" alt="" />
+            </div>
+            <div className={styles.actions}>
+                <Button
+                    text="New Game"
+                    disabled={allSlotsFull}
+                    onClick={() => dispatch(switchUi("save"))}
+                />
+                {hasSaves && <Button text="Load" onClick={() => dispatch(switchUi("load"))} />}
+                <Button text="Settings" onClick={() => dispatch(switchUi("settings"))} />
+                <Button
+                    text="Quit"
+                    onClick={() => {
+                        // Browsers only honour close() for script-opened windows, so
+                        // in a normal tab it is a no-op and the reload runs instead.
+                        window.close();
+                        window.location.reload();
+                    }}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default MainMenu;

--- a/src/ui/components/templates/Settings.test.tsx
+++ b/src/ui/components/templates/Settings.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import { readSettings, writeSettings } from "@services/settingsStorage";
+import Settings from "@components/Settings";
+
+// Template tests for the Settings screen (#379). Verify it reflects the
+// persisted debug flag on mount and that toggling persists the new value.
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+afterEach(() => {
+    localStorage.clear();
+});
+
+describe("Settings template", () => {
+    it("reflects the default (debug off) when nothing is persisted", () => {
+        renderWithProviders(<Settings />);
+
+        expect(screen.getByRole("button", { name: "Off" })).toBeInTheDocument();
+    });
+
+    it("reflects a persisted debug-on setting on mount", () => {
+        writeSettings({ debug: true });
+
+        renderWithProviders(<Settings />);
+
+        expect(screen.getByRole("button", { name: "On" })).toBeInTheDocument();
+    });
+
+    it("persists the new value and updates the control when toggled on", () => {
+        renderWithProviders(<Settings />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Off" }));
+
+        // The write happened...
+        expect(readSettings().debug).toBe(true);
+        // ...and the control reflects it.
+        expect(screen.getByRole("button", { name: "On" })).toBeInTheDocument();
+    });
+
+    it("toggles back off and persists that too", () => {
+        writeSettings({ debug: true });
+
+        renderWithProviders(<Settings />);
+
+        fireEvent.click(screen.getByRole("button", { name: "On" }));
+
+        expect(readSettings().debug).toBe(false);
+        expect(screen.getByRole("button", { name: "Off" })).toBeInTheDocument();
+    });
+});

--- a/src/ui/components/templates/Settings.tsx
+++ b/src/ui/components/templates/Settings.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import Button from "@components/Button";
+import { readSettings, writeSettings, type Settings as SettingsData } from "@services/settingsStorage";
+
+// Settings screen (#379). Reads the persisted settings on mount and lets the
+// player toggle debug mode. The debug flag applies on next launch — it feeds the
+// Phaser physics config at boot (see PhaserGame.tsx). The layout is intentionally
+// minimal (one toggle row) but structured so more rows drop in easily.
+const Settings: React.FC = () => {
+    const [settings, setSettings] = useState<SettingsData>(() => readSettings());
+
+    const toggleDebug = () => {
+        const next: SettingsData = { ...settings, debug: !settings.debug };
+        writeSettings(next);
+        setSettings(next);
+    };
+
+    return (
+        <div>
+            <div style={{ display: "flex", alignItems: "center", gap: "1em" }}>
+                <span>Debug mode</span>
+                <Button
+                    text={settings.debug ? "On" : "Off"}
+                    on={settings.debug}
+                    onClick={toggleDebug}
+                />
+            </div>
+        </div>
+    );
+};
+
+export default Settings;

--- a/src/ui/components/templates/Settings.tsx
+++ b/src/ui/components/templates/Settings.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from "react";
 import Button from "@components/Button";
-import { readSettings, writeSettings, type Settings as SettingsData } from "@services/settingsStorage";
+import {
+    readSettings,
+    writeSettings,
+    type Settings as SettingsData,
+} from "@services/settingsStorage";
 
 // Settings screen (#379). Reads the persisted settings on mount and lets the
 // player toggle debug mode. The debug flag applies on next launch — it feeds the


### PR DESCRIPTION
Implements the game startup flow from epic #377: an intro splash while assets load, a main menu, and a settings screen with a persisted debug toggle. Closes #378, #379, #380, #381, #382.

## What changed

**Boot / splash (#380, #381)**
- New `BootScene` preloads only the splash assets, then `LoadScene` shows a centered placeholder logo (pixel-3D styled text — thick black stroke + offset pixel shadow) with a character sprite and a progress bar beneath it while the heavy asset load runs.
- On load complete the flow lands on the **main menu** instead of jumping into the save picker. `SelectScene` is still started as the passive listener that launches `GameScene` once a character is chosen.
- Reusable `createLogo` helper; splash objects cleaned up in `LoadScene.shutdown()`.

**Main menu (#382)**
- New `MainMenu` React screen (registry key `menu`) using the shared `Button` atom:
  - **New Game** — disabled when all 3 save slots are full; opens the save-slot picker.
  - **Load** — hidden when there are no saves; opens the picker in load mode.
  - **Settings** — opens the settings screen.
  - **Quit** — attempts `window.close()`, falls back to reload.

**Settings (#378, #379)**
- New typed `settingsStorage` service (mirrors `saveStorage`: never throws, corrupt/SSR tolerant). `Settings = { debug: boolean }`, default off.
- The stored `debug` flag feeds `physics.arcade.debug` at boot (applies on next launch).
- New `Settings` screen with a debug on/off toggle built from the `Button` `on` state.

**Close / back navigation**
- Added a `previousMenu` to game state; `switchUi` records where you came from.
- A `back` flag on a screen makes its close button return to the previous screen instead of hiding the whole overlay. Applied to **Settings** and the **New Game (save)** page, so their `X` returns to the main menu.

## Behavior decisions (as agreed)
- Debug toggle applies on next launch. Quit tries `window.close()` then reloads. New Game greyed when all 3 slots are full. Boot now lands on the main menu.

## Test evidence
Full gate passes locally: `typecheck`, `lint`, `test` (27 files, 215 pass / 2 pre-existing skips), `build`, `format:check`. New tests cover the settings service, the Settings and MainMenu screens, `switchUi` previous-menu tracking, and the overlay close/back behavior.

## Risk notes
- Runtime-behavior changes to the startup flow (new landing screen) and physics-debug default (now off). No save-format changes.
- Verification was the test suite + code trace — no browser harness in the build environment; a manual click-through is worth doing.
- Logo is an intentional placeholder to refine later.
- `graphify` knowledge graph refreshed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2o9SjDeLf3BxREadj67fN