### PR TITLE
feat: batch-sell UX for component stacks — stepper + Sell 1 / Sell N / Sell All (#402)

### DIFF
--- a/src/ui/components/molecules/ComponentSellControls.module.css
+++ b/src/ui/components/molecules/ComponentSellControls.module.css
@@ -1,0 +1,30 @@
+.controls {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.stepper {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.qty {
+    min-width: 2ch;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+.value {
+    min-width: 3ch;
+    color: #ffc93e;
+    font-variant-numeric: tabular-nums;
+}
+
+.empty {
+    margin: 0;
+    opacity: 0.7;
+    font-style: italic;
+}

--- a/src/ui/components/molecules/ComponentSellControls.test.tsx
+++ b/src/ui/components/molecules/ComponentSellControls.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import ComponentSellControls from "./ComponentSellControls";
+import { COMPONENT_DEFS, type ComponentStack } from "@/types/game";
+
+const cloth: ComponentStack = { id: "c1", type: "cloth", quantity: 5 };
+
+describe("ComponentSellControls", () => {
+    it("prompts to select a component when nothing is selected", () => {
+        renderWithProviders(<ComponentSellControls stack={null} />);
+        expect(screen.getByText("Select a component to sell.")).toBeInTheDocument();
+        expect(screen.queryByTestId("sell-controls")).not.toBeInTheDocument();
+    });
+
+    it("shows the running value for the stepped quantity", () => {
+        renderWithProviders(<ComponentSellControls stack={cloth} />, {
+            preloadedGame: { components: [cloth] },
+        });
+        expect(screen.getByTestId("sell-qty")).toHaveTextContent("1");
+        expect(screen.getByTestId("sell-value")).toHaveTextContent(
+            `+${COMPONENT_DEFS.cloth.sellValue}`
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "+" }));
+        fireEvent.click(screen.getByRole("button", { name: "+" }));
+        expect(screen.getByTestId("sell-qty")).toHaveTextContent("3");
+        expect(screen.getByTestId("sell-value")).toHaveTextContent(
+            `+${COMPONENT_DEFS.cloth.sellValue * 3}`
+        );
+    });
+
+    it("clamps the stepper to [1, stack.quantity]", () => {
+        const single: ComponentStack = { id: "s", type: "scrap", quantity: 1 };
+        renderWithProviders(<ComponentSellControls stack={single} />, {
+            preloadedGame: { components: [single] },
+        });
+        expect(screen.getByRole("button", { name: "-" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "+" })).toBeDisabled();
+    });
+
+    it("Sell 1 sells a single unit", () => {
+        const { store } = renderWithProviders(<ComponentSellControls stack={cloth} />, {
+            preloadedGame: { components: [cloth] },
+        });
+        const coinsBefore = store.getState().game.coins;
+
+        fireEvent.click(screen.getByRole("button", { name: "Sell 1" }));
+
+        const state = store.getState().game;
+        expect(state.components[0].quantity).toBe(4);
+        expect(state.coins).toBe(coinsBefore + COMPONENT_DEFS.cloth.sellValue);
+    });
+
+    it("Sell N sells the stepped quantity", () => {
+        const { store } = renderWithProviders(<ComponentSellControls stack={cloth} />, {
+            preloadedGame: { components: [cloth] },
+        });
+        const coinsBefore = store.getState().game.coins;
+
+        fireEvent.click(screen.getByRole("button", { name: "+" })); // qty 2
+        fireEvent.click(screen.getByRole("button", { name: "Sell 2" }));
+
+        const state = store.getState().game;
+        expect(state.components[0].quantity).toBe(3);
+        expect(state.coins).toBe(coinsBefore + COMPONENT_DEFS.cloth.sellValue * 2);
+    });
+
+    it("Sell All removes the whole stack", () => {
+        const { store } = renderWithProviders(<ComponentSellControls stack={cloth} />, {
+            preloadedGame: { components: [cloth] },
+        });
+        const coinsBefore = store.getState().game.coins;
+
+        fireEvent.click(screen.getByRole("button", { name: "Sell All" }));
+
+        const state = store.getState().game;
+        expect(state.components).toEqual([]);
+        expect(state.coins).toBe(coinsBefore + COMPONENT_DEFS.cloth.sellValue * cloth.quantity);
+    });
+});

--- a/src/ui/components/molecules/ComponentSellControls.tsx
+++ b/src/ui/components/molecules/ComponentSellControls.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { useDispatch } from "react-redux";
+import Button from "@components/Button";
+import { sellComponent, sellComponentStack } from "@store/gameReducer";
+import { COMPONENT_DEFS } from "@/types/game";
+import type { ComponentStack } from "@/types/game";
+import styles from "./ComponentSellControls.module.css";
+
+interface ComponentSellControlsProps {
+    // The currently selected stack, or null when nothing is selected / the
+    // selection was just sold out.
+    stack: ComponentStack | null;
+}
+
+// Sell controls for the selected component stack: a quantity stepper (clamped to
+// the stack) plus Sell 1 / Sell N / Sell All. Prices come from COMPONENT_DEFS.
+const ComponentSellControls: React.FC<ComponentSellControlsProps> = ({ stack }) => {
+    const dispatch = useDispatch();
+    // Raw requested quantity; clamped on read to [1, stack.quantity] so a shrinking
+    // stack or a change of selection can never leave it out of range.
+    const [rawQty, setRawQty] = useState(1);
+
+    if (!stack) {
+        return (
+            <div className={styles.controls}>
+                <p className={styles.empty}>Select a component to sell.</p>
+            </div>
+        );
+    }
+
+    const def = COMPONENT_DEFS[stack.type];
+    const qty = Math.min(Math.max(1, rawQty), stack.quantity);
+
+    return (
+        <div className={styles.controls} data-testid="sell-controls">
+            <div className={styles.stepper}>
+                <Button text="-" size={1} disabled={qty <= 1} onClick={() => setRawQty(qty - 1)} />
+                <span className={styles.qty} data-testid="sell-qty">
+                    {qty}
+                </span>
+                <Button
+                    text="+"
+                    size={1}
+                    disabled={qty >= stack.quantity}
+                    onClick={() => setRawQty(qty + 1)}
+                />
+            </div>
+            <span className={styles.value} data-testid="sell-value">
+                +{def.sellValue * qty}
+            </span>
+            <Button text="Sell 1" size={1} onClick={() => dispatch(sellComponent(stack.id, 1))} />
+            {qty > 1 && (
+                // Only shown when it differs from "Sell 1"; at qty 1 it would duplicate it.
+                <Button
+                    text={`Sell ${qty}`}
+                    size={1}
+                    onClick={() => dispatch(sellComponent(stack.id, qty))}
+                />
+            )}
+            <Button
+                text="Sell All"
+                size={1}
+                onClick={() => dispatch(sellComponentStack(stack.id))}
+            />
+        </div>
+    );
+};
+
+export default ComponentSellControls;

--- a/src/ui/components/molecules/ComponentsPanel.module.css
+++ b/src/ui/components/molecules/ComponentsPanel.module.css
@@ -1,0 +1,11 @@
+.panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    gap: 0.5rem;
+}
+
+.gridArea {
+    flex: 1;
+    min-height: 0;
+}

--- a/src/ui/components/molecules/ComponentsPanel.test.tsx
+++ b/src/ui/components/molecules/ComponentsPanel.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent, screen, within } from "@testing-library/react";
+import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import ComponentsPanel from "./ComponentsPanel";
+import { COMPONENT_DEFS, type ComponentStack } from "@/types/game";
+
+const scrap: ComponentStack = { id: "a", type: "scrap", quantity: 3 };
+
+describe("ComponentsPanel", () => {
+    it("shows the empty sell prompt until a stack is selected", () => {
+        renderWithProviders(<ComponentsPanel />, { preloadedGame: { components: [scrap] } });
+        expect(screen.getByText("Select a component to sell.")).toBeInTheDocument();
+        expect(screen.queryByTestId("sell-controls")).not.toBeInTheDocument();
+    });
+
+    it("reveals sell controls for a selected stack", () => {
+        renderWithProviders(<ComponentsPanel />, { preloadedGame: { components: [scrap] } });
+
+        const grid = screen.getByTestId("components-grid");
+        fireEvent.click(within(grid).getAllByRole("button")[0]);
+
+        expect(screen.getByTestId("sell-controls")).toBeInTheDocument();
+        expect(screen.getByTestId("sell-value")).toHaveTextContent(
+            `+${COMPONENT_DEFS.scrap.sellValue}`
+        );
+    });
+
+    it("sells the selected stack and falls back to the empty prompt when it is gone", () => {
+        const { store } = renderWithProviders(<ComponentsPanel />, {
+            preloadedGame: { components: [scrap] },
+        });
+
+        const grid = screen.getByTestId("components-grid");
+        fireEvent.click(within(grid).getAllByRole("button")[0]);
+        fireEvent.click(screen.getByRole("button", { name: "Sell All" }));
+
+        // Stack is gone from the store and the controls reset to the prompt.
+        expect(store.getState().game.components).toEqual([]);
+        expect(screen.getByText("Select a component to sell.")).toBeInTheDocument();
+        expect(screen.queryByTestId("sell-controls")).not.toBeInTheDocument();
+    });
+});

