### PR TITLE
feat(enemy): enlarge tap area for easier selection

### DIFF
--- a/src/entities/Enemy/Enemy.ts
+++ b/src/entities/Enemy/Enemy.ts
@@ -145,8 +145,9 @@ class Enemy extends GameObjects.Container {
         this.setAlpha(0);
         this.scene.tweens.add({ targets: this, alpha: 1, ease: "Power1", duration: 500 });
 
-        // Odd bug where the hit box is offset by 14px. not sure why but compensating here
-        this.setInteractive(new Geom.Circle(14, 14, 15), Geom.Circle.Contains);
+        // Odd bug where the hit box is offset by 14px. not sure why but compensating here.
+        // Radius bumped from 15 to 18 (~20% larger) to make enemies easier to tap/select.
+        this.setInteractive(new Geom.Circle(14, 14, 18), Geom.Circle.Contains);
         this.bringToTop(this.monster);
 
         this.scene.events.on("pointerdown:game", this.deselect, this);


### PR DESCRIPTION
## Scope

Increase the interactive tap/hit area for enemies by ~20% so they are easier to select. Only the enemy hit-region geometry should change; no changes to visuals, balance, save format, or other entities.

## Summary

Increases the interactive hit area for enemies so they are easier to tap/select.

- Bumps the `setInteractive` hit-circle radius in `Enemy.ts` from **15 → 18** (~20% larger), centered on the existing `(14, 14)` offset that compensates for the known 14px hitbox offset.
- The visual selection ring (`drawSelected`) uses separate geometry and is intentionally left unchanged — this only grows the tappable region, not the highlight.

## Interpretation note

"About 20% bigger" was applied to the hit-circle **radius** (a linear 20% bump), which is the most intuitive reading of "make the target 20% bigger" and best serves the goal of easier selection. If you'd prefer a 20% increase in *area* instead (radius ≈ 16.4), that's a one-line tweak — let me know.

## Risk / behavior notes

This is a runtime behavior change (enemy selection feel), requested by the maintainer. No balance, save-format, or public-API impact. The larger radius could make it marginally easier to select an enemy near an overlapping neighbor; still well within the enemy sprite bounds.

## Test evidence

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (42 files, 382 passed / 2 skipped)
- `npm run build` ✅

No existing tests reference the hit-area geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1iSdeuwVfoKEJHWe1yLpY