### PR TITLE
fix(ui): repair the save game flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,12 @@
     </head>
     <body>
         <div id="root"></div>
+        <!--
+            Dedicated portal node for modal dialogs. Kept a sibling of #root so a
+            dialog's stacking context is independent of the menu container it
+            overlays. Dialog.tsx recreates this node if it is missing.
+        -->
+        <div id="dialog-root"></div>
         <script type="module" src="/src/main.tsx"></script>
     </body>
 </html>

--- a/src/ui/components/organisms/Dialog.test.tsx
+++ b/src/ui/components/organisms/Dialog.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import fs from "node:fs";
+import path from "node:path";
+import Dialog, { DIALOG_ROOT_ID } from "@components/Dialog";
+
+// Regression cover for a silent-failure bug: Dialog used to portal into a `#app`
+// node that no page ever rendered, and returned null when it was missing. Every
+// confirm dialog in the app (save, delete-save) therefore rendered nothing at
+// all, with no error. These tests deliberately start from a document with *no*
+// mount point — the previous implementation passes only if a test fabricates the
+// node for it, which is exactly how the bug slipped through.
+
+afterEach(() => {
+    cleanup();
+    document.getElementById(DIALOG_ROOT_ID)?.remove();
+});
+
+describe("Dialog", () => {
+    it("renders its children when no portal root exists yet", () => {
+        expect(document.getElementById(DIALOG_ROOT_ID)).toBeNull();
+
+        render(<Dialog>confirm me</Dialog>);
+
+        expect(screen.getByText("confirm me")).toBeInTheDocument();
+    });
+
+    it("creates the portal root on demand and renders into it", () => {
+        render(<Dialog>confirm me</Dialog>);
+
+        const root = document.getElementById(DIALOG_ROOT_ID);
+        expect(root).not.toBeNull();
+        expect(root).toContainElement(screen.getByText("confirm me"));
+    });
+
+    it("reuses an existing portal root rather than creating a second one", () => {
+        const existing = document.createElement("div");
+        existing.id = DIALOG_ROOT_ID;
+        document.body.appendChild(existing);
+
+        render(<Dialog>confirm me</Dialog>);
+
+        expect(document.querySelectorAll(`#${DIALOG_ROOT_ID}`)).toHaveLength(1);
+        expect(existing).toContainElement(screen.getByText("confirm me"));
+    });
+
+    it("keeps concurrently mounted dialogs in their own containers", () => {
+        render(
+            <>
+                <Dialog>first</Dialog>
+                <Dialog>second</Dialog>
+            </>
+        );
+
+        const root = document.getElementById(DIALOG_ROOT_ID)!;
+        expect(root.children).toHaveLength(2);
+        expect(screen.getByText("first")).toBeInTheDocument();
+        expect(screen.getByText("second")).toBeInTheDocument();
+    });
+
+    it("removes its container from the portal root on unmount", () => {
+        const { unmount } = render(<Dialog>confirm me</Dialog>);
+        const root = document.getElementById(DIALOG_ROOT_ID)!;
+        expect(root.children).toHaveLength(1);
+
+        unmount();
+
+        expect(root.children).toHaveLength(0);
+        expect(screen.queryByText("confirm me")).not.toBeInTheDocument();
+    });
+
+    // Dialog self-heals a missing root, but the node belongs in the served HTML
+    // so its stacking context is a declared sibling of #root rather than an
+    // append-on-first-dialog accident. Pin that contract: this assertion is what
+    // catches the id drifting apart again.
+    it("has its portal root declared in index.html", () => {
+        const html = fs.readFileSync(path.resolve(__dirname, "../../../../index.html"), "utf8");
+
+        expect(html).toContain(`id="${DIALOG_ROOT_ID}"`);
+    });
+});

--- a/src/ui/components/organisms/Dialog.tsx
+++ b/src/ui/components/organisms/Dialog.tsx
@@ -5,20 +5,37 @@ interface DialogProps {
     children: React.ReactNode;
 }
 
+export const DIALOG_ROOT_ID = "dialog-root";
+
+// Resolve the dedicated portal node declared in index.html, recreating it if it
+// is absent. The previous implementation targeted a `#app` node that no page
+// ever rendered and returned null when it was missing, which silently swallowed
+// every confirm dialog in the app — the save and delete-save flows both became
+// no-ops with no error. A dialog must never fail to render because its mount
+// point is missing, so we self-heal instead of bailing out.
+function getDialogRoot(): HTMLElement {
+    const existing = document.getElementById(DIALOG_ROOT_ID);
+    if (existing) return existing;
+
+    const created = document.createElement("div");
+    created.id = DIALOG_ROOT_ID;
+    document.body.appendChild(created);
+    return created;
+}
+
 const Dialog: React.FC<DialogProps> = ({ children }) => {
+    // One container per Dialog instance, so concurrently mounted dialogs don't
+    // clobber each other inside the shared portal root.
     const el = useMemo(() => document.createElement("div"), []);
 
     useEffect(() => {
-        const root = document.querySelector("#app");
-        if (!root) return;
-        root.appendChild(el);
+        getDialogRoot().appendChild(el);
         return () => {
-            root.removeChild(el);
+            el.remove();
         };
     }, [el]);
 
-    const root = document.querySelector("#app");
-    return root ? createPortal(children, el) : null;
+    return createPortal(children, el);
 };
 
 export default Dialog;

--- a/src/ui/components/templates/Save.test.tsx
+++ b/src/ui/components/templates/Save.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { fireEvent, screen, within } from "@testing-library/react";
 import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
 import { SAVE_SLOTS, writeSave, type SaveData } from "@services/saveStorage";
+import { DIALOG_ROOT_ID } from "@components/Dialog";
 import Save from "@components/Save";
 
 // Build a minimal persisted save (root state shape: `{ game: {...} }`) for a slot.
@@ -19,15 +20,14 @@ function makeSave(overrides: Partial<SaveData["game"]> = {}): SaveData {
 
 beforeEach(() => {
     localStorage.clear();
-    // Dialog portals into #app; provide the mount point for the delete flow.
-    const app = document.createElement("div");
-    app.id = "app";
-    document.body.appendChild(app);
 });
 
 afterEach(() => {
     localStorage.clear();
-    document.getElementById("app")?.remove();
+    // Dialog owns its portal root; drop it so each test starts from a bare
+    // document. Never create it here — hand-building the mount point is what
+    // masked the dialogs failing to render in the real app.
+    document.getElementById(DIALOG_ROOT_ID)?.remove();
 });
 
 describe("Save template (save slots)", () => {
@@ -97,9 +97,10 @@ describe("Save template (save slots)", () => {
 
         fireEvent.click(deleteButtons[0]);
 
-        // The confirmation dialog appears (portaled into #app).
-        const app = document.getElementById("app") as HTMLElement;
-        const dialog = within(app);
+        // The confirmation dialog appears in the portal root Dialog owns.
+        const dialogRoot = document.getElementById(DIALOG_ROOT_ID) as HTMLElement;
+        expect(dialogRoot).not.toBeNull();
+        const dialog = within(dialogRoot);
         expect(dialog.getByText(/Are you sure/i)).toBeInTheDocument();
 
         fireEvent.click(dialog.getByRole("button", { name: "Confirm" }));
@@ -114,8 +115,8 @@ describe("Save template (save slots)", () => {
         renderWithProviders(<Save />);
 
         fireEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
-        const app = document.getElementById("app") as HTMLElement;
-        fireEvent.click(within(app).getByRole("button", { name: "Cancel" }));
+        const dialogRoot = document.getElementById(DIALOG_ROOT_ID) as HTMLElement;
+        fireEvent.click(within(dialogRoot).getByRole("button", { name: "Cancel" }));
 
         expect(localStorage.getItem(SAVE_SLOTS[0])).not.toBeNull();
     });

--- a/src/ui/components/templates/System.test.tsx
+++ b/src/ui/components/templates/System.test.tsx
@@ -1,8 +1,10 @@
+import React from "react";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { fireEvent, screen } from "@testing-library/react";
 import { renderWithProviders } from "@ui/test-utils/renderWithProviders";
+import { DIALOG_ROOT_ID } from "@components/Dialog";
+import { readSave } from "@services/saveStorage";
 import System from "@components/System";
-import type { RootState } from "@store";
 
 beforeEach(() => {
     localStorage.clear();
@@ -10,11 +12,12 @@ beforeEach(() => {
 
 afterEach(() => {
     localStorage.clear();
+    document.getElementById(DIALOG_ROOT_ID)?.remove();
 });
 
 describe("System template", () => {
     it("renders the in-game system actions", () => {
-        renderWithProviders(<System state={{} as RootState} />);
+        renderWithProviders(<System />);
 
         expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
         expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
@@ -22,7 +25,7 @@ describe("System template", () => {
     });
 
     it("Settings navigates to the settings screen and records the return path", () => {
-        const { store } = renderWithProviders(<System state={{} as RootState} />, {
+        const { store } = renderWithProviders(<System />, {
             preloadedGame: { menu: "system" },
         });
 
@@ -32,5 +35,117 @@ describe("System template", () => {
         // Settings can now be reached mid-run; closing it returns to the system menu.
         expect(menu).toBe("settings");
         expect(previousMenu).toBe("system");
+    });
+
+    // The save flow had no coverage at all, which is how two separate bugs shipped:
+    // the confirm dialog never rendered (missing portal root), and the state to
+    // persist arrived as `undefined` because the menu registry never passed the
+    // prop it required — so every save wrote the literal string "undefined".
+    describe("save flow", () => {
+        it("Save opens the overwrite confirmation", () => {
+            renderWithProviders(<System />, { preloadedGame: { saveSlot: "slot_a" } });
+
+            expect(
+                screen.queryByText(/overwrite your existing save game/i)
+            ).not.toBeInTheDocument();
+
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+            expect(screen.getByText(/overwrite your existing save game/i)).toBeInTheDocument();
+            expect(screen.getByRole("button", { name: "Yes" })).toBeInTheDocument();
+        });
+
+        it("confirming writes the live store state to the selected slot", () => {
+            const { store } = renderWithProviders(<System />, {
+                preloadedGame: { saveSlot: "slot_a", coins: 250, wave: 7, character: "Mage" },
+            });
+
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+            // Confirming also dispatches toggleUi, so snapshot the state that is
+            // being persisted before it changes underneath the assertion.
+            const persisted = JSON.stringify(store.getState());
+            fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+            expect(localStorage.getItem("slot_a")).toBe(persisted);
+        });
+
+        it("writes a save the loader can actually read back", () => {
+            renderWithProviders(<System />, {
+                preloadedGame: { saveSlot: "slot_a", coins: 250, wave: 7, character: "Mage" },
+            });
+
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+            fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+            // The round trip is the property that actually matters: a slot the
+            // Save menu reads as empty is indistinguishable from never saving.
+            const loaded = readSave("slot_a");
+            expect(loaded).not.toBeNull();
+            expect(loaded!.game.character).toBe("Mage");
+            expect(loaded!.game.coins).toBe(250);
+            expect(loaded!.game.wave).toBe(7);
+        });
+
+        it("never persists a non-object payload", () => {
+            renderWithProviders(<System />, { preloadedGame: { saveSlot: "slot_a" } });
+
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+            fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+            const raw = localStorage.getItem("slot_a");
+            // `JSON.stringify(undefined)` returns undefined, which setItem coerces
+            // to the string "undefined" and writeSave reports as a success.
+            expect(raw).not.toBe("undefined");
+            expect(() => JSON.parse(raw!)).not.toThrow();
+            expect(JSON.parse(raw!)).toMatchObject({ game: expect.any(Object) });
+        });
+
+        it("persists state changes made after mount", () => {
+            const { store } = renderWithProviders(<System />, {
+                preloadedGame: { saveSlot: "slot_a", wave: 1 },
+            });
+
+            store.dispatch({ type: "NEXT_WAVE" });
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+            fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+            expect(readSave("slot_a")!.game.wave).toBe(2);
+        });
+
+        it("Cancel closes the dialog without writing", () => {
+            renderWithProviders(<System />, { preloadedGame: { saveSlot: "slot_a" } });
+
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+            fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+            expect(
+                screen.queryByText(/overwrite your existing save game/i)
+            ).not.toBeInTheDocument();
+            expect(localStorage.getItem("slot_a")).toBeNull();
+        });
+
+        it("does not write when no save slot has been selected", () => {
+            renderWithProviders(<System />, { preloadedGame: { saveSlot: undefined } });
+
+            fireEvent.click(screen.getByRole("button", { name: "Save" }));
+            fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+            expect(localStorage).toHaveLength(0);
+        });
+    });
+
+    // The menu registry (UI.tsx) widens every template to a prop-erased component
+    // type before rendering it, which deletes the type error a missing required
+    // prop would otherwise raise. Render System the same way the registry does:
+    // with no props at all, which must still produce a valid save.
+    it("saves correctly when rendered the way the menu registry renders it", () => {
+        const AsMenuComponent = System as React.ComponentType<Record<string, unknown>>;
+
+        renderWithProviders(<AsMenuComponent />, { preloadedGame: { saveSlot: "slot_a" } });
+
+        fireEvent.click(screen.getByRole("button", { name: "Save" }));
+        fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+        expect(readSave("slot_a")).not.toBeNull();
     });
 });

--- a/src/ui/components/templates/System.tsx
+++ b/src/ui/components/templates/System.tsx
@@ -7,12 +7,14 @@ import theme from "@ui/themes.module.css";
 import { writeSave } from "@services/saveStorage";
 import type { RootState } from "@store";
 
-interface SystemProps {
-    state: RootState;
-}
-
-const System: React.FC<SystemProps> = ({ state }) => {
+const System: React.FC = () => {
     const dispatch = useDispatch();
+    // Saves persist the whole root state, so read it from the store rather than
+    // taking it as a prop: the menu registry in UI.tsx renders templates through
+    // a prop-erased component type, so a required prop it forgot to pass arrived
+    // as `undefined` with no type error, and every save wrote the string
+    // "undefined" into the slot.
+    const state = useSelector((state: RootState) => state);
     const saveSlot = useSelector((state: RootState) => state.game.saveSlot);
     const [showDialog, setShowDialog] = useState(false);
 


### PR DESCRIPTION
Saving a game silently did nothing, and no save was ever offered to load. Two independent bugs, both reproduced in the browser before and after the fix.

## Scope

Fix the broken save/load flow reported by the maintainer, and close the test gap that let it ship. No gameplay, balance, or save-format changes.

## Bug 1 — the confirm dialog never rendered

`Dialog` portalled into `#app`, a node no page renders — `index.html` mounts the app at `#root`. `Dialog` returned `null` when the node was missing, so **every** confirm dialog in the app (save, delete-save) rendered nothing at all, with no error and no console warning. Clicking **Save** did nothing.

Verified live: `document.getElementById("app")` → `null`; injecting a `div#app` by hand made the dialog appear immediately.

Fixed with a dedicated `#dialog-root` node declared in `index.html`, kept a sibling of `#root` so a dialog's stacking context is independent of the menu container it overlays. `Dialog` recreates the node if it is absent rather than rendering nothing — a dialog must never silently fail to render because its mount point is missing.

## Bug 2 — every save wrote the string `"undefined"`

`System` required a `state: RootState` prop, but the `UI.tsx` menu registry renders it with no props. The registry widens every template to `ComponentType<Record<string, unknown>>` via `asMenuComponent`, which deleted the type error, so `state` arrived `undefined`:

- `JSON.stringify(undefined)` returns `undefined` (the value)
- `setItem` coerces that to the **string** `"undefined"`
- `writeSave` returns `true` — a completely successful-looking failed save
- `readSave` then throws on `JSON.parse("undefined")`, is caught, returns `null`
- the slot reads as empty, so no Load is ever offered

Verified live: after saving, `localStorage.slot_a` was the 9-character string `"undefined"`.

`System` now reads the root state from the store via `useSelector`, consistent with how it already selects `saveSlot`.

The HUD keyboard save path (`HUD.ts:151`) was unaffected — it already passed `store.getState()` correctly, which is why that path worked.

## Why the tests missed it

Both bugs lived in wiring (`index.html` ↔ `Dialog`, `UI.tsx` ↔ `System`), and nothing tested those seams. Worse, the tests actively hid them:

- `Save.test.tsx` **hand-built the missing `#app` node in `beforeEach`**, with a comment documenting the behaviour without treating it as a bug.
- `System.test.tsx` passed `state={{} as RootState}` — supplying the exact prop the app fails to supply, with a cast that silenced the type error.
- No test asserted that clicking Save wrote anything at all.

Every unit passed in isolation; the integration did not exist. Three layers of defensive error handling (`writeSave` returning `true`, `readSave` swallowing the parse error, `Dialog` returning `null`) turned a hard failure into silence.

## Test evidence

New `Dialog.test.tsx` (6 tests) deliberately starts from a document with **no** mount point — the old implementation only passes if a test fabricates the node for it. Includes an assertion that the portal root is declared in `index.html`, pinning the contract that drifted.

New `System` save-flow tests (7) cover: the dialog opening, the persisted payload matching store state, a **round trip through `readSave`**, an explicit "never persists a non-object payload" guard, post-mount state changes, Cancel not writing, and no-slot-selected not writing. Plus a test that renders `System` through the same prop-erased type the registry uses.

`Save.test.tsx` no longer fabricates the mount point.

**Mutation-checked — these tests fail against the old code:**

| Reverted fix | Result |
|---|---|
| Dialog → old `#app` behaviour | 15 tests fail |
| System → required `state` prop | 5 tests fail |

Full gate on Node 24: `typecheck`, `lint`, `test` (330 passed, 2 skipped), `build`, `format:check` all pass.

**Manual verification** (dev server, real browser): New Game → Slot 1 → Warrior → Save → **Yes** writes 1067 bytes of valid JSON (`character: "Warrior"`, `saveSlot: "slot_a"`); reload shows a **Load** button; the Load Game screen renders the slot with its sprite and metadata; loading returns to the run.

## Risk notes

- `index.html` gains a DOM node.
- `System`'s prop contract changes. No external callers — the registry passed nothing, which was the bug.
- **No save-format change.** The persisted shape is unchanged. Pre-existing `"undefined"` slots were already read as empty, so they remain harmless and are overwritten on the next save.
- Not addressed (flagged for a follow-up): `writeSave` still returns `true` for a payload that serializes to `undefined`. A type guard there would turn this class of bug into a loud failure rather than a silent one — worth doing, but it changes a service's contract so it belongs in its own PR.
- The committed knowledge graph was **not** refreshed: `graphify` requires Python ≥3.10 and this machine has 3.9.6 with no `uv`/`pipx`, so `graphify update` could not run. The structural delta is small (one new test file, one changed component signature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)