### PR TITLE
fix(spells): stop Invocation's channel breaking itself; tie channel length to effect duration

### DIFF
--- a/src/entities/Spells/CastingController.test.ts
+++ b/src/entities/Spells/CastingController.test.ts
@@ -574,6 +574,35 @@ describe("CastingController.notifyDisabled", () => {
 
         expect(controller.getState()).toBe("primed");
     });
+
+    // Regression: a channelled self-buff (Invocation) goes on cooldown the moment
+    // it casts, and the next resource-regen `change` disables its button and
+    // notifies the controller. That must NOT break the already-committed channel
+    // — otherwise the channel starts and immediately stops.
+    it("does not interrupt a committed channel when its spell is disabled", () => {
+        const controller = makeController();
+        const spell = makeSpell("self", { channelDuration: 5 });
+        controller.request(spell);
+        expect(controller.getState()).toBe("casting");
+
+        controller.notifyDisabled(spell);
+
+        expect(spell.interruptChannel).not.toHaveBeenCalled();
+        expect(controller.getState()).toBe("casting");
+    });
+
+    // A wind-up has not committed its cost yet, so a spell going unavailable
+    // during it is still cancelled.
+    it("still interrupts a wind-up when its spell is disabled", () => {
+        const controller = makeController();
+        const spell = makeSpell("self", { castTime: 1 });
+        controller.request(spell);
+        expect(controller.getState()).toBe("casting");
+
+        controller.notifyDisabled(spell);
+
+        expect(controller.getState()).toBe("idle");
+    });
 });
 
 describe("CastingController.cleanup", () => {

--- a/src/entities/Spells/CastingController.ts
+++ b/src/entities/Spells/CastingController.ts
@@ -229,7 +229,16 @@ class CastingController {
     notifyDisabled(spell: object): void {
         if (this.primed === spell) this.clearPrime();
         if (this.pending?.spell === spell) this.cancelPending();
-        if (this.casting?.spell === spell) this.interruptCast();
+        // A wind-up is cancelled if its spell goes unavailable (its cost hasn't
+        // committed yet). A channel must not be: by the time it is running the
+        // cast has committed, the cost is charged and the effect is live, so the
+        // spell going "not ready" — which right after a successful cast means
+        // "on cooldown", fired by the very next resource-regen `change` — would
+        // otherwise tear down its own channel a frame after it started. Genuine
+        // channel stops come through interruptForMove/onHit/request instead.
+        if (this.casting?.spell === spell && this.casting.phase !== "channel") {
+            this.interruptCast();
+        }
     }
 
     cancelAll(): void {

--- a/src/entities/Spells/Invocation.test.ts
+++ b/src/entities/Spells/Invocation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import Invocation from "./Invocation";
+
+// clearEffect is the channel teardown. It runs when the channel ends naturally
+// (Invocation's own timer) and when the CastingController breaks the channel
+// early via interruptChannel. Both must fully release the effect: cancel the
+// pending natural-end timer and remove the regen boon (which carries its own
+// duration timer and would otherwise run to full duration after the channel is
+// gone), then restore the player. Exercised against the real prototype with a
+// constructor-free fake — no Phaser boot — matching the other lifecycle tests.
+
+interface InvocationUnderTest {
+    timer?: { remove: ReturnType<typeof vi.fn> };
+    player: {
+        boons: { removeEffect: ReturnType<typeof vi.fn> };
+        idle: ReturnType<typeof vi.fn>;
+        hero: { clearTint: ReturnType<typeof vi.fn> };
+        body: { setMaxVelocity: ReturnType<typeof vi.fn> };
+    };
+    clearEffect(): void;
+    interruptChannel(): void;
+}
+
+function makeInvocation(): InvocationUnderTest {
+    const spell = Object.create(Invocation.prototype) as InvocationUnderTest;
+    spell.timer = { remove: vi.fn() };
+    spell.player = {
+        boons: { removeEffect: vi.fn() },
+        idle: vi.fn(),
+        hero: { clearTint: vi.fn() },
+        body: { setMaxVelocity: vi.fn() },
+    };
+    return spell;
+}
+
+describe("Invocation.clearEffect", () => {
+    it("cancels the pending natural-end timer", () => {
+        const spell = makeInvocation();
+
+        spell.clearEffect();
+
+        expect(spell.timer!.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it("removes the regen boon so the effect never outlives the channel", () => {
+        const spell = makeInvocation();
+
+        spell.clearEffect();
+
+        expect(spell.player.boons.removeEffect).toHaveBeenCalledWith(spell);
+    });
+
+    it("restores the player (idle, clears the tint, resets max velocity)", () => {
+        const spell = makeInvocation();
+
+        spell.clearEffect();
+
+        expect(spell.player.idle).toHaveBeenCalledTimes(1);
+        expect(spell.player.hero.clearTint).toHaveBeenCalledTimes(1);
+        expect(spell.player.body.setMaxVelocity).toHaveBeenCalledWith(10000);
+    });
+
+    // The early-break path and the natural-end timer can both reach clearEffect
+    // for one cast, so it must be safe to run twice.
+    it("is idempotent — a second call does not throw", () => {
+        const spell = makeInvocation();
+
+        spell.clearEffect();
+
+        expect(() => spell.clearEffect()).not.toThrow();
+        expect(spell.player.boons.removeEffect).toHaveBeenCalledTimes(2);
+    });
+
+    // The guard means a fake without a timer (never cast) tears down cleanly.
+    it("does not throw when no timer was scheduled", () => {
+        const spell = makeInvocation();
+        spell.timer = undefined;
+
+        expect(() => spell.clearEffect()).not.toThrow();
+        expect(spell.player.boons.removeEffect).toHaveBeenCalledWith(spell);
+    });
+});
+
+describe("Invocation.interruptChannel", () => {
+    it("ends the effect by delegating to clearEffect", () => {
+        const spell = makeInvocation();
+        const clearEffect = vi.spyOn(
+            Invocation.prototype as unknown as { clearEffect: () => void },
+            "clearEffect"
+        );
+
+        spell.interruptChannel();
+
+        expect(clearEffect).toHaveBeenCalledTimes(1);
+        clearEffect.mockRestore();
+    });
+});

--- a/src/entities/Spells/Invocation.ts
+++ b/src/entities/Spells/Invocation.ts
@@ -62,12 +62,23 @@ class Invocation extends Boon {
         this.player.root();
     }
 
-    // Channel broken early — restore the player just like a natural end.
+    // Channel broken early — end the buff and restore the player just like a
+    // natural end, so the effect never outlives the channel.
     interruptChannel(): void {
         this.clearEffect();
     }
 
     clearEffect(): void {
+        // Reachable twice for one cast (an early channel break and the
+        // natural-end timer), so keep it idempotent.
+        // Cancel the pending natural-end timer: without this, breaking the
+        // channel early leaves it to fire later and force-idle the player
+        // mid-action.
+        if (this.timer) this.timer.remove();
+        // End the regen buff now. The boon carries its own duration timer, so
+        // an early break must remove it here — otherwise the buff runs to the
+        // full duration after the channel is already gone.
+        this.player.boons.removeEffect(this);
         this.player.idle();
         this.player.hero.clearTint();
         // Set player stats back to normal.

--- a/src/entities/Spells/Invocation.ts
+++ b/src/entities/Spells/Invocation.ts
@@ -29,9 +29,6 @@ class Invocation extends Boon {
             type: "magic",
             duration: 5,
             targetKind: "self" as const,
-            // Modelled as a channel: the controller roots the player, shows
-            // the cast bar, and breaks it on move/hit/new cast.
-            channelDuration: 5,
             value: {
                 resource_regen_value: (bs: number) => bs * 4, // Increase by 400%
                 resource_regen_rate: -0.1, // Tick 0.1s more frequently
@@ -40,6 +37,12 @@ class Invocation extends Boon {
 
         super({ ...defaults, ...config });
         this.hasAnimation = false;
+        // Modelled as a channel: the controller roots the player, shows the
+        // cast bar, and breaks it on move/hit/new cast. The channel runs for
+        // exactly as long as the buff it applies, so the cast bar and the root
+        // last the whole effect — derive it from `duration` (defaults or an
+        // override) so the two can never drift.
+        this.channelDuration = this.duration;
     }
 
     effect(): void {


### PR DESCRIPTION
## Summary

Invocation is a channelled self-buff. Two problems, one visible:

**1. The channel started and immediately stopped.** Casting Invocation starts its 60s cooldown, and the very next Mana-regen `change` event runs `Spell.onResourceChangeHandler`, which finds the spell "not ready" (on cooldown), disables the button, and calls `CastingController.notifyDisabled`. `notifyDisabled` then interrupted the spell's **own in-flight channel** — a frame after it began. (`SiphonSoul` escaped this only because `cooldownDelayAll`/`killSpell` drops its resource-change listener on cast.) Invocation actually *boosts* regen, so the killing `change` arrives almost instantly.

Fix: `notifyDisabled` now leaves a **committed channel** alone. Once a channel is running the cast has committed, the cost is charged and the effect is live, so the spell going "not ready" (i.e. on cooldown) must not cancel it. Wind-ups still cancel on disable — their cost has not committed yet — and genuine channel stops (move / hit / recast) keep flowing through `interruptForMove` / `onHit` / `request`.

**2. Breaking a channel early left the effect running.** Exposed once channels actually hold: `Invocation.clearEffect` didn't remove the boon (whose stat buff carries its own duration timer and ran to the full 5s after the channel was already gone) and didn't cancel the pending natural-end timer (which fired later and force-idled the player mid-action). `clearEffect` is now complete and idempotent, so **the effect never outlives the channel** — which also fulfils the original "channel length == effect length" intent for the interrupted case.

Also retains the original refactor tying `channelDuration` to `duration` so the two can't drift.

## Behaviour

This changes runtime behaviour (it's a bug fix), as requested:

- Invocation's channel now holds for its full duration instead of dying on the first regen tick.
- Breaking the channel early now ends the buff immediately and cleanly, instead of leaking it to the full duration plus a delayed force-idle.

No balance-number, save-format, or public-API change: durations, costs, cooldown, and regen values are untouched.

## Files

- `src/entities/Spells/CastingController.ts` — `notifyDisabled` no longer interrupts a channel-phase cast.
- `src/entities/Spells/Invocation.ts` — `clearEffect` removes the boon + cancels its timer, idempotently; `channelDuration` derived from `duration`.
- `src/entities/Spells/CastingController.test.ts` — regression tests: a committed channel survives `notifyDisabled`; a wind-up still cancels.
- `src/entities/Spells/Invocation.test.ts` — regression tests for the `clearEffect` teardown (cancels the timer, removes the boon, restores the player, idempotent; `interruptChannel` delegates to it).

## Scope

Fix the Invocation channel starting-then-immediately-stopping bug, and the adjacent effect-outlives-channel defect the fix exposes, within `src/entities/Spells/`. Changes limited to `CastingController.ts` (the false interrupt), `Invocation.ts` (complete channel teardown + channel/effect duration link), and the tests for those two files (`CastingController.test.ts`, `Invocation.test.ts`). `SiphonSoul` is intentionally untouched — it does not exhibit either bug.

## Test evidence

All five local gates pass:

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 43 files, 390 passed / 2 skipped (2 new `CastingController` + 6 new `Invocation` regression tests)
- `npm run build` — succeeds (pre-existing chunk-size warning only)
- `npm run format:check` — clean

## Risk

Moderate — a deliberate runtime-behaviour fix to a channelled spell. Wind-up cancellation, `SiphonSoul`, and all other spells are unaffected (verified by the full suite). The channel-interrupt paths (move/hit/recast/esc) are unchanged.