--- a/src/ui/components/molecules/ComponentsPanel.tsx
+++ b/src/ui/components/molecules/ComponentsPanel.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
+import ComponentsGrid from "./ComponentsGrid";
+import ComponentSellControls from "./ComponentSellControls";
+import type { RootState } from "@store";
+import styles from "./ComponentsPanel.module.css";
+
+// The Components tab: the stacked grid plus its batch-sell controls. Owns the
+// selected-stack id and resolves it against the live store, so a stack that gets
+// sold out (and removed) resolves to null and the controls fall back to their
+// empty state without stale references.
+const ComponentsPanel: React.FC = () => {
+    const components = useSelector((state: RootState) => state.game.components);
+    const [selectedId, setSelectedId] = useState<string | null>(null);
+
+    const selected = components.find((stack) => stack.id === selectedId) ?? null;
+
+    return (
+        <div className={styles.panel}>
+            <div className={styles.gridArea}>
+                <ComponentsGrid selectedId={selectedId} onSelectStack={setSelectedId} />
+            </div>
+            <ComponentSellControls stack={selected} />
+        </div>
+    );
+};
+
+export default ComponentsPanel;

--- a/src/ui/components/molecules/InventoryTabs.tsx
+++ b/src/ui/components/molecules/InventoryTabs.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Button from "@components/Button";
 import GearGrid from "./GearGrid";
