### PR TITLE
refactor: optimize title screen layout and styling

### DIFF
--- a/src/ui/UI.module.css
+++ b/src/ui/UI.module.css
@@ -19,3 +19,14 @@
 .headerContainer {
     margin-bottom: 14px;
 }
+
+/* Title screen: no framed panel — fill the overlay and center the splash so the
+   logo and actions sit in the middle of the full-screen background. */
+.titleScreen {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    overflow-y: auto;
+}

--- a/src/ui/UI.tsx
+++ b/src/ui/UI.tsx
@@ -107,6 +107,24 @@ const UI: React.FC = () => {
     // Use specified menu other use equipment as default
     const CurrentMenu = menu ? config[menu] : config.equipment;
     const isSystem = menu === "system";
+    // The title screen (#382) is not a menu: it drops the header chrome and the
+    // framed pixel-background panel, filling the overlay as a plain full-screen
+    // splash so the logo and actions stay centered and visible on mobile.
+    const isTitle = menu === "menu";
+
+    const containerClassName = isTitle
+        ? styles.titleScreen
+        : isSystem
+          ? undefined
+          : theme.pixelBackground;
+    const containerStyle: React.CSSProperties | undefined = isTitle
+        ? undefined
+        : {
+              ...(isSystem ? {} : pixelBackgroundVars()),
+              margin: "0 auto",
+              padding: "calc(1em + 6px) 1em 1em",
+              width: isSystem ? "200px" : "100%",
+          };
 
     // Screens flagged `back` return to the previous screen on close; everything
     // else closes the overlay entirely (the original behavior).
@@ -124,21 +142,18 @@ const UI: React.FC = () => {
             <InstallBanner />
             {showUi && (
                 <div className={styles.uiMain}>
-                    <div className={styles.headerContainer}>
-                        <Header config={CurrentMenu} toggleUi={handleClose} />
-                    </div>
+                    {!isTitle && (
+                        <div className={styles.headerContainer}>
+                            <Header config={CurrentMenu} toggleUi={handleClose} />
+                        </div>
+                    )}
                     <div
                         id={CurrentMenu.title.toLowerCase().replace(" ", "-")}
                         data-testid="menu-container"
-                        className={isSystem ? undefined : theme.pixelBackground}
-                        style={{
-                            ...(isSystem ? {} : pixelBackgroundVars()),
-                            margin: "0 auto",
-                            padding: "calc(1em + 6px) 1em 1em",
-                            width: isSystem ? "200px" : "100%",
-                        }}
+                        className={containerClassName}
+                        style={containerStyle}
                     >
-                        <CustomDragLayer />
+                        {!isTitle && <CustomDragLayer />}
                         <MenuContext.Provider value={menu || "equipment"}>
                             <CurrentMenu.component {...CurrentMenu.props} />
                         </MenuContext.Provider>

--- a/src/ui/components/templates/MainMenu.module.css
+++ b/src/ui/components/templates/MainMenu.module.css
@@ -3,7 +3,6 @@
     flex-direction: column;
     align-items: center;
     gap: 1.5rem;
-    padding: 1rem 0;
 }
 
 .logo {
@@ -16,7 +15,7 @@
 /* Placeholder pixel/3D wordmark; the Phaser splash owns the real canvas logo. */
 .title {
     margin: 0;
-    font-size: 3rem;
+    font-size: clamp(2rem, 10vw, 3rem);
     letter-spacing: 0.1em;
     color: #ffc93e;
     text-transform: uppercase;
@@ -30,7 +29,7 @@
 
 .sprite {
     image-rendering: pixelated;
-    width: 96px;
+    width: 64px;
     height: auto;
 }
 


### PR DESCRIPTION
## Scope
The main menu (title screen) renders inside the same framed pixel-background panel and "Main Menu" header as the other menus. On mobile the header plus panel padding push the title/logo down so the menu buttons scroll off the screen. This PR reworks **only the title screen's presentation** so it reads as a simple full-screen splash (no menu chrome) with the buttons visible, by:
- dropping the header and framed panel for the title screen (`menu === "menu"`) and rendering it as a centered full-screen layout,
- shrinking the character sprite so all menu buttons fit,
- keeping the wordmark responsive.

Constraints: no navigation/state/save-format/API behavior changes; the `data-testid="menu-container"` element and its derived id are retained for the e2e smoke tests. Purely layout/CSS scoped to the title screen.

## Summary
Refactors the UI container logic to treat the title screen (main menu) as a special full-screen splash layout, distinct from the standard framed menu panels. This improves mobile visibility by centering the logo and actions on a full-screen background without the header chrome and pixel-background frame.

## Changes
- **UI.tsx**: Extracted container styling logic into `containerClassName` and `containerStyle` variables to conditionally apply different layouts based on menu type:
  - Title screen (`menu === "menu"`): uses new `titleScreen` class for full-screen centered flex layout
  - System menu: minimal styling (200px width)
  - Other menus: standard pixel-background frame with padding
  - Conditionally hide `Header` and `CustomDragLayer` components on title screen

- **UI.module.css**: Added `.titleScreen` class with flex centering, full width, and vertical scroll support to fill the overlay and center content

- **MainMenu.module.css**: Adjusted title screen styling for better mobile responsiveness:
  - Removed fixed padding from the menu container
  - Changed title font size to `clamp(2rem, 10vw, 3rem)` for fluid scaling across viewport sizes
  - Reduced sprite width from 96px to 64px for better mobile proportions

## Implementation notes
- The title screen is identified by `menu === "menu"` (the default menu key)
- Container styling is now centralized and easier to extend for future layout variants
- Responsive font sizing uses CSS `clamp()` to scale smoothly between mobile and desktop
- No behavior changes; purely layout and styling improvements for mobile UX

## Test evidence
`typecheck`, `lint`, `test` (356 passed / 2 pre-existing skips), `build`, and `format:check` all pass locally.

https://claude.ai/code/session_01MJKesTe4e8CRUQ6mrwXovD