### PR TITLE
feat: PWA install banner (iOS + Chromium paths)

### DIFF
--- a/src/services/settingsStorage.test.ts
+++ b/src/services/settingsStorage.test.ts
@@ -22,7 +22,7 @@ describe("readSettings", () => {
     });
 
     it("round-trips a written value", () => {
-        const settings: Settings = { debug: true };
+        const settings: Settings = { debug: true, installBannerDismissed: true };
         expect(writeSettings(settings)).toBe(true);
         expect(readSettings()).toEqual(settings);
     });
@@ -37,11 +37,13 @@ describe("readSettings", () => {
     });
 
     it("merges a partial stored object over the defaults", () => {
-        // Store a payload missing `debug`; the default should fill it in.
+        // Store a payload missing `debug` and `installBannerDismissed`; the
+        // defaults should fill them in.
         localStorage.setItem(SETTINGS_KEY, JSON.stringify({}));
 
         expect(readSettings()).toEqual(DEFAULT_SETTINGS);
         expect(readSettings().debug).toBe(false);
+        expect(readSettings().installBannerDismissed).toBe(false);
     });
 
     it("returns defaults for a non-object payload", () => {
@@ -53,7 +55,7 @@ describe("readSettings", () => {
 
 describe("writeSettings", () => {
     it("serializes the settings under the settings key and reports success", () => {
-        const settings: Settings = { debug: true };
+        const settings: Settings = { debug: true, installBannerDismissed: false };
 
         expect(writeSettings(settings)).toBe(true);
         expect(localStorage.getItem(SETTINGS_KEY)).toBe(JSON.stringify(settings));
@@ -65,7 +67,7 @@ describe("writeSettings", () => {
             throw new DOMException("quota exceeded", "QuotaExceededError");
         });
 
-        expect(writeSettings({ debug: true })).toBe(false);
+        expect(writeSettings({ debug: true, installBannerDismissed: false })).toBe(false);
         expect(console.warn).toHaveBeenCalled();
     });
 });

--- a/src/services/settingsStorage.ts
+++ b/src/services/settingsStorage.ts
@@ -8,9 +8,10 @@
 
 export interface Settings {
     debug: boolean;
+    installBannerDismissed: boolean;
 }
 
-export const DEFAULT_SETTINGS: Settings = { debug: false };
+export const DEFAULT_SETTINGS: Settings = { debug: false, installBannerDismissed: false };
 
 export const SETTINGS_KEY = "settings";
 

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -11,6 +11,7 @@ import CharacterSelect from "@components/CharacterSelect";
 import Equipment from "@components/Equipment";
 import Header from "@components/Header";
 import HUD from "@components/HUD";
+import InstallBanner from "@components/InstallBanner";
 import MainMenu from "@components/MainMenu";
 import Save from "@components/Save";
 import Settings from "@components/Settings";
@@ -120,6 +121,7 @@ const UI: React.FC = () => {
     return (
         <div className={styles.uiContainer}>
             {showHUD && <HUD />}
+            <InstallBanner />
             {showUi && (
                 <div className={styles.uiMain}>
                     <div className={styles.headerContainer}>

--- a/src/ui/components/molecules/InstallBanner.module.css
+++ b/src/ui/components/molecules/InstallBanner.module.css
@@ -1,0 +1,63 @@
+.banner {
+    position: absolute;
+    /* Sit above the iOS home-indicator; falls back to a small margin. */
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 0.5rem);
+    left: 0.5rem;
+    right: 0.5rem;
+    /* Overlay chrome — the parent uiContainer disables pointer events, so
+       re-enable them on the banner itself so the buttons can be tapped. */
+    pointer-events: all;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border: 2px solid #000;
+    background-color: rgba(20, 20, 20, 0.92);
+    color: #ffc93e;
+    font-family: "VT323", monospace;
+    font-size: 1.25rem;
+    line-height: 1.2;
+    box-shadow: 0 3px 0 #000;
+}
+
+.message {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #fff;
+}
+
+.shareIcon {
+    display: inline-block;
+    vertical-align: middle;
+    fill: currentColor;
+    color: #ffc93e;
+}
+
+.actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.close {
+    box-sizing: border-box;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    line-height: 1;
+    font-family: inherit;
+    font-size: 1.25rem;
+    color: #fff;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    cursor: pointer;
+}
+
+.close:hover {
+    color: #ffc93e;
+    border-color: #ffc93e;
+}

--- a/src/ui/components/molecules/InstallBanner.test.tsx
+++ b/src/ui/components/molecules/InstallBanner.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { fireEvent, screen, act } from "@testing-library/react";
+
+import InstallBanner from "./InstallBanner";
+import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import { readSettings, writeSettings } from "@services/settingsStorage";
+
+// The banner sits at the top of the render tree and decides visibility from
+// three signals: `beforeinstallprompt` (Chromium), iOS Safari UA, and the
+// persisted `installBannerDismissed` setting. These tests cover each branch.
+
+const IOS_UA =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const DESKTOP_UA =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36";
+
+// jsdom does not implement matchMedia. Provide a controllable stub the tests
+// can flip to model an installed / standalone PWA.
+function stubMatchMedia(matches: boolean) {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+        matches,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+}
+
+function setUserAgent(ua: string) {
+    Object.defineProperty(window.navigator, "userAgent", {
+        value: ua,
+        configurable: true,
+    });
+}
+
+function fireBeforeInstallPrompt(prompt = vi.fn().mockResolvedValue(undefined)) {
+    // Chromium's event exposes `prompt()` and a `userChoice` promise. jsdom's
+    // Event constructor won't take arbitrary properties, so decorate after
+    // construction.
+    const event = new Event("beforeinstallprompt") as Event & {
+        prompt: () => Promise<void>;
+        userChoice: Promise<{ outcome: string }>;
+        platforms: string[];
+    };
+    event.prompt = prompt;
+    event.userChoice = Promise.resolve({ outcome: "dismissed" });
+    event.platforms = ["web"];
+    act(() => {
+        window.dispatchEvent(event);
+    });
+    return { event, prompt };
+}
+
+beforeEach(() => {
+    stubMatchMedia(false);
+    setUserAgent(DESKTOP_UA);
+    localStorage.clear();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+});
+
+describe("InstallBanner", () => {
+    it("stays hidden on a plain desktop browser with no install event", () => {
+        renderWithProviders(<InstallBanner />);
+        expect(screen.queryByTestId("install-banner")).toBeNull();
+    });
+
+    it("shows the iOS variant on iOS Safari when not standalone", () => {
+        setUserAgent(IOS_UA);
+        renderWithProviders(<InstallBanner />);
+        const banner = screen.getByTestId("install-banner");
+        expect(banner).toBeInTheDocument();
+        expect(banner.textContent).toMatch(/Add to Home Screen/i);
+        // The native "Install" button must NOT appear on iOS — there is no
+        // programmatic install path.
+        expect(screen.queryByRole("button", { name: /^Install$/i })).toBeNull();
+    });
+
+    it("shows the native variant when beforeinstallprompt fires", async () => {
+        renderWithProviders(<InstallBanner />);
+        const { prompt } = fireBeforeInstallPrompt();
+
+        const installButton = await screen.findByRole("button", { name: /^Install$/i });
+        expect(installButton).toBeInTheDocument();
+
+        await act(async () => {
+            fireEvent.click(installButton);
+            // let the async prompt/userChoice chain resolve
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        expect(prompt).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides itself once dismissed and persists the choice", () => {
+        setUserAgent(IOS_UA);
+        renderWithProviders(<InstallBanner />);
+        expect(screen.getByTestId("install-banner")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /Dismiss install banner/i }));
+
+        expect(screen.queryByTestId("install-banner")).toBeNull();
+        expect(readSettings().installBannerDismissed).toBe(true);
+    });
+
+    it("stays hidden on iOS Safari when the user already dismissed it", () => {
+        setUserAgent(IOS_UA);
+        writeSettings({ debug: false, installBannerDismissed: true });
+        renderWithProviders(<InstallBanner />);
+        expect(screen.queryByTestId("install-banner")).toBeNull();
+    });
+
+    it("stays hidden when running as an installed standalone PWA", () => {
+        setUserAgent(IOS_UA);
+        stubMatchMedia(true); // display-mode: standalone
+        renderWithProviders(<InstallBanner />);
+        expect(screen.queryByTestId("install-banner")).toBeNull();
+    });
+});

--- a/src/ui/components/molecules/InstallBanner.tsx
+++ b/src/ui/components/molecules/InstallBanner.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+
+import Button from "@components/Button";
+import { useInstallPrompt } from "@ui/hooks/useInstallPrompt";
+import styles from "./InstallBanner.module.css";
+
+// Discovery UI for the PWA install flow. Chromium can show its own "Install"
+// UI via `beforeinstallprompt`; iOS Safari never prompts, so we point users at
+// the Share sheet manually. See `useInstallPrompt` for the detection logic.
+
+// iOS Share glyph, drawn to match Apple's icon closely enough that users
+// recognise it. Inline so the banner has no external asset dependency.
+const ShareIcon: React.FC<{ size?: number }> = ({ size = 20 }) => (
+    <svg
+        className={styles.shareIcon}
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+        focusable="false"
+    >
+        <path d="M12 3.5l-4 4 1.4 1.4L11 7.3V15h2V7.3l1.6 1.6L16 7.5l-4-4z" fill="currentColor" />
+        <path d="M5 10v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V10h-2v9H7v-9H5z" fill="currentColor" />
+    </svg>
+);
+
+const InstallBanner: React.FC = () => {
+    const { shown, mode, install, dismiss } = useInstallPrompt();
+
+    if (!shown || !mode) return null;
+
+    return (
+        <div
+            className={styles.banner}
+            role="region"
+            aria-label="Install Phasercraft"
+            data-testid="install-banner"
+        >
+            {mode === "ios" ? (
+                <span className={styles.message}>
+                    Install Phasercraft: tap <ShareIcon /> then <b>Add to Home Screen</b>
+                </span>
+            ) : (
+                <span className={styles.message}>Install Phasercraft for full-screen play</span>
+            )}
+            <span className={styles.actions}>
+                {mode === "native" && (
+                    <Button
+                        text="Install"
+                        size={1}
+                        onClick={() => {
+                            void install();
+                        }}
+                    />
+                )}
+                <button
+                    type="button"
+                    className={styles.close}
+                    aria-label="Dismiss install banner"
+                    onClick={dismiss}
+                >
+                    ×
+                </button>
+            </span>
+        </div>
+    );
+};
+
+export default InstallBanner;

--- a/src/ui/components/templates/Settings.test.tsx
+++ b/src/ui/components/templates/Settings.test.tsx
@@ -23,7 +23,7 @@ describe("Settings template", () => {
     });
 
     it("reflects a persisted debug-on setting on mount", () => {
-        writeSettings({ debug: true });
+        writeSettings({ debug: true, installBannerDismissed: false });
 
         renderWithProviders(<Settings />);
 
@@ -42,7 +42,7 @@ describe("Settings template", () => {
     });
 
     it("toggles back off and persists that too", () => {
-        writeSettings({ debug: true });
+        writeSettings({ debug: true, installBannerDismissed: false });
 
         renderWithProviders(<Settings />);
 

--- a/src/ui/hooks/useInstallPrompt.ts
+++ b/src/ui/hooks/useInstallPrompt.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { readSettings, writeSettings } from "@services/settingsStorage";
+
+// PWA install-prompt discovery. Two paths, one hook:
+//   - "native": Chromium fires `beforeinstallprompt` before showing its own
+//     mini-infobar; we capture the event, suppress the default UI, and expose
+//     `install()` so our own banner can call `prompt()` at the right moment.
+//   - "ios":    iOS Safari does not implement `beforeinstallprompt` at all —
+//     the ONLY install path is manual (Share sheet → Add to Home Screen). We
+//     surface an in-app hint pointing users at that flow.
+// The banner is hidden entirely once the user dismisses it (persisted via the
+// typed settings service) or once the app is already running standalone.
+
+// The event type ships in `lib.dom` on modern TS versions but is not always in
+// scope here; declare the minimal shape we rely on.
+interface BeforeInstallPromptEvent extends Event {
+    readonly platforms: readonly string[];
+    prompt(): Promise<void>;
+    readonly userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+export type InstallPromptMode = "native" | "ios";
+
+export interface UseInstallPrompt {
+    shown: boolean;
+    mode: InstallPromptMode | null;
+    install: () => Promise<void>;
+    dismiss: () => void;
+}
+
+function isIosSafari(): boolean {
+    if (typeof navigator === "undefined") return false;
+    const ua = navigator.userAgent;
+    // Exclude non-Safari iOS browsers (CriOS = Chrome, FxiOS = Firefox,
+    // EdgiOS = Edge) and desktop Chromium/Firefox/Edge — those either don't
+    // honor Add-to-Home-Screen for arbitrary sites, or aren't iOS at all.
+    if (/CriOS|FxiOS|EdgiOS|OPiOS|Chrome\/|Firefox\/|Edg\//.test(ua)) return false;
+    // Match iPhone/iPad/iPod (and the "iPad on macOS" desktop-mode case where
+    // Safari reports Mac + touch support).
+    return (
+        /iPad|iPhone|iPod/.test(ua) ||
+        (ua.includes("Mac") && typeof document !== "undefined" && "ontouchend" in document)
+    );
+}
+
+function isStandalone(): boolean {
+    if (typeof window === "undefined") return false;
+    if (window.matchMedia?.("(display-mode: standalone)").matches) return true;
+    // iOS exposes `navigator.standalone` (not in the TS lib type).
+    const nav = navigator as Navigator & { standalone?: boolean };
+    return nav.standalone === true;
+}
+
+export function useInstallPrompt(): UseInstallPrompt {
+    const [nativeEvent, setNativeEvent] = useState<BeforeInstallPromptEvent | null>(null);
+    const [dismissed, setDismissed] = useState<boolean>(
+        () => readSettings().installBannerDismissed
+    );
+    const [installed, setInstalled] = useState<boolean>(() => isStandalone());
+    const [iosEligible] = useState<boolean>(() => isIosSafari());
+
+    useEffect(() => {
+        const onBeforeInstall = (event: Event) => {
+            event.preventDefault();
+            setNativeEvent(event as BeforeInstallPromptEvent);
+        };
+        const onInstalled = () => {
+            setNativeEvent(null);
+            setInstalled(true);
+        };
+        window.addEventListener("beforeinstallprompt", onBeforeInstall);
+        window.addEventListener("appinstalled", onInstalled);
+        return () => {
+            window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+            window.removeEventListener("appinstalled", onInstalled);
+        };
+    }, []);
+
+    const install = useCallback(async () => {
+        if (!nativeEvent) return;
+        await nativeEvent.prompt();
+        // Whatever the user chose, we've done our job — clear the saved event
+        // (it can only be used once) and hide the banner. Accepted installs
+        // will also fire `appinstalled` below.
+        try {
+            await nativeEvent.userChoice;
+        } catch {
+            // ignore — Chromium resolves this, but we don't want a stray
+            // rejection to bubble out of the banner click handler.
+        }
+        setNativeEvent(null);
+    }, [nativeEvent]);
+
+    const dismiss = useCallback(() => {
+        const current = readSettings();
+        writeSettings({ ...current, installBannerDismissed: true });
+        setDismissed(true);
+    }, []);
+
+    const mode: InstallPromptMode | null = nativeEvent
+        ? "native"
+        : iosEligible && !installed
+          ? "ios"
+          : null;
+
+    const shown = mode !== null && !dismissed && !installed;
+
+    return { shown, mode, install, dismiss };
+}


### PR DESCRIPTION
Closes #394

## Summary
- Adds an install-discovery banner rendered above the game canvas, driven by a new `useInstallPrompt` hook.
- Chromium path: capture `beforeinstallprompt`, suppress the native mini-infobar, expose a first-party **Install** button that calls `prompt()`.
- iOS Safari path: detects iOS Safari (excluding CriOS/FxiOS/EdgiOS/Chrome/Firefox/Edge), points users at the Share sheet **Add to Home Screen** flow — no programmatic install exists on iOS.
- Banner auto-hides when the app is already running as a standalone PWA (`display-mode: standalone` or `navigator.standalone`) or after the user dismisses it. Dismissal persists through the typed settings service (new `installBannerDismissed` field, defaults to `false`).

## Risk notes
- Pure additive UI overlay; does not change gameplay, save format, or public API.
- Only new persisted-settings field is `installBannerDismissed: boolean` (defaulted, merged over defaults by `readSettings`), so existing saves continue to load unchanged.
- New listeners (`beforeinstallprompt`, `appinstalled`) are registered and released in the same `useEffect` cleanup.
- iOS/Safari UA sniffing is a best-effort discovery signal — worst case, the banner doesn't appear; nothing else in the app depends on it.

## Test plan
- [x] `npm run typecheck` — no new errors (pre-existing `dist/types/*` Next-scaffolding errors on `main` are unchanged).
- [x] `npm run lint` — clean.
- [x] `npm test` — 278 pass / 2 skipped; new `InstallBanner.test.tsx` covers desktop-hidden, iOS-shown, Chromium-shown, dismissal-persisted, standalone-hidden, and dismissed-hidden.
- [x] `npm run build` — succeeds; workbox SW still generated.
- [ ] Manual: verify banner does not obstruct HUD/menu interaction on mobile and dismisses cleanly on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)