-import ComponentsGrid from "./ComponentsGrid";
+import ComponentsPanel from "./ComponentsPanel";
 import styles from "./InventoryTabs.module.css";
 
 type Tab = "gear" | "components";
@@ -22,7 +22,9 @@ const InventoryTabs: React.FC = () => {
                     onClick={() => setTab("components")}
                 />
             </div>
-            <div className={styles.panel}>{tab === "gear" ? <GearGrid /> : <ComponentsGrid />}</div>
+            <div className={styles.panel}>
+                {tab === "gear" ? <GearGrid /> : <ComponentsPanel />}
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
Stage 5 of the **inventory system overhaul epic (#397)**, building on the merged tabs + grid (#407). Closes **#402**.

Makes the Components tab interactive: a selected stack can now be sold in configurable batches.

## What

- **`ComponentSellControls`** — the sell UI for the selected stack:
  - **Quantity stepper** (`- / value / +`) **clamped to `[1, stack.quantity]`**, clamp-on-read so a shrinking stack or a change of selection can never leave the quantity out of range.
  - **Running value** display (`sellValue × qty`, from `COMPONENT_DEFS`).
  - **Sell 1** → `sellComponent(id, 1)`, **Sell N** → `sellComponent(id, qty)`, **Sell All** → `sellComponentStack(id)`. The "Sell N" button is hidden at `qty === 1` where it would duplicate "Sell 1".
  - Empty state ("Select a component to sell.") when nothing is selected.
- **`ComponentsPanel`** — lifts the selected-stack id out of the grid and **resolves it against the live store**, so a stack sold to zero (and removed by the reducer) resolves to `null` and the controls fall back to the empty prompt with no stale reference. Composes `ComponentsGrid` (controlled selection) + `ComponentSellControls`.
- `InventoryTabs`' Components tab now renders `ComponentsPanel`.

## Design decisions (mechanics — documented per CLAUDE.md)

- Selection is **owned by `ComponentsPanel`** and resolved live from `state.components`, rather than stored as an object — this is what makes the post-sell cleanup automatic (sold-out stack → `null`).
- The stepper uses the same **clamp-on-read** approach as `usePagination`, avoiding set-state-in-effect.
- No reducer changes — the `sellComponent` / `sellComponentStack` actions shipped in the foundation (#405); this PR only wires UI to them.

## Test evidence

Locally: **typecheck ✓ · lint ✓ · format:check ✓ · test ✓ (324 passed, 2 pre-existing skips; +9 new) · build ✓**. New tests: `ComponentSellControls` (empty prompt, running value, stepper clamp, Sell 1 / Sell N / Sell All crediting coins + updating the stack) and `ComponentsPanel` (prompt → select → sell → prompt).

## Scope / follow-ups

Final stage: **Stage 6** (#403) — integration polish, migration/E2E coverage, docs, and the deferred `graphify` graph refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YaWsi4JRKnmErPTfeNnQoa)_