### PR TITLE
feat(spells): channelled spells ignore ranged attack interrupts

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -261,16 +261,16 @@ button extracts to `SpellButton` (stays Phaser-side); new `TargetReticle`,
 
 ### Decisions update (2026-07-01) — Spell rework
 
-| Topic        | Decision                                                                                                                                                                      |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Cast flow    | Auto-target, tap-driven: button tap casts at the selected enemy (walking into range first) or primes; next tap on a valid target commits, floor/invalid taps clear the prime. |
-| Ground       | Two-step tap-to-place with a radius reticle; any world tap (including on an enemy) is a placement.                                                                            |
-| Out of range | Queue the cast: walk toward the target, cast on arrival; another action cancels the queue.                                                                                    |
-| Auto attack  | Keep tap-to-select chase-and-swing (no auto-acquire); it pauses during wind-ups/channels.                                                                                     |
-| Interrupts   | Moving, taking actual damage (`player:hit`, so shield absorbs protect casts), or casting another spell. Wind-ups charge resource on completion only.                          |
-| Projectiles  | Homing (always hit; damage on impact): Fireball, Frostbolt, Multishot arrows, Ranger basic attack.                                                                            |
-| HUD          | Spell buttons stay in Phaser (`SpellButton`), not the React overlay.                                                                                                          |
-| Balance      | Initial numbers (castRange 200–300, Heal 1s wind-up, SiphonSoul/Invocation as 5s channels) are proposals to tune in review.                                                   |
+| Topic        | Decision                                                                                                                                                                                                                                                                   |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Cast flow    | Auto-target, tap-driven: button tap casts at the selected enemy (walking into range first) or primes; next tap on a valid target commits, floor/invalid taps clear the prime.                                                                                              |
+| Ground       | Two-step tap-to-place with a radius reticle; any world tap (including on an enemy) is a placement.                                                                                                                                                                         |
+| Out of range | Queue the cast: walk toward the target, cast on arrival; another action cancels the queue.                                                                                                                                                                                 |
+| Auto attack  | Keep tap-to-select chase-and-swing (no auto-acquire); it pauses during wind-ups/channels.                                                                                                                                                                                  |
+| Interrupts   | Moving, taking actual damage (`player:hit`, so shield absorbs protect casts), or casting another spell. Channels are the exception: they ignore ranged attacks (only melee/other hits, movement, or another cast break them). Wind-ups charge resource on completion only. |
+| Projectiles  | Homing (always hit; damage on impact): Fireball, Frostbolt, Multishot arrows, Ranger basic attack.                                                                                                                                                                         |
+| HUD          | Spell buttons stay in Phaser (`SpellButton`), not the React overlay.                                                                                                                                                                                                       |
+| Balance      | Initial numbers (castRange 200–300, Heal 1s wind-up, SiphonSoul/Invocation as 5s channels) are proposals to tune in review.                                                                                                                                                |
 
 ## Deferred / backlog
 

--- a/src/entities/Enemy/Enemy.ts
+++ b/src/entities/Enemy/Enemy.ts
@@ -7,6 +7,7 @@ import Crafting from "@entities/Loot/Crafting";
 import Gem from "@entities/Loot/Gem";
 import Banes from "@entities/UI/Banes";
 import type {
+    CombatType,
     EnemyOptions,
     EnemyAttributes,
     LootTable,
@@ -48,6 +49,7 @@ class Enemy extends GameObjects.Container {
     public monster: Monster;
     public key: string;
     public target: TargetType;
+    public combat_type: CombatType;
     public attack_ready: boolean;
     public attack_radius: number;
     public aggro_radius: number;
@@ -101,6 +103,9 @@ class Enemy extends GameObjects.Container {
 
         this.key = config.key;
         this.target = config.target;
+        // The declared enemy archetype (Melee/Ranged/Healer) lower-cased; the
+        // caster reads it off an attack to know whether it can break a channel.
+        this.combat_type = config.type.toLowerCase() as CombatType;
         this.attack_ready = true;
         this.attack_radius = config.attributes.range || 40;
         this.aggro_radius = config.aggro_radius || 250;
@@ -420,7 +425,7 @@ class Enemy extends GameObjects.Container {
     attack(): void {
         if (this.states.attack === "primed") {
             this.states.attack = "recovering";
-            this.scene.events.emit("enemy:attack", this.stats.damage);
+            this.scene.events.emit("enemy:attack", this.stats.damage, this.combat_type);
             this.attack_ready = false;
             this.swing = this.scene.time.addEvent({
                 delay: this.stats.attack_speed * 1000,

--- a/src/entities/Player/Player.ts
+++ b/src/entities/Player/Player.ts
@@ -17,7 +17,7 @@ import mapStateToData from "@helpers/mapStateToData";
 import CombatText from "../UI/CombatText";
 import CastBar from "@entities/UI/CastBar";
 import Projectile from "@entities/Weapons/Projectile";
-import type { PlayerOptions, PlayerStats, SpellProjectileConfig } from "@/types/game";
+import type { CombatType, PlayerOptions, PlayerStats, SpellProjectileConfig } from "@/types/game";
 import type Enemy from "@entities/Enemy/Enemy";
 import type { GameSceneLike } from "@/types/scene";
 import * as converter from "number-to-words";
@@ -316,12 +316,14 @@ class Player extends GameObjects.Container {
         this.alive = false;
     }
 
-    hit(power: number): void {
+    hit(power: number, attackType?: CombatType): void {
         const damage = Math.ceil(power * (100 / (100 + (this.stats.defence || 0))));
         this.scene.events.emit("player:attacked", this);
         const hasShield = "hasShield" in this.shield && this.shield.hasShield();
         const pool = hasShield ? this.shield : this.health;
-        if (!hasShield) this.scene.events.emit("player:hit", this);
+        // Forward the attacker's combat type so the caster can decide whether
+        // the hit interrupts (channelled spells ignore ranged attacks).
+        if (!hasShield) this.scene.events.emit("player:hit", this, attackType);
         pool.adjustValue(-damage);
     }
 

--- a/src/entities/Spells/CastingController.test.ts
+++ b/src/entities/Spells/CastingController.test.ts
@@ -55,7 +55,7 @@ interface ControllerUnderTest {
     onPlayerTap(): void;
     onEnemyTap(enemy: { x: number; y: number; alive: boolean }): void;
     interruptForMove(): void;
-    onHit(): void;
+    onHit(player?: unknown, attackType?: string): void;
     notifyDisabled(spell: CastableSpell): void;
     cancelAll(): void;
     update(): void;
@@ -492,6 +492,53 @@ describe("CastingController channels", () => {
         fireTimer(controller);
 
         expect(spell.interruptChannel).not.toHaveBeenCalled();
+        expect(controller.getState()).toBe("idle");
+    });
+
+    it("a ranged hit does not break a channel", () => {
+        const controller = makeController();
+        const spell = makeSpell("enemy", { castRange: 100, channelDuration: 5 });
+        controller.scene.selected = { x: 10, y: 0, alive: true };
+        controller.request(spell);
+
+        controller.onHit(controller.player, "ranged");
+
+        expect(spell.interruptChannel).not.toHaveBeenCalled();
+        expect(controller.getState()).toBe("casting");
+    });
+
+    it("a melee hit still breaks a channel", () => {
+        const controller = makeController();
+        const spell = makeSpell("enemy", { castRange: 100, channelDuration: 5 });
+        controller.scene.selected = { x: 10, y: 0, alive: true };
+        controller.request(spell);
+
+        controller.onHit(controller.player, "melee");
+
+        expect(spell.interruptChannel).toHaveBeenCalled();
+        expect(controller.getState()).toBe("idle");
+    });
+
+    it("a hit with no combat type still breaks a channel", () => {
+        const controller = makeController();
+        const spell = makeSpell("enemy", { castRange: 100, channelDuration: 5 });
+        controller.scene.selected = { x: 10, y: 0, alive: true };
+        controller.request(spell);
+
+        controller.onHit();
+
+        expect(spell.interruptChannel).toHaveBeenCalled();
+        expect(controller.getState()).toBe("idle");
+    });
+
+    it("a ranged hit still breaks a wind-up", () => {
+        const controller = makeController();
+        const spell = makeSpell("self", { castTime: 1 });
+        controller.request(spell);
+
+        controller.onHit(controller.player, "ranged");
+
+        expect(spell.castSpell).not.toHaveBeenCalled();
         expect(controller.getState()).toBe("idle");
     });
 });

--- a/src/entities/Spells/CastingController.ts
+++ b/src/entities/Spells/CastingController.ts
@@ -1,6 +1,6 @@
 import { Math as PhaserMath, Scenes } from "phaser";
 import TargetReticle from "@entities/UI/TargetReticle";
-import type { TargetKind, TargetType } from "@/types/game";
+import type { CombatType, TargetKind, TargetType } from "@/types/game";
 import type { GameSceneLike } from "@/types/scene";
 
 // The subset of Spell the controller drives. Kept narrow so tests can fake a
@@ -91,7 +91,8 @@ class CastingController {
         this.scene.events.on("pointerdown:enemy", this.onEnemyTap, this);
         this.scene.events.on("pointerdown:player", this.onPlayerTap, this);
         this.scene.events.on("keypress:esc", this.cancelAll, this);
-        // Actual damage (shield absorbs don't emit player:hit) breaks casts.
+        // Actual damage (shield absorbs don't emit player:hit) breaks casts;
+        // the hit carries its combat type so channels can ignore ranged ones.
         this.scene.events.on("player:hit", this.onHit, this);
         // The controller is not a GameObject, so SHUTDOWN is its only
         // lifecycle signal; Player.cleanup() also calls cleanup() (idempotent).
@@ -218,7 +219,10 @@ class CastingController {
     }
 
     // Taking actual damage breaks wind-ups and channels (approach is fine).
-    onHit(): void {
+    // Channelled spells are the exception: they shrug off ranged attacks, so
+    // only movement, another cast, or a melee/other hit break them.
+    onHit(_player?: unknown, attackType?: CombatType): void {
+        if (this.casting?.phase === "channel" && attackType === "ranged") return;
         this.interruptCast();
     }
 


### PR DESCRIPTION
## Summary

Channelled spells (e.g. SiphonSoul, Invocation) previously broke on **any** actual damage, sharing the exact interrupt path with wind-ups via `player:hit`. This makes channels shrug off **ranged** attacks — they now only break on melee/other damage, movement, or another cast. Wind-ups are unchanged (still interrupted by everything).

## Changes

- **`Enemy`** — stores its declared archetype as `combat_type` (`config.type` lower-cased) and emits it alongside damage on `enemy:attack`.
- **`Player.hit`** — accepts the attacker's combat type and forwards it on the `player:hit` event.
- **`CastingController.onHit`** — now receives the attack's combat type; skips the interrupt **only** when an active **channel** is hit by a **ranged** attack. Wind-ups and all other interrupt triggers (movement, another cast, melee/unknown hits) are untouched.
- **`docs/ROADMAP.md`** — Interrupts decision row updated to note the channel/ranged exception.

## Scope

This is a runtime-behavior change requested directly by the maintainer ("Channelled spells should not be interruptable by ranged attacks"). Design choices left to mechanics: the combat type is threaded through the existing `enemy:attack` → `player:hit` event chain rather than introducing new events; enemies expose their type via a lower-cased `combat_type` field derived from the already-required `config.type`.

## Test evidence

- Added `CastingController` channel tests: ranged hit does **not** break a channel; melee hit **does**; a hit with no combat type **does** (safe default); a ranged hit **still** breaks a wind-up.
- `npm run typecheck` · `npm run lint` · `npm test` (386 passed, 2 skipped) · `npm run build` · `npm run format:check` — all pass locally.

## Risk notes

Low. The event payload gains an optional trailing argument; the only `player:hit` listener is `CastingController`, and the only `enemy:attack` listener is `Player.hit` — both updated. Missing/undefined combat type falls back to the previous always-interrupt behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHsPWUeKzLXXsU4uAMCkVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHsPWUeKzLXXsU4uAMCkVJ